### PR TITLE
Silence warning on Solaris.

### DIFF
--- a/src/topology-solaris-chiptype.c
+++ b/src/topology-solaris-chiptype.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2009-2010 Oracle and/or its affiliates.  All rights reserved. 
- * Copyright (c) 2013 Université Bordeaux 1.  All rights reserved.
+ * Copyright (c) 2013      Université Bordeaux 1.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * $COPYRIGHT$
  * 
@@ -11,8 +13,8 @@
 
 #include <private/autogen/config.h>
 #include <hwloc/autogen/config.h>
-#include <private/solaris-chiptype.h>
 #include <hwloc.h>
+#include <private/solaris-chiptype.h>
 #include <stdlib.h>
 #include <strings.h>
 


### PR DESCRIPTION
Ensure the hwloc_solaris_get_chip_type and hwloc_solaris_get_chip_model
macros are defined before the prototype is defined.

In order to reproduce the issue
$ hwloc_symbol_prefix_value=hwloc_git_ /.../configure --enable-debug --enable-picky
then
$ cd src
$ make topology-solaris-chiptype.lo 
  CC       topology-solaris-chiptype.lo
In file included from /export/home/gilles/src/hwloc/include/hwloc.h:59:0,
                 from ../../../src/hwloc/src/topology-solaris-chiptype.c:17:
/export/home/gilles/build/hwloc/include/hwloc/autogen/config.h:197:26: warning: no previous prototype for 'hwloc_git_hwloc_solaris_get_chip_type' [-Wmissing-prototypes]
 #define HWLOC_SYM_PREFIX hwloc_git_
                          ^
/export/home/gilles/src/hwloc/include/hwloc/rename.h:29:33: note: in definition of macro 'HWLOC_MUNGE_NAME2'
 #define HWLOC_MUNGE_NAME2(a, b) a ## b
                                 ^
/export/home/gilles/src/hwloc/include/hwloc/rename.h:30:26: note: in expansion of macro 'HWLOC_MUNGE_NAME'
 #define HWLOC_NAME(name) HWLOC_MUNGE_NAME(HWLOC_SYM_PREFIX, hwloc_ ## name)
                          ^
/export/home/gilles/src/hwloc/include/hwloc/rename.h:30:43: note: in expansion of macro 'HWLOC_SYM_PREFIX'
 #define HWLOC_NAME(name) HWLOC_MUNGE_NAME(HWLOC_SYM_PREFIX, hwloc_ ## name)
                                           ^
/export/home/gilles/src/hwloc/include/hwloc/rename.h:630:37: note: in expansion of macro 'HWLOC_NAME'
 #define hwloc_solaris_get_chip_type HWLOC_NAME(solaris_get_chip_type)
                                     ^
../../../src/hwloc/src/topology-solaris-chiptype.c:284:7: note: in expansion of macro 'hwloc_solaris_get_chip_type'
 char\* hwloc_solaris_get_chip_type(void) {
       ^
/export/home/gilles/build/hwloc/include/hwloc/autogen/config.h:197:26: warning: no previous prototype for 'hwloc_git_hwloc_solaris_get_chip_model' [-Wmissing-prototypes]
 #define HWLOC_SYM_PREFIX hwloc_git_
                          ^
/export/home/gilles/src/hwloc/include/hwloc/rename.h:29:33: note: in definition of macro 'HWLOC_MUNGE_NAME2'
 #define HWLOC_MUNGE_NAME2(a, b) a ## b
                                 ^
/export/home/gilles/src/hwloc/include/hwloc/rename.h:30:26: note: in expansion of macro 'HWLOC_MUNGE_NAME'
 #define HWLOC_NAME(name) HWLOC_MUNGE_NAME(HWLOC_SYM_PREFIX, hwloc_ ## name)
                          ^
/export/home/gilles/src/hwloc/include/hwloc/rename.h:30:43: note: in expansion of macro 'HWLOC_SYM_PREFIX'
 #define HWLOC_NAME(name) HWLOC_MUNGE_NAME(HWLOC_SYM_PREFIX, hwloc_ ## name)
                                           ^
/export/home/gilles/src/hwloc/include/hwloc/rename.h:631:38: note: in expansion of macro 'HWLOC_NAME'
 #define hwloc_solaris_get_chip_model HWLOC_NAME(solaris_get_chip_model)
                                      ^
../../../src/hwloc/src/topology-solaris-chiptype.c:321:7: note: in expansion of macro 'hwloc_solaris_get_chip_model'
 char *hwloc_solaris_get_chip_model(void) {
