### PR TITLE
X11: use the hwloc.m4-determined X11 flags properly

### DIFF
--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -9,7 +9,7 @@ dnl Copyright © 2004-2012 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright © 2004-2008 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
-dnl Copyright © 2006-2014 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright © 2006-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright © 2012  Blue Brain Project, BBP/EPFL. All rights reserved.
 dnl Copyright © 2012       Oracle and/or its affiliates.  All rights reserved.
 dnl See COPYING in top-level directory.
@@ -876,7 +876,9 @@ EOF])
              AC_CHECK_HEADERS([X11/Xutil.h],
                 [AC_CHECK_HEADERS([X11/keysym.h],
                     [AC_DEFINE([HWLOC_HAVE_X11_KEYSYM], [1], [Define to 1 if X11 headers including Xutil.h and keysym.h are available.])])
-                     AC_SUBST([HWLOC_X11_LIBS], ["-lX11"])
+                     AS_IF([test "x$X_LIBS" = "x"], [X_LIBS="-lX11"])
+                     AC_SUBST([HWLOC_X11_CPPFLAGS], [$(X_CFLAGS)])
+                     AC_SUBST([HWLOC_X11_LIBS], ["$(X_PRE_LIBS) $X_LIBS $(X_EXTRA_LIBS) "])
                 ], [], [#include <X11/Xlib.h>])
             ])
          ])

--- a/utils/lstopo/Makefile.am
+++ b/utils/lstopo/Makefile.am
@@ -1,6 +1,6 @@
 # Copyright © 2009-2015 Inria.  All rights reserved.
 # Copyright © 2009-2012, 2014 Université Bordeaux
-# Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright © 2009-2015 Cisco Systems, Inc.  All rights reserved.
 #
 # See COPYING in top-level directory.
 
@@ -37,7 +37,7 @@ lstopo_LDADD = $(lstopo_no_graphics_LDADD)
 if HWLOC_HAVE_CAIRO
 bin_PROGRAMS += lstopo
 lstopo_SOURCES += lstopo-cairo.c
-lstopo_CPPFLAGS += -DLSTOPO_HAVE_GRAPHICS
+lstopo_CPPFLAGS += -DLSTOPO_HAVE_GRAPHICS $(HWLOC_X11_CPPFLAGS)
 lstopo_CFLAGS = $(lstopo_no_graphics_CFLAGS) $(HWLOC_CAIRO_CFLAGS)
 lstopo_LDADD += $(HWLOC_CAIRO_LIBS) $(HWLOC_X11_LIBS)
 endif


### PR DESCRIPTION
Set new HWLOC_X11_CPPFLAGS macro with X_CFLAGS, and set HWLOC_X11_LIBS to all 3 of X_PRE_LIBS, X_LIBS, and X_EXTRA_LIBS.

Then be sure to use both of these macros when compiling lstopo.

This patch based on an email sent to me from @bgoglin with initial bug report from @scottatchley.

Specifically, I think Scott's initial patch was in the right direction, but I'm not sure it went far enough.  I don't have problems compiling on my Yosemite (10.10.2) OS X system, but:

1. I don't seem to have a sym link from /opt/X11 to /usr/X11, and
1. My CPP and linker seem to find the X11 headers/libraries in their default search paths.

Specifically, in my lstopo/Makefile:

```make
X_CFLAGS = 
X_EXTRA_LIBS = 
X_LIBS = 
X_PRE_LIBS = 
```

Hence, I wonder if the real solution is twofold:

1. Ensure that HWLOC_X11_LIBS is actually complete, and ensure that HWLOC_X11_CPPFLAGS exists.
2. Use both of those values properly in lstopo/Makefile.am.

@scottatchley Does this patch work for you?