### PR TITLE
X86 : Adding cache inclusiveness detection and regrouping annotations in not fulldiscovery

### DIFF
--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -639,6 +639,8 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int
         /* Annotate packages previously-existing cache */
         case HWLOC_OBJ_CACHE:
           {
+            if (hwloc_obj_get_info_by_name(object,"inclusiveness"))
+              break;
             unsigned char type = 0;
             switch(object->attr->cache.type){
               case HWLOC_OBJ_CACHE_DATA : type = 1;

--- a/tests/hwloc/x86/AMD-15h-Bulldozer-4xOpteron-6272.output
+++ b/tests/hwloc/x86/AMD-15h-Bulldozer-4xOpteron-6272.output
@@ -11,14 +11,19 @@
       <info name="CPUStepping" value="2"/>
       <object type="NUMANode" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
         <object type="Cache" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="0" cpuset="0x00000003" complete_cpuset="0x00000003" allowed_cpuset="0x00000003" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00000003" complete_cpuset="0x00000003" allowed_cpuset="0x00000003" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
               <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -26,13 +31,17 @@
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x0000000c" complete_cpuset="0x0000000c" allowed_cpuset="0x0000000c" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x0000000c" complete_cpuset="0x0000000c" allowed_cpuset="0x0000000c" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
               <object type="Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -40,13 +49,17 @@
             </object>
           </object>
           <object type="Cache" os_index="2" cpuset="0x00000030" complete_cpuset="0x00000030" allowed_cpuset="0x00000030" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00000030" complete_cpuset="0x00000030" allowed_cpuset="0x00000030" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
               <object type="Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -54,13 +67,17 @@
             </object>
           </object>
           <object type="Cache" os_index="3" cpuset="0x000000c0" complete_cpuset="0x000000c0" allowed_cpuset="0x000000c0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="3" cpuset="0x000000c0" complete_cpuset="0x000000c0" allowed_cpuset="0x000000c0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
               <object type="Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -71,14 +88,19 @@
       </object>
       <object type="NUMANode" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
         <object type="Cache" os_index="1" cpuset="0x0000ff00" complete_cpuset="0x0000ff00" allowed_cpuset="0x0000ff00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="4" cpuset="0x00000300" complete_cpuset="0x00000300" allowed_cpuset="0x00000300" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="4" cpuset="0x00000300" complete_cpuset="0x00000300" allowed_cpuset="0x00000300" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
                   <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
                 </object>
               </object>
               <object type="Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
                   <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
                 </object>
@@ -86,13 +108,17 @@
             </object>
           </object>
           <object type="Cache" os_index="5" cpuset="0x00000c00" complete_cpuset="0x00000c00" allowed_cpuset="0x00000c00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="5" cpuset="0x00000c00" complete_cpuset="0x00000c00" allowed_cpuset="0x00000c00" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
                   <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
                 </object>
               </object>
               <object type="Cache" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
                   <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
                 </object>
@@ -100,13 +126,17 @@
             </object>
           </object>
           <object type="Cache" os_index="6" cpuset="0x00003000" complete_cpuset="0x00003000" allowed_cpuset="0x00003000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="6" cpuset="0x00003000" complete_cpuset="0x00003000" allowed_cpuset="0x00003000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
                   <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
                 </object>
               </object>
               <object type="Cache" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
                   <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
                 </object>
@@ -114,13 +144,17 @@
             </object>
           </object>
           <object type="Cache" os_index="7" cpuset="0x0000c000" complete_cpuset="0x0000c000" allowed_cpuset="0x0000c000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="7" cpuset="0x0000c000" complete_cpuset="0x0000c000" allowed_cpuset="0x0000c000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
                   <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
                 </object>
               </object>
               <object type="Cache" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002">
                   <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000002" complete_nodeset="0x00000002" allowed_nodeset="0x00000002"/>
                 </object>
@@ -138,14 +172,19 @@
       <info name="CPUStepping" value="2"/>
       <object type="NUMANode" os_index="6" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
         <object type="Cache" os_index="12" cpuset="0x00ff0000" complete_cpuset="0x00ff0000" allowed_cpuset="0x00ff0000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="48" cpuset="0x00030000" complete_cpuset="0x00030000" allowed_cpuset="0x00030000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="48" cpuset="0x00030000" complete_cpuset="0x00030000" allowed_cpuset="0x00030000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="96" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
                   <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
                 </object>
               </object>
               <object type="Cache" os_index="97" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
                   <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
                 </object>
@@ -153,13 +192,17 @@
             </object>
           </object>
           <object type="Cache" os_index="49" cpuset="0x000c0000" complete_cpuset="0x000c0000" allowed_cpuset="0x000c0000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="49" cpuset="0x000c0000" complete_cpuset="0x000c0000" allowed_cpuset="0x000c0000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="98" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
                   <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
                 </object>
               </object>
               <object type="Cache" os_index="99" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
                   <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
                 </object>
@@ -167,13 +210,17 @@
             </object>
           </object>
           <object type="Cache" os_index="50" cpuset="0x00300000" complete_cpuset="0x00300000" allowed_cpuset="0x00300000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="50" cpuset="0x00300000" complete_cpuset="0x00300000" allowed_cpuset="0x00300000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="100" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
                   <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
                 </object>
               </object>
               <object type="Cache" os_index="101" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
                   <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
                 </object>
@@ -181,13 +228,17 @@
             </object>
           </object>
           <object type="Cache" os_index="51" cpuset="0x00c00000" complete_cpuset="0x00c00000" allowed_cpuset="0x00c00000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="51" cpuset="0x00c00000" complete_cpuset="0x00c00000" allowed_cpuset="0x00c00000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="102" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
                   <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
                 </object>
               </object>
               <object type="Cache" os_index="103" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040">
                   <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000040" complete_nodeset="0x00000040" allowed_nodeset="0x00000040"/>
                 </object>
@@ -198,14 +249,19 @@
       </object>
       <object type="NUMANode" os_index="7" cpuset="0xff000000" complete_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
         <object type="Cache" os_index="13" cpuset="0xff000000" complete_cpuset="0xff000000" allowed_cpuset="0xff000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="52" cpuset="0x03000000" complete_cpuset="0x03000000" allowed_cpuset="0x03000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="52" cpuset="0x03000000" complete_cpuset="0x03000000" allowed_cpuset="0x03000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="104" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
                   <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
                 </object>
               </object>
               <object type="Cache" os_index="105" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
                   <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
                 </object>
@@ -213,13 +269,17 @@
             </object>
           </object>
           <object type="Cache" os_index="53" cpuset="0x0c000000" complete_cpuset="0x0c000000" allowed_cpuset="0x0c000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="53" cpuset="0x0c000000" complete_cpuset="0x0c000000" allowed_cpuset="0x0c000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="106" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
                   <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
                 </object>
               </object>
               <object type="Cache" os_index="107" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="11" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
                   <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
                 </object>
@@ -227,13 +287,17 @@
             </object>
           </object>
           <object type="Cache" os_index="54" cpuset="0x30000000" complete_cpuset="0x30000000" allowed_cpuset="0x30000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="54" cpuset="0x30000000" complete_cpuset="0x30000000" allowed_cpuset="0x30000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="108" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="12" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
                   <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
                 </object>
               </object>
               <object type="Cache" os_index="109" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="13" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
                   <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
                 </object>
@@ -241,13 +305,17 @@
             </object>
           </object>
           <object type="Cache" os_index="55" cpuset="0xc0000000" complete_cpuset="0xc0000000" allowed_cpuset="0xc0000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="55" cpuset="0xc0000000" complete_cpuset="0xc0000000" allowed_cpuset="0xc0000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="110" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="14" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
                   <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
                 </object>
               </object>
               <object type="Cache" os_index="111" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="15" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080">
                   <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000080" complete_nodeset="0x00000080" allowed_nodeset="0x00000080"/>
                 </object>
@@ -265,14 +333,19 @@
       <info name="CPUStepping" value="2"/>
       <object type="NUMANode" os_index="2" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
         <object type="Cache" os_index="4" cpuset="0x000000ff,0x0" complete_cpuset="0x000000ff,0x0" allowed_cpuset="0x000000ff,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="16" cpuset="0x00000003,0x0" complete_cpuset="0x00000003,0x0" allowed_cpuset="0x00000003,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="16" cpuset="0x00000003,0x0" complete_cpuset="0x00000003,0x0" allowed_cpuset="0x00000003,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
                   <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
                 </object>
               </object>
               <object type="Cache" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
                   <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
                 </object>
@@ -280,13 +353,17 @@
             </object>
           </object>
           <object type="Cache" os_index="17" cpuset="0x0000000c,0x0" complete_cpuset="0x0000000c,0x0" allowed_cpuset="0x0000000c,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="17" cpuset="0x0000000c,0x0" complete_cpuset="0x0000000c,0x0" allowed_cpuset="0x0000000c,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
                   <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
                 </object>
               </object>
               <object type="Cache" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
                   <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
                 </object>
@@ -294,13 +371,17 @@
             </object>
           </object>
           <object type="Cache" os_index="18" cpuset="0x00000030,0x0" complete_cpuset="0x00000030,0x0" allowed_cpuset="0x00000030,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="18" cpuset="0x00000030,0x0" complete_cpuset="0x00000030,0x0" allowed_cpuset="0x00000030,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
                   <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
                 </object>
               </object>
               <object type="Cache" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
                   <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
                 </object>
@@ -308,13 +389,17 @@
             </object>
           </object>
           <object type="Cache" os_index="19" cpuset="0x000000c0,0x0" complete_cpuset="0x000000c0,0x0" allowed_cpuset="0x000000c0,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="19" cpuset="0x000000c0,0x0" complete_cpuset="0x000000c0,0x0" allowed_cpuset="0x000000c0,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
                   <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
                 </object>
               </object>
               <object type="Cache" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004">
                   <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000004" complete_nodeset="0x00000004" allowed_nodeset="0x00000004"/>
                 </object>
@@ -325,14 +410,19 @@
       </object>
       <object type="NUMANode" os_index="3" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
         <object type="Cache" os_index="5" cpuset="0x0000ff00,0x0" complete_cpuset="0x0000ff00,0x0" allowed_cpuset="0x0000ff00,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="20" cpuset="0x00000300,0x0" complete_cpuset="0x00000300,0x0" allowed_cpuset="0x00000300,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="20" cpuset="0x00000300,0x0" complete_cpuset="0x00000300,0x0" allowed_cpuset="0x00000300,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
                   <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
                 </object>
               </object>
               <object type="Cache" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
                   <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
                 </object>
@@ -340,13 +430,17 @@
             </object>
           </object>
           <object type="Cache" os_index="21" cpuset="0x00000c00,0x0" complete_cpuset="0x00000c00,0x0" allowed_cpuset="0x00000c00,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="21" cpuset="0x00000c00,0x0" complete_cpuset="0x00000c00,0x0" allowed_cpuset="0x00000c00,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
                   <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
                 </object>
               </object>
               <object type="Cache" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="11" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
                   <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
                 </object>
@@ -354,13 +448,17 @@
             </object>
           </object>
           <object type="Cache" os_index="22" cpuset="0x00003000,0x0" complete_cpuset="0x00003000,0x0" allowed_cpuset="0x00003000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="22" cpuset="0x00003000,0x0" complete_cpuset="0x00003000,0x0" allowed_cpuset="0x00003000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="12" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
                   <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
                 </object>
               </object>
               <object type="Cache" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="13" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
                   <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
                 </object>
@@ -368,13 +466,17 @@
             </object>
           </object>
           <object type="Cache" os_index="23" cpuset="0x0000c000,0x0" complete_cpuset="0x0000c000,0x0" allowed_cpuset="0x0000c000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="23" cpuset="0x0000c000,0x0" complete_cpuset="0x0000c000,0x0" allowed_cpuset="0x0000c000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="14" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
                   <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
                 </object>
               </object>
               <object type="Cache" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="15" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008">
                   <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000008" complete_nodeset="0x00000008" allowed_nodeset="0x00000008"/>
                 </object>
@@ -392,14 +494,19 @@
       <info name="CPUStepping" value="2"/>
       <object type="NUMANode" os_index="4" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
         <object type="Cache" os_index="8" cpuset="0x00ff0000,0x0" complete_cpuset="0x00ff0000,0x0" allowed_cpuset="0x00ff0000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="32" cpuset="0x00030000,0x0" complete_cpuset="0x00030000,0x0" allowed_cpuset="0x00030000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="32" cpuset="0x00030000,0x0" complete_cpuset="0x00030000,0x0" allowed_cpuset="0x00030000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="64" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
                   <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
                 </object>
               </object>
               <object type="Cache" os_index="65" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
                   <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
                 </object>
@@ -407,13 +514,17 @@
             </object>
           </object>
           <object type="Cache" os_index="33" cpuset="0x000c0000,0x0" complete_cpuset="0x000c0000,0x0" allowed_cpuset="0x000c0000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="33" cpuset="0x000c0000,0x0" complete_cpuset="0x000c0000,0x0" allowed_cpuset="0x000c0000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="66" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
                   <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
                 </object>
               </object>
               <object type="Cache" os_index="67" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
                   <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
                 </object>
@@ -421,13 +532,17 @@
             </object>
           </object>
           <object type="Cache" os_index="34" cpuset="0x00300000,0x0" complete_cpuset="0x00300000,0x0" allowed_cpuset="0x00300000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="34" cpuset="0x00300000,0x0" complete_cpuset="0x00300000,0x0" allowed_cpuset="0x00300000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="68" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
                   <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
                 </object>
               </object>
               <object type="Cache" os_index="69" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
                   <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
                 </object>
@@ -435,13 +550,17 @@
             </object>
           </object>
           <object type="Cache" os_index="35" cpuset="0x00c00000,0x0" complete_cpuset="0x00c00000,0x0" allowed_cpuset="0x00c00000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="35" cpuset="0x00c00000,0x0" complete_cpuset="0x00c00000,0x0" allowed_cpuset="0x00c00000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="70" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
                   <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
                 </object>
               </object>
               <object type="Cache" os_index="71" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010">
                   <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000010" complete_nodeset="0x00000010" allowed_nodeset="0x00000010"/>
                 </object>
@@ -452,14 +571,19 @@
       </object>
       <object type="NUMANode" os_index="5" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
         <object type="Cache" os_index="9" cpuset="0xff000000,0x0" complete_cpuset="0xff000000,0x0" allowed_cpuset="0xff000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="6291456" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="36" cpuset="0x03000000,0x0" complete_cpuset="0x03000000,0x0" allowed_cpuset="0x03000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="36" cpuset="0x03000000,0x0" complete_cpuset="0x03000000,0x0" allowed_cpuset="0x03000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="72" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
                   <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
                 </object>
               </object>
               <object type="Cache" os_index="73" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
                   <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
                 </object>
@@ -467,13 +591,17 @@
             </object>
           </object>
           <object type="Cache" os_index="37" cpuset="0x0c000000,0x0" complete_cpuset="0x0c000000,0x0" allowed_cpuset="0x0c000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="37" cpuset="0x0c000000,0x0" complete_cpuset="0x0c000000,0x0" allowed_cpuset="0x0c000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="74" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
                   <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
                 </object>
               </object>
               <object type="Cache" os_index="75" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="11" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
                   <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
                 </object>
@@ -481,13 +609,17 @@
             </object>
           </object>
           <object type="Cache" os_index="38" cpuset="0x30000000,0x0" complete_cpuset="0x30000000,0x0" allowed_cpuset="0x30000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="38" cpuset="0x30000000,0x0" complete_cpuset="0x30000000,0x0" allowed_cpuset="0x30000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="76" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="12" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
                   <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
                 </object>
               </object>
               <object type="Cache" os_index="77" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="13" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
                   <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
                 </object>
@@ -495,13 +627,17 @@
             </object>
           </object>
           <object type="Cache" os_index="39" cpuset="0xc0000000,0x0" complete_cpuset="0xc0000000,0x0" allowed_cpuset="0xc0000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="2097152" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="39" cpuset="0xc0000000,0x0" complete_cpuset="0xc0000000,0x0" allowed_cpuset="0xc0000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="78" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="14" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
                   <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
                 </object>
               </object>
               <object type="Cache" os_index="79" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020" cache_size="16384" depth="1" cache_linesize="64" cache_associativity="4" cache_type="1">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="15" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020">
                   <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000020" complete_nodeset="0x00000020" allowed_nodeset="0x00000020"/>
                 </object>

--- a/tests/hwloc/x86/AMD-K10-Istanbul-8xOpteron-8439SE.output
+++ b/tests/hwloc/x86/AMD-K10-Istanbul-8xOpteron-8439SE.output
@@ -11,9 +11,13 @@
         <info name="CPUModel" value="Six-Core AMD Opteron(tm) Processor 8439 SE"/>
         <info name="CPUStepping" value="0"/>
         <object type="Cache" os_index="0" cpuset="0x00000101,0x01010101" complete_cpuset="0x00000101,0x01010101" allowed_cpuset="0x00000101,0x01010101" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="5242880" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -21,8 +25,11 @@
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="1" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="1" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -30,8 +37,11 @@
             </object>
           </object>
           <object type="Cache" os_index="2" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="2" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="2" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -39,8 +49,11 @@
             </object>
           </object>
           <object type="Cache" os_index="3" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="3" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="3" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -48,8 +61,11 @@
             </object>
           </object>
           <object type="Cache" os_index="4" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="4" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="4" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -57,8 +73,11 @@
             </object>
           </object>
           <object type="Cache" os_index="5" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="5" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="5" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -74,9 +93,13 @@
         <info name="CPUModel" value="Six-Core AMD Opteron(tm) Processor 8439 SE"/>
         <info name="CPUStepping" value="0"/>
         <object type="Cache" os_index="1" cpuset="0x00000202,0x02020202" complete_cpuset="0x00000202,0x02020202" allowed_cpuset="0x00000202,0x02020202" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="5242880" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="8" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="8" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="8" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -84,8 +107,11 @@
             </object>
           </object>
           <object type="Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -93,8 +119,11 @@
             </object>
           </object>
           <object type="Cache" os_index="10" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="10" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="10" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -102,8 +131,11 @@
             </object>
           </object>
           <object type="Cache" os_index="11" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="11" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="11" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -111,8 +143,11 @@
             </object>
           </object>
           <object type="Cache" os_index="12" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="12" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="12" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -120,8 +155,11 @@
             </object>
           </object>
           <object type="Cache" os_index="13" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="13" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="13" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -137,9 +175,13 @@
         <info name="CPUModel" value="Six-Core AMD Opteron(tm) Processor 8439 SE"/>
         <info name="CPUStepping" value="0"/>
         <object type="Cache" os_index="2" cpuset="0x00000404,0x04040404" complete_cpuset="0x00000404,0x04040404" allowed_cpuset="0x00000404,0x04040404" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="5242880" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="16" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="16" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="16" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -147,8 +189,11 @@
             </object>
           </object>
           <object type="Cache" os_index="17" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="17" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="17" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -156,8 +201,11 @@
             </object>
           </object>
           <object type="Cache" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -165,8 +213,11 @@
             </object>
           </object>
           <object type="Cache" os_index="19" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="19" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="19" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -174,8 +225,11 @@
             </object>
           </object>
           <object type="Cache" os_index="20" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="20" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="20" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -183,8 +237,11 @@
             </object>
           </object>
           <object type="Cache" os_index="21" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="21" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="21" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -200,9 +257,13 @@
         <info name="CPUModel" value="Six-Core AMD Opteron(tm) Processor 8439 SE"/>
         <info name="CPUStepping" value="0"/>
         <object type="Cache" os_index="3" cpuset="0x00000808,0x08080808" complete_cpuset="0x00000808,0x08080808" allowed_cpuset="0x00000808,0x08080808" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="5242880" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="24" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="24" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="24" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -210,8 +271,11 @@
             </object>
           </object>
           <object type="Cache" os_index="25" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="25" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="25" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -219,8 +283,11 @@
             </object>
           </object>
           <object type="Cache" os_index="26" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="26" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="26" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -228,8 +295,11 @@
             </object>
           </object>
           <object type="Cache" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -237,8 +307,11 @@
             </object>
           </object>
           <object type="Cache" os_index="28" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="28" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="28" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -246,8 +319,11 @@
             </object>
           </object>
           <object type="Cache" os_index="29" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="29" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="29" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -263,9 +339,13 @@
         <info name="CPUModel" value="Six-Core AMD Opteron(tm) Processor 8439 SE"/>
         <info name="CPUStepping" value="0"/>
         <object type="Cache" os_index="4" cpuset="0x00001010,0x10101010" complete_cpuset="0x00001010,0x10101010" allowed_cpuset="0x00001010,0x10101010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="5242880" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="32" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="32" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="32" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -273,8 +353,11 @@
             </object>
           </object>
           <object type="Cache" os_index="33" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="33" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="33" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -282,8 +365,11 @@
             </object>
           </object>
           <object type="Cache" os_index="34" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="34" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="34" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -291,8 +377,11 @@
             </object>
           </object>
           <object type="Cache" os_index="35" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="35" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="35" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -300,8 +389,11 @@
             </object>
           </object>
           <object type="Cache" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -309,8 +401,11 @@
             </object>
           </object>
           <object type="Cache" os_index="37" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="37" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="37" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -326,9 +421,13 @@
         <info name="CPUModel" value="Six-Core AMD Opteron(tm) Processor 8439 SE"/>
         <info name="CPUStepping" value="0"/>
         <object type="Cache" os_index="5" cpuset="0x00002020,0x20202020" complete_cpuset="0x00002020,0x20202020" allowed_cpuset="0x00002020,0x20202020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="5242880" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="40" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="40" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="40" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -336,8 +435,11 @@
             </object>
           </object>
           <object type="Cache" os_index="41" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="41" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="41" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -345,8 +447,11 @@
             </object>
           </object>
           <object type="Cache" os_index="42" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="42" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="42" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -354,8 +459,11 @@
             </object>
           </object>
           <object type="Cache" os_index="43" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="43" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="43" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -363,8 +471,11 @@
             </object>
           </object>
           <object type="Cache" os_index="44" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="44" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="44" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -372,8 +483,11 @@
             </object>
           </object>
           <object type="Cache" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -389,9 +503,13 @@
         <info name="CPUModel" value="Six-Core AMD Opteron(tm) Processor 8439 SE"/>
         <info name="CPUStepping" value="0"/>
         <object type="Cache" os_index="6" cpuset="0x00004040,0x40404040" complete_cpuset="0x00004040,0x40404040" allowed_cpuset="0x00004040,0x40404040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="5242880" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="48" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="48" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="48" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -399,8 +517,11 @@
             </object>
           </object>
           <object type="Cache" os_index="49" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="49" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="49" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -408,8 +529,11 @@
             </object>
           </object>
           <object type="Cache" os_index="50" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="50" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="50" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -417,8 +541,11 @@
             </object>
           </object>
           <object type="Cache" os_index="51" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="51" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="51" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -426,8 +553,11 @@
             </object>
           </object>
           <object type="Cache" os_index="52" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="52" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="52" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -435,8 +565,11 @@
             </object>
           </object>
           <object type="Cache" os_index="53" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="53" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="53" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -452,9 +585,13 @@
         <info name="CPUModel" value="Six-Core AMD Opteron(tm) Processor 8439 SE"/>
         <info name="CPUStepping" value="0"/>
         <object type="Cache" os_index="7" cpuset="0x00008080,0x80808080" complete_cpuset="0x00008080,0x80808080" allowed_cpuset="0x00008080,0x80808080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="5242880" depth="3" cache_linesize="64" cache_associativity="48" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="56" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="56" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="56" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -462,8 +599,11 @@
             </object>
           </object>
           <object type="Cache" os_index="57" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="57" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="57" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -471,8 +611,11 @@
             </object>
           </object>
           <object type="Cache" os_index="58" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="58" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="58" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -480,8 +623,11 @@
             </object>
           </object>
           <object type="Cache" os_index="59" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="59" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="59" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -489,8 +635,11 @@
             </object>
           </object>
           <object type="Cache" os_index="60" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="60" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="60" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -498,8 +647,11 @@
             </object>
           </object>
           <object type="Cache" os_index="61" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="61" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="61" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>

--- a/tests/hwloc/x86/AMD-K10-MagnyCours-2xOpteron-6164HE.output
+++ b/tests/hwloc/x86/AMD-K10-MagnyCours-2xOpteron-6164HE.output
@@ -11,9 +11,13 @@
         <info name="CPUModel" value="AMD Opteron(tm) Processor 6164 HE"/>
         <info name="CPUStepping" value="1"/>
         <object type="Cache" os_index="0" cpuset="0x00000fff" complete_cpuset="0x00000fff" allowed_cpuset="0x00000fff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="64" cache_associativity="96" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -21,8 +25,11 @@
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -30,8 +37,11 @@
             </object>
           </object>
           <object type="Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -39,8 +49,11 @@
             </object>
           </object>
           <object type="Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -48,8 +61,11 @@
             </object>
           </object>
           <object type="Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -57,8 +73,11 @@
             </object>
           </object>
           <object type="Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -66,8 +85,11 @@
             </object>
           </object>
           <object type="Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -75,8 +97,11 @@
             </object>
           </object>
           <object type="Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -84,8 +109,11 @@
             </object>
           </object>
           <object type="Cache" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -93,8 +121,11 @@
             </object>
           </object>
           <object type="Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -102,8 +133,11 @@
             </object>
           </object>
           <object type="Cache" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -111,8 +145,11 @@
             </object>
           </object>
           <object type="Cache" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -128,9 +165,13 @@
         <info name="CPUModel" value="AMD Opteron(tm) Processor 6164 HE"/>
         <info name="CPUStepping" value="1"/>
         <object type="Cache" os_index="1" cpuset="0x00fff000" complete_cpuset="0x00fff000" allowed_cpuset="0x00fff000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="10485760" depth="3" cache_linesize="64" cache_associativity="96" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="16" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="16" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="16" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -138,8 +179,11 @@
             </object>
           </object>
           <object type="Cache" os_index="17" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="17" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="17" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -147,8 +191,11 @@
             </object>
           </object>
           <object type="Cache" os_index="18" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="18" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="18" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -156,8 +203,11 @@
             </object>
           </object>
           <object type="Cache" os_index="19" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="19" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="19" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -165,8 +215,11 @@
             </object>
           </object>
           <object type="Cache" os_index="20" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="20" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="20" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -174,8 +227,11 @@
             </object>
           </object>
           <object type="Cache" os_index="21" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="21" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="21" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -183,8 +239,11 @@
             </object>
           </object>
           <object type="Cache" os_index="22" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="22" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="22" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -192,8 +251,11 @@
             </object>
           </object>
           <object type="Cache" os_index="23" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="23" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="23" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -201,8 +263,11 @@
             </object>
           </object>
           <object type="Cache" os_index="24" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="24" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="24" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -210,8 +275,11 @@
             </object>
           </object>
           <object type="Cache" os_index="25" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="25" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="25" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -219,8 +287,11 @@
             </object>
           </object>
           <object type="Cache" os_index="26" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="26" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="26" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -228,8 +299,11 @@
             </object>
           </object>
           <object type="Cache" os_index="27" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+            <info name="inclusiveness" value="true"/>
             <object type="Cache" os_index="27" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="27" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="11" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>

--- a/tests/hwloc/x86/AMD-K8-SantaRosa-2xOpteron-2218.output
+++ b/tests/hwloc/x86/AMD-K8-SantaRosa-2xOpteron-2218.output
@@ -11,8 +11,11 @@
         <info name="CPUModel" value="Dual-Core AMD Opteron(tm) Processor 2218"/>
         <info name="CPUStepping" value="2"/>
         <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
@@ -20,8 +23,11 @@
           </object>
         </object>
         <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
@@ -36,8 +42,11 @@
         <info name="CPUModel" value="Dual-Core AMD Opteron(tm) Processor 2218"/>
         <info name="CPUStepping" value="2"/>
         <object type="Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="0" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
@@ -45,8 +54,11 @@
           </object>
         </object>
         <object type="Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="1" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>

--- a/tests/hwloc/x86/AMD-K8-SledgeHammer-2xOpteron-250.output
+++ b/tests/hwloc/x86/AMD-K8-SledgeHammer-2xOpteron-250.output
@@ -11,8 +11,11 @@
         <info name="CPUModel" value="AMD Opteron(tm) Processor 250"/>
         <info name="CPUStepping" value="10"/>
         <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
@@ -27,8 +30,11 @@
         <info name="CPUModel" value="AMD Opteron(tm) Processor 250"/>
         <info name="CPUStepping" value="10"/>
         <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="1048576" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="65536" depth="1" cache_linesize="64" cache_associativity="2" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="0" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>

--- a/tests/hwloc/x86/Intel-Core-2xXeon-E5345.output
+++ b/tests/hwloc/x86/Intel-Core-2xXeon-E5345.output
@@ -11,15 +11,20 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           E5345  @ 2.33GHz"/>
         <info name="CPUStepping" value="7"/>
         <object type="Cache" os_index="0" cpuset="0x00000011" complete_cpuset="0x00000011" allowed_cpuset="0x00000011" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="4194304" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="1" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
@@ -27,15 +32,20 @@
           </object>
         </object>
         <object type="Cache" os_index="1" cpuset="0x00000044" complete_cpuset="0x00000044" allowed_cpuset="0x00000044" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="4194304" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
             </object>
           </object>
           <object type="Cache" os_index="3" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="3" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="3" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
@@ -50,15 +60,20 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           E5345  @ 2.33GHz"/>
         <info name="CPUStepping" value="7"/>
         <object type="Cache" os_index="2" cpuset="0x00000022" complete_cpuset="0x00000022" allowed_cpuset="0x00000022" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="4194304" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="4" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="4" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="0" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
             </object>
           </object>
           <object type="Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="1" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
@@ -66,15 +81,20 @@
           </object>
         </object>
         <object type="Cache" os_index="3" cpuset="0x00000088" complete_cpuset="0x00000088" allowed_cpuset="0x00000088" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="4194304" depth="2" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="6" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="6" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="2" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>
             </object>
           </object>
           <object type="Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="3" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
               </object>

--- a/tests/hwloc/x86/Intel-Haswell-2xXeon-E5-2680v3.output
+++ b/tests/hwloc/x86/Intel-Haswell-2xXeon-E5-2680v3.output
@@ -11,9 +11,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"/>
         <info name="CPUStepping" value="2"/>
         <object type="Cache" os_index="0" cpuset="0x00000555" complete_cpuset="0x00000555" allowed_cpuset="0x00000555" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="15728640" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -21,8 +25,11 @@
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="1" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -30,8 +37,11 @@
             </object>
           </object>
           <object type="Cache" os_index="2" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="2" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -39,8 +49,11 @@
             </object>
           </object>
           <object type="Cache" os_index="3" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="3" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="3" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -48,8 +61,11 @@
             </object>
           </object>
           <object type="Cache" os_index="4" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="4" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="4" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -57,8 +73,11 @@
             </object>
           </object>
           <object type="Cache" os_index="5" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="5" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="5" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -67,9 +86,13 @@
           </object>
         </object>
         <object type="Cache" os_index="1" cpuset="0x00555000" complete_cpuset="0x00555000" allowed_cpuset="0x00555000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="15728640" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="8" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="8" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="8" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -77,8 +100,11 @@
             </object>
           </object>
           <object type="Cache" os_index="9" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="9" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="9" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -86,8 +112,11 @@
             </object>
           </object>
           <object type="Cache" os_index="10" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="10" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="10" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -95,8 +124,11 @@
             </object>
           </object>
           <object type="Cache" os_index="11" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="11" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="11" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="11" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -104,8 +136,11 @@
             </object>
           </object>
           <object type="Cache" os_index="12" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="12" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="12" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="12" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -113,8 +148,11 @@
             </object>
           </object>
           <object type="Cache" os_index="13" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="13" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="13" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="13" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -130,9 +168,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz"/>
         <info name="CPUStepping" value="2"/>
         <object type="Cache" os_index="2" cpuset="0x00000aaa" complete_cpuset="0x00000aaa" allowed_cpuset="0x00000aaa" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="15728640" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="16" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="16" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="16" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -140,8 +182,11 @@
             </object>
           </object>
           <object type="Cache" os_index="17" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="17" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="17" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -149,8 +194,11 @@
             </object>
           </object>
           <object type="Cache" os_index="18" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="18" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="18" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -158,8 +206,11 @@
             </object>
           </object>
           <object type="Cache" os_index="19" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="19" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="19" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -167,8 +218,11 @@
             </object>
           </object>
           <object type="Cache" os_index="20" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="20" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="20" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -176,8 +230,11 @@
             </object>
           </object>
           <object type="Cache" os_index="21" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="21" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="21" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -186,9 +243,13 @@
           </object>
         </object>
         <object type="Cache" os_index="3" cpuset="0x00aaa000" complete_cpuset="0x00aaa000" allowed_cpuset="0x00aaa000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="15728640" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="24" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="24" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="24" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -196,8 +257,11 @@
             </object>
           </object>
           <object type="Cache" os_index="25" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="25" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="25" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -205,8 +269,11 @@
             </object>
           </object>
           <object type="Cache" os_index="26" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="26" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="26" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -214,8 +281,11 @@
             </object>
           </object>
           <object type="Cache" os_index="27" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="27" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="27" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="11" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -223,8 +293,11 @@
             </object>
           </object>
           <object type="Cache" os_index="28" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="28" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="28" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="12" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -232,8 +305,11 @@
             </object>
           </object>
           <object type="Cache" os_index="29" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="29" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="29" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="13" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>

--- a/tests/hwloc/x86/Intel-IvyBridge-12xXeon-E5-4620v2.output
+++ b/tests/hwloc/x86/Intel-IvyBridge-12xXeon-E5-4620v2.output
@@ -11,9 +11,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="0" cpuset="0x000000ff,,,0x000000ff" complete_cpuset="0x000000ff,,,0x000000ff" allowed_cpuset="0x000000ff,,,0x000000ff" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" allowed_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" allowed_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" allowed_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000001,,,0x00000001" complete_cpuset="0x00000001,,,0x00000001" allowed_cpuset="0x00000001,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="96" cpuset="0x00000001,,,0x0" complete_cpuset="0x00000001,,,0x0" allowed_cpuset="0x00000001,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -22,8 +26,11 @@
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" allowed_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" allowed_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" allowed_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000002,,,0x00000002" complete_cpuset="0x00000002,,,0x00000002" allowed_cpuset="0x00000002,,,0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -32,8 +39,11 @@
             </object>
           </object>
           <object type="Cache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" allowed_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" allowed_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" allowed_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000004,,,0x00000004" complete_cpuset="0x00000004,,,0x00000004" allowed_cpuset="0x00000004,,,0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -42,8 +52,11 @@
             </object>
           </object>
           <object type="Cache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" allowed_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" allowed_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" allowed_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000008,,,0x00000008" complete_cpuset="0x00000008,,,0x00000008" allowed_cpuset="0x00000008,,,0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="99" cpuset="0x00000008,,,0x0" complete_cpuset="0x00000008,,,0x0" allowed_cpuset="0x00000008,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -52,8 +65,11 @@
             </object>
           </object>
           <object type="Cache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" allowed_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" allowed_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" allowed_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000010,,,0x00000010" complete_cpuset="0x00000010,,,0x00000010" allowed_cpuset="0x00000010,,,0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="100" cpuset="0x00000010,,,0x0" complete_cpuset="0x00000010,,,0x0" allowed_cpuset="0x00000010,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -62,8 +78,11 @@
             </object>
           </object>
           <object type="Cache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" allowed_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" allowed_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" allowed_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000020,,,0x00000020" complete_cpuset="0x00000020,,,0x00000020" allowed_cpuset="0x00000020,,,0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -72,8 +91,11 @@
             </object>
           </object>
           <object type="Cache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" allowed_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" allowed_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" allowed_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00000040,,,0x00000040" complete_cpuset="0x00000040,,,0x00000040" allowed_cpuset="0x00000040,,,0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -82,8 +104,11 @@
             </object>
           </object>
           <object type="Cache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" allowed_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" allowed_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" allowed_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00000080,,,0x00000080" complete_cpuset="0x00000080,,,0x00000080" allowed_cpuset="0x00000080,,,0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="103" cpuset="0x00000080,,,0x0" complete_cpuset="0x00000080,,,0x0" allowed_cpuset="0x00000080,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -100,9 +125,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="1" cpuset="0x0000ff00,,,0x0000ff00" complete_cpuset="0x0000ff00,,,0x0000ff00" allowed_cpuset="0x0000ff00,,,0x0000ff00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="16" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" allowed_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="16" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" allowed_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="16" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" allowed_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000100,,,0x00000100" complete_cpuset="0x00000100,,,0x00000100" allowed_cpuset="0x00000100,,,0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="104" cpuset="0x00000100,,,0x0" complete_cpuset="0x00000100,,,0x0" allowed_cpuset="0x00000100,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -111,8 +140,11 @@
             </object>
           </object>
           <object type="Cache" os_index="17" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" allowed_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="17" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" allowed_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="17" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" allowed_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000200,,,0x00000200" complete_cpuset="0x00000200,,,0x00000200" allowed_cpuset="0x00000200,,,0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -121,8 +153,11 @@
             </object>
           </object>
           <object type="Cache" os_index="18" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" allowed_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="18" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" allowed_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="18" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" allowed_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000400,,,0x00000400" complete_cpuset="0x00000400,,,0x00000400" allowed_cpuset="0x00000400,,,0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -131,8 +166,11 @@
             </object>
           </object>
           <object type="Cache" os_index="19" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" allowed_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="19" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" allowed_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="19" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" allowed_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000800,,,0x00000800" complete_cpuset="0x00000800,,,0x00000800" allowed_cpuset="0x00000800,,,0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="107" cpuset="0x00000800,,,0x0" complete_cpuset="0x00000800,,,0x0" allowed_cpuset="0x00000800,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -141,8 +179,11 @@
             </object>
           </object>
           <object type="Cache" os_index="20" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" allowed_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="20" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" allowed_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="20" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" allowed_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00001000,,,0x00001000" complete_cpuset="0x00001000,,,0x00001000" allowed_cpuset="0x00001000,,,0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="108" cpuset="0x00001000,,,0x0" complete_cpuset="0x00001000,,,0x0" allowed_cpuset="0x00001000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -151,8 +192,11 @@
             </object>
           </object>
           <object type="Cache" os_index="21" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" allowed_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="21" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" allowed_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="21" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" allowed_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00002000,,,0x00002000" complete_cpuset="0x00002000,,,0x00002000" allowed_cpuset="0x00002000,,,0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -161,8 +205,11 @@
             </object>
           </object>
           <object type="Cache" os_index="22" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" allowed_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="22" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" allowed_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="22" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" allowed_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00004000,,,0x00004000" complete_cpuset="0x00004000,,,0x00004000" allowed_cpuset="0x00004000,,,0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -171,8 +218,11 @@
             </object>
           </object>
           <object type="Cache" os_index="23" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" allowed_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="23" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" allowed_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="23" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" allowed_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00008000,,,0x00008000" complete_cpuset="0x00008000,,,0x00008000" allowed_cpuset="0x00008000,,,0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="111" cpuset="0x00008000,,,0x0" complete_cpuset="0x00008000,,,0x0" allowed_cpuset="0x00008000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -189,9 +239,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="2" cpuset="0x00ff0000,,,0x00ff0000" complete_cpuset="0x00ff0000,,,0x00ff0000" allowed_cpuset="0x00ff0000,,,0x00ff0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="32" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" allowed_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="32" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" allowed_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="32" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" allowed_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00010000,,,0x00010000" complete_cpuset="0x00010000,,,0x00010000" allowed_cpuset="0x00010000,,,0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="112" cpuset="0x00010000,,,0x0" complete_cpuset="0x00010000,,,0x0" allowed_cpuset="0x00010000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -200,8 +254,11 @@
             </object>
           </object>
           <object type="Cache" os_index="33" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" allowed_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="33" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" allowed_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="33" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" allowed_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00020000,,,0x00020000" complete_cpuset="0x00020000,,,0x00020000" allowed_cpuset="0x00020000,,,0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -210,8 +267,11 @@
             </object>
           </object>
           <object type="Cache" os_index="34" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" allowed_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="34" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" allowed_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="34" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" allowed_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00040000,,,0x00040000" complete_cpuset="0x00040000,,,0x00040000" allowed_cpuset="0x00040000,,,0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -220,8 +280,11 @@
             </object>
           </object>
           <object type="Cache" os_index="35" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" allowed_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="35" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" allowed_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="35" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" allowed_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00080000,,,0x00080000" complete_cpuset="0x00080000,,,0x00080000" allowed_cpuset="0x00080000,,,0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="115" cpuset="0x00080000,,,0x0" complete_cpuset="0x00080000,,,0x0" allowed_cpuset="0x00080000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -230,8 +293,11 @@
             </object>
           </object>
           <object type="Cache" os_index="36" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" allowed_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="36" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" allowed_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="36" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" allowed_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00100000,,,0x00100000" complete_cpuset="0x00100000,,,0x00100000" allowed_cpuset="0x00100000,,,0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="116" cpuset="0x00100000,,,0x0" complete_cpuset="0x00100000,,,0x0" allowed_cpuset="0x00100000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -240,8 +306,11 @@
             </object>
           </object>
           <object type="Cache" os_index="37" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" allowed_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="37" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" allowed_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="37" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" allowed_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00200000,,,0x00200000" complete_cpuset="0x00200000,,,0x00200000" allowed_cpuset="0x00200000,,,0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -250,8 +319,11 @@
             </object>
           </object>
           <object type="Cache" os_index="38" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" allowed_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="38" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" allowed_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="38" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" allowed_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00400000,,,0x00400000" complete_cpuset="0x00400000,,,0x00400000" allowed_cpuset="0x00400000,,,0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -260,8 +332,11 @@
             </object>
           </object>
           <object type="Cache" os_index="39" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" allowed_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="39" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" allowed_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="39" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" allowed_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00800000,,,0x00800000" complete_cpuset="0x00800000,,,0x00800000" allowed_cpuset="0x00800000,,,0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="119" cpuset="0x00800000,,,0x0" complete_cpuset="0x00800000,,,0x0" allowed_cpuset="0x00800000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -278,9 +353,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="3" cpuset="0xff000000,,,0xff000000" complete_cpuset="0xff000000,,,0xff000000" allowed_cpuset="0xff000000,,,0xff000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="48" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" allowed_cpuset="0x01000000,,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="48" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" allowed_cpuset="0x01000000,,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="48" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" allowed_cpuset="0x01000000,,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x01000000,,,0x01000000" complete_cpuset="0x01000000,,,0x01000000" allowed_cpuset="0x01000000,,,0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="120" cpuset="0x01000000,,,0x0" complete_cpuset="0x01000000,,,0x0" allowed_cpuset="0x01000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -289,8 +368,11 @@
             </object>
           </object>
           <object type="Cache" os_index="49" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" allowed_cpuset="0x02000000,,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="49" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" allowed_cpuset="0x02000000,,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="49" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" allowed_cpuset="0x02000000,,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x02000000,,,0x02000000" complete_cpuset="0x02000000,,,0x02000000" allowed_cpuset="0x02000000,,,0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -299,8 +381,11 @@
             </object>
           </object>
           <object type="Cache" os_index="50" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" allowed_cpuset="0x04000000,,,0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="50" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" allowed_cpuset="0x04000000,,,0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="50" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" allowed_cpuset="0x04000000,,,0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x04000000,,,0x04000000" complete_cpuset="0x04000000,,,0x04000000" allowed_cpuset="0x04000000,,,0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -309,8 +394,11 @@
             </object>
           </object>
           <object type="Cache" os_index="51" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" allowed_cpuset="0x08000000,,,0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="51" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" allowed_cpuset="0x08000000,,,0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="51" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" allowed_cpuset="0x08000000,,,0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x08000000,,,0x08000000" complete_cpuset="0x08000000,,,0x08000000" allowed_cpuset="0x08000000,,,0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="123" cpuset="0x08000000,,,0x0" complete_cpuset="0x08000000,,,0x0" allowed_cpuset="0x08000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -319,8 +407,11 @@
             </object>
           </object>
           <object type="Cache" os_index="52" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" allowed_cpuset="0x10000000,,,0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="52" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" allowed_cpuset="0x10000000,,,0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="52" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" allowed_cpuset="0x10000000,,,0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x10000000,,,0x10000000" complete_cpuset="0x10000000,,,0x10000000" allowed_cpuset="0x10000000,,,0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="124" cpuset="0x10000000,,,0x0" complete_cpuset="0x10000000,,,0x0" allowed_cpuset="0x10000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -329,8 +420,11 @@
             </object>
           </object>
           <object type="Cache" os_index="53" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" allowed_cpuset="0x20000000,,,0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="53" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" allowed_cpuset="0x20000000,,,0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="53" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" allowed_cpuset="0x20000000,,,0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x20000000,,,0x20000000" complete_cpuset="0x20000000,,,0x20000000" allowed_cpuset="0x20000000,,,0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -339,8 +433,11 @@
             </object>
           </object>
           <object type="Cache" os_index="54" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" allowed_cpuset="0x40000000,,,0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="54" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" allowed_cpuset="0x40000000,,,0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="54" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" allowed_cpuset="0x40000000,,,0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x40000000,,,0x40000000" complete_cpuset="0x40000000,,,0x40000000" allowed_cpuset="0x40000000,,,0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -349,8 +446,11 @@
             </object>
           </object>
           <object type="Cache" os_index="55" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" allowed_cpuset="0x80000000,,,0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="55" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" allowed_cpuset="0x80000000,,,0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="55" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" allowed_cpuset="0x80000000,,,0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x80000000,,,0x80000000" complete_cpuset="0x80000000,,,0x80000000" allowed_cpuset="0x80000000,,,0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="127" cpuset="0x80000000,,,0x0" complete_cpuset="0x80000000,,,0x0" allowed_cpuset="0x80000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -367,9 +467,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="4" cpuset="0x000000ff,,,0x000000ff,0x0" complete_cpuset="0x000000ff,,,0x000000ff,0x0" allowed_cpuset="0x000000ff,,,0x000000ff,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="64" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" allowed_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="64" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" allowed_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="64" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" allowed_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000001,,,0x00000001,0x0" complete_cpuset="0x00000001,,,0x00000001,0x0" allowed_cpuset="0x00000001,,,0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="32" cpuset="0x00000001,0x0" complete_cpuset="0x00000001,0x0" allowed_cpuset="0x00000001,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="128" cpuset="0x00000001,,,,0x0" complete_cpuset="0x00000001,,,,0x0" allowed_cpuset="0x00000001,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -378,8 +482,11 @@
             </object>
           </object>
           <object type="Cache" os_index="65" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" allowed_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="65" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" allowed_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="65" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" allowed_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000002,,,0x00000002,0x0" complete_cpuset="0x00000002,,,0x00000002,0x0" allowed_cpuset="0x00000002,,,0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -388,8 +495,11 @@
             </object>
           </object>
           <object type="Cache" os_index="66" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" allowed_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="66" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" allowed_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="66" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" allowed_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000004,,,0x00000004,0x0" complete_cpuset="0x00000004,,,0x00000004,0x0" allowed_cpuset="0x00000004,,,0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -398,8 +508,11 @@
             </object>
           </object>
           <object type="Cache" os_index="67" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" allowed_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="67" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" allowed_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="67" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" allowed_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000008,,,0x00000008,0x0" complete_cpuset="0x00000008,,,0x00000008,0x0" allowed_cpuset="0x00000008,,,0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="35" cpuset="0x00000008,0x0" complete_cpuset="0x00000008,0x0" allowed_cpuset="0x00000008,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="131" cpuset="0x00000008,,,,0x0" complete_cpuset="0x00000008,,,,0x0" allowed_cpuset="0x00000008,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -408,8 +521,11 @@
             </object>
           </object>
           <object type="Cache" os_index="68" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" allowed_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="68" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" allowed_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="68" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" allowed_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000010,,,0x00000010,0x0" complete_cpuset="0x00000010,,,0x00000010,0x0" allowed_cpuset="0x00000010,,,0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="36" cpuset="0x00000010,0x0" complete_cpuset="0x00000010,0x0" allowed_cpuset="0x00000010,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="132" cpuset="0x00000010,,,,0x0" complete_cpuset="0x00000010,,,,0x0" allowed_cpuset="0x00000010,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -418,8 +534,11 @@
             </object>
           </object>
           <object type="Cache" os_index="69" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" allowed_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="69" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" allowed_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="69" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" allowed_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000020,,,0x00000020,0x0" complete_cpuset="0x00000020,,,0x00000020,0x0" allowed_cpuset="0x00000020,,,0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -428,8 +547,11 @@
             </object>
           </object>
           <object type="Cache" os_index="70" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" allowed_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="70" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" allowed_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="70" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" allowed_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00000040,,,0x00000040,0x0" complete_cpuset="0x00000040,,,0x00000040,0x0" allowed_cpuset="0x00000040,,,0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -438,8 +560,11 @@
             </object>
           </object>
           <object type="Cache" os_index="71" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" allowed_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="71" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" allowed_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="71" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" allowed_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00000080,,,0x00000080,0x0" complete_cpuset="0x00000080,,,0x00000080,0x0" allowed_cpuset="0x00000080,,,0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="39" cpuset="0x00000080,0x0" complete_cpuset="0x00000080,0x0" allowed_cpuset="0x00000080,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="135" cpuset="0x00000080,,,,0x0" complete_cpuset="0x00000080,,,,0x0" allowed_cpuset="0x00000080,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -456,9 +581,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="5" cpuset="0x0000ff00,,,0x0000ff00,0x0" complete_cpuset="0x0000ff00,,,0x0000ff00,0x0" allowed_cpuset="0x0000ff00,,,0x0000ff00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="80" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" allowed_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="80" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" allowed_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="80" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" allowed_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000100,,,0x00000100,0x0" complete_cpuset="0x00000100,,,0x00000100,0x0" allowed_cpuset="0x00000100,,,0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="40" cpuset="0x00000100,0x0" complete_cpuset="0x00000100,0x0" allowed_cpuset="0x00000100,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="136" cpuset="0x00000100,,,,0x0" complete_cpuset="0x00000100,,,,0x0" allowed_cpuset="0x00000100,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -467,8 +596,11 @@
             </object>
           </object>
           <object type="Cache" os_index="81" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" allowed_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="81" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" allowed_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="81" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" allowed_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000200,,,0x00000200,0x0" complete_cpuset="0x00000200,,,0x00000200,0x0" allowed_cpuset="0x00000200,,,0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -477,8 +609,11 @@
             </object>
           </object>
           <object type="Cache" os_index="82" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" allowed_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="82" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" allowed_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="82" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" allowed_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000400,,,0x00000400,0x0" complete_cpuset="0x00000400,,,0x00000400,0x0" allowed_cpuset="0x00000400,,,0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -487,8 +622,11 @@
             </object>
           </object>
           <object type="Cache" os_index="83" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" allowed_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="83" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" allowed_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="83" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" allowed_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000800,,,0x00000800,0x0" complete_cpuset="0x00000800,,,0x00000800,0x0" allowed_cpuset="0x00000800,,,0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="43" cpuset="0x00000800,0x0" complete_cpuset="0x00000800,0x0" allowed_cpuset="0x00000800,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="139" cpuset="0x00000800,,,,0x0" complete_cpuset="0x00000800,,,,0x0" allowed_cpuset="0x00000800,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -497,8 +635,11 @@
             </object>
           </object>
           <object type="Cache" os_index="84" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" allowed_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="84" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" allowed_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="84" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" allowed_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00001000,,,0x00001000,0x0" complete_cpuset="0x00001000,,,0x00001000,0x0" allowed_cpuset="0x00001000,,,0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="44" cpuset="0x00001000,0x0" complete_cpuset="0x00001000,0x0" allowed_cpuset="0x00001000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="140" cpuset="0x00001000,,,,0x0" complete_cpuset="0x00001000,,,,0x0" allowed_cpuset="0x00001000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -507,8 +648,11 @@
             </object>
           </object>
           <object type="Cache" os_index="85" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" allowed_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="85" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" allowed_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="85" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" allowed_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00002000,,,0x00002000,0x0" complete_cpuset="0x00002000,,,0x00002000,0x0" allowed_cpuset="0x00002000,,,0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -517,8 +661,11 @@
             </object>
           </object>
           <object type="Cache" os_index="86" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" allowed_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="86" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" allowed_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="86" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" allowed_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00004000,,,0x00004000,0x0" complete_cpuset="0x00004000,,,0x00004000,0x0" allowed_cpuset="0x00004000,,,0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -527,8 +674,11 @@
             </object>
           </object>
           <object type="Cache" os_index="87" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" allowed_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="87" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" allowed_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="87" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" allowed_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00008000,,,0x00008000,0x0" complete_cpuset="0x00008000,,,0x00008000,0x0" allowed_cpuset="0x00008000,,,0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="47" cpuset="0x00008000,0x0" complete_cpuset="0x00008000,0x0" allowed_cpuset="0x00008000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="143" cpuset="0x00008000,,,,0x0" complete_cpuset="0x00008000,,,,0x0" allowed_cpuset="0x00008000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -545,9 +695,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="6" cpuset="0x00ff0000,,,0x00ff0000,0x0" complete_cpuset="0x00ff0000,,,0x00ff0000,0x0" allowed_cpuset="0x00ff0000,,,0x00ff0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="96" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" allowed_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="96" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" allowed_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="96" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" allowed_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00010000,,,0x00010000,0x0" complete_cpuset="0x00010000,,,0x00010000,0x0" allowed_cpuset="0x00010000,,,0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="48" cpuset="0x00010000,0x0" complete_cpuset="0x00010000,0x0" allowed_cpuset="0x00010000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="144" cpuset="0x00010000,,,,0x0" complete_cpuset="0x00010000,,,,0x0" allowed_cpuset="0x00010000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -556,8 +710,11 @@
             </object>
           </object>
           <object type="Cache" os_index="97" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" allowed_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="97" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" allowed_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="97" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" allowed_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00020000,,,0x00020000,0x0" complete_cpuset="0x00020000,,,0x00020000,0x0" allowed_cpuset="0x00020000,,,0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -566,8 +723,11 @@
             </object>
           </object>
           <object type="Cache" os_index="98" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" allowed_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="98" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" allowed_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="98" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" allowed_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00040000,,,0x00040000,0x0" complete_cpuset="0x00040000,,,0x00040000,0x0" allowed_cpuset="0x00040000,,,0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -576,8 +736,11 @@
             </object>
           </object>
           <object type="Cache" os_index="99" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" allowed_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="99" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" allowed_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="99" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" allowed_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00080000,,,0x00080000,0x0" complete_cpuset="0x00080000,,,0x00080000,0x0" allowed_cpuset="0x00080000,,,0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="51" cpuset="0x00080000,0x0" complete_cpuset="0x00080000,0x0" allowed_cpuset="0x00080000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="147" cpuset="0x00080000,,,,0x0" complete_cpuset="0x00080000,,,,0x0" allowed_cpuset="0x00080000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -586,8 +749,11 @@
             </object>
           </object>
           <object type="Cache" os_index="100" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" allowed_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="100" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" allowed_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="100" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" allowed_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00100000,,,0x00100000,0x0" complete_cpuset="0x00100000,,,0x00100000,0x0" allowed_cpuset="0x00100000,,,0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="52" cpuset="0x00100000,0x0" complete_cpuset="0x00100000,0x0" allowed_cpuset="0x00100000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="148" cpuset="0x00100000,,,,0x0" complete_cpuset="0x00100000,,,,0x0" allowed_cpuset="0x00100000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -596,8 +762,11 @@
             </object>
           </object>
           <object type="Cache" os_index="101" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" allowed_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="101" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" allowed_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="101" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" allowed_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00200000,,,0x00200000,0x0" complete_cpuset="0x00200000,,,0x00200000,0x0" allowed_cpuset="0x00200000,,,0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -606,8 +775,11 @@
             </object>
           </object>
           <object type="Cache" os_index="102" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" allowed_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="102" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" allowed_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="102" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" allowed_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00400000,,,0x00400000,0x0" complete_cpuset="0x00400000,,,0x00400000,0x0" allowed_cpuset="0x00400000,,,0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -616,8 +788,11 @@
             </object>
           </object>
           <object type="Cache" os_index="103" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" allowed_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="103" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" allowed_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="103" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" allowed_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00800000,,,0x00800000,0x0" complete_cpuset="0x00800000,,,0x00800000,0x0" allowed_cpuset="0x00800000,,,0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="55" cpuset="0x00800000,0x0" complete_cpuset="0x00800000,0x0" allowed_cpuset="0x00800000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="151" cpuset="0x00800000,,,,0x0" complete_cpuset="0x00800000,,,,0x0" allowed_cpuset="0x00800000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -634,9 +809,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="7" cpuset="0xff000000,,,0xff000000,0x0" complete_cpuset="0xff000000,,,0xff000000,0x0" allowed_cpuset="0xff000000,,,0xff000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="112" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" allowed_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="112" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" allowed_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="112" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" allowed_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x01000000,,,0x01000000,0x0" complete_cpuset="0x01000000,,,0x01000000,0x0" allowed_cpuset="0x01000000,,,0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="56" cpuset="0x01000000,0x0" complete_cpuset="0x01000000,0x0" allowed_cpuset="0x01000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="152" cpuset="0x01000000,,,,0x0" complete_cpuset="0x01000000,,,,0x0" allowed_cpuset="0x01000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -645,8 +824,11 @@
             </object>
           </object>
           <object type="Cache" os_index="113" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" allowed_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="113" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" allowed_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="113" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" allowed_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x02000000,,,0x02000000,0x0" complete_cpuset="0x02000000,,,0x02000000,0x0" allowed_cpuset="0x02000000,,,0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -655,8 +837,11 @@
             </object>
           </object>
           <object type="Cache" os_index="114" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" allowed_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="114" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" allowed_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="114" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" allowed_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x04000000,,,0x04000000,0x0" complete_cpuset="0x04000000,,,0x04000000,0x0" allowed_cpuset="0x04000000,,,0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -665,8 +850,11 @@
             </object>
           </object>
           <object type="Cache" os_index="115" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" allowed_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="115" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" allowed_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="115" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" allowed_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x08000000,,,0x08000000,0x0" complete_cpuset="0x08000000,,,0x08000000,0x0" allowed_cpuset="0x08000000,,,0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="59" cpuset="0x08000000,0x0" complete_cpuset="0x08000000,0x0" allowed_cpuset="0x08000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="155" cpuset="0x08000000,,,,0x0" complete_cpuset="0x08000000,,,,0x0" allowed_cpuset="0x08000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -675,8 +863,11 @@
             </object>
           </object>
           <object type="Cache" os_index="116" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" allowed_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="116" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" allowed_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="116" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" allowed_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x10000000,,,0x10000000,0x0" complete_cpuset="0x10000000,,,0x10000000,0x0" allowed_cpuset="0x10000000,,,0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="60" cpuset="0x10000000,0x0" complete_cpuset="0x10000000,0x0" allowed_cpuset="0x10000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="156" cpuset="0x10000000,,,,0x0" complete_cpuset="0x10000000,,,,0x0" allowed_cpuset="0x10000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -685,8 +876,11 @@
             </object>
           </object>
           <object type="Cache" os_index="117" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" allowed_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="117" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" allowed_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="117" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" allowed_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x20000000,,,0x20000000,0x0" complete_cpuset="0x20000000,,,0x20000000,0x0" allowed_cpuset="0x20000000,,,0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -695,8 +889,11 @@
             </object>
           </object>
           <object type="Cache" os_index="118" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" allowed_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="118" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" allowed_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="118" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" allowed_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x40000000,,,0x40000000,0x0" complete_cpuset="0x40000000,,,0x40000000,0x0" allowed_cpuset="0x40000000,,,0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -705,8 +902,11 @@
             </object>
           </object>
           <object type="Cache" os_index="119" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" allowed_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="119" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" allowed_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="119" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" allowed_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x80000000,,,0x80000000,0x0" complete_cpuset="0x80000000,,,0x80000000,0x0" allowed_cpuset="0x80000000,,,0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="63" cpuset="0x80000000,0x0" complete_cpuset="0x80000000,0x0" allowed_cpuset="0x80000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="159" cpuset="0x80000000,,,,0x0" complete_cpuset="0x80000000,,,,0x0" allowed_cpuset="0x80000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -723,9 +923,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="8" cpuset="0x000000ff,,,0x000000ff,,0x0" complete_cpuset="0x000000ff,,,0x000000ff,,0x0" allowed_cpuset="0x000000ff,,,0x000000ff,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="128" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" allowed_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="128" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" allowed_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="128" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" allowed_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000001,,,0x00000001,,0x0" complete_cpuset="0x00000001,,,0x00000001,,0x0" allowed_cpuset="0x00000001,,,0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="64" cpuset="0x00000001,,0x0" complete_cpuset="0x00000001,,0x0" allowed_cpuset="0x00000001,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="160" cpuset="0x00000001,,,,,0x0" complete_cpuset="0x00000001,,,,,0x0" allowed_cpuset="0x00000001,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -734,8 +938,11 @@
             </object>
           </object>
           <object type="Cache" os_index="129" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" allowed_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="129" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" allowed_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="129" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" allowed_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000002,,,0x00000002,,0x0" complete_cpuset="0x00000002,,,0x00000002,,0x0" allowed_cpuset="0x00000002,,,0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -744,8 +951,11 @@
             </object>
           </object>
           <object type="Cache" os_index="130" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" allowed_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="130" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" allowed_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="130" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" allowed_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000004,,,0x00000004,,0x0" complete_cpuset="0x00000004,,,0x00000004,,0x0" allowed_cpuset="0x00000004,,,0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -754,8 +964,11 @@
             </object>
           </object>
           <object type="Cache" os_index="131" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" allowed_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="131" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" allowed_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="131" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" allowed_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000008,,,0x00000008,,0x0" complete_cpuset="0x00000008,,,0x00000008,,0x0" allowed_cpuset="0x00000008,,,0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="67" cpuset="0x00000008,,0x0" complete_cpuset="0x00000008,,0x0" allowed_cpuset="0x00000008,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="163" cpuset="0x00000008,,,,,0x0" complete_cpuset="0x00000008,,,,,0x0" allowed_cpuset="0x00000008,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -764,8 +977,11 @@
             </object>
           </object>
           <object type="Cache" os_index="132" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" allowed_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="132" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" allowed_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="132" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" allowed_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00000010,,,0x00000010,,0x0" complete_cpuset="0x00000010,,,0x00000010,,0x0" allowed_cpuset="0x00000010,,,0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="68" cpuset="0x00000010,,0x0" complete_cpuset="0x00000010,,0x0" allowed_cpuset="0x00000010,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="164" cpuset="0x00000010,,,,,0x0" complete_cpuset="0x00000010,,,,,0x0" allowed_cpuset="0x00000010,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -774,8 +990,11 @@
             </object>
           </object>
           <object type="Cache" os_index="133" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" allowed_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="133" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" allowed_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="133" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" allowed_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00000020,,,0x00000020,,0x0" complete_cpuset="0x00000020,,,0x00000020,,0x0" allowed_cpuset="0x00000020,,,0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -784,8 +1003,11 @@
             </object>
           </object>
           <object type="Cache" os_index="134" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" allowed_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="134" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" allowed_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="134" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" allowed_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00000040,,,0x00000040,,0x0" complete_cpuset="0x00000040,,,0x00000040,,0x0" allowed_cpuset="0x00000040,,,0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -794,8 +1016,11 @@
             </object>
           </object>
           <object type="Cache" os_index="135" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" allowed_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="135" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" allowed_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="135" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" allowed_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00000080,,,0x00000080,,0x0" complete_cpuset="0x00000080,,,0x00000080,,0x0" allowed_cpuset="0x00000080,,,0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="71" cpuset="0x00000080,,0x0" complete_cpuset="0x00000080,,0x0" allowed_cpuset="0x00000080,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="167" cpuset="0x00000080,,,,,0x0" complete_cpuset="0x00000080,,,,,0x0" allowed_cpuset="0x00000080,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -812,9 +1037,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="9" cpuset="0x0000ff00,,,0x0000ff00,,0x0" complete_cpuset="0x0000ff00,,,0x0000ff00,,0x0" allowed_cpuset="0x0000ff00,,,0x0000ff00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="144" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" allowed_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="144" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" allowed_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="144" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" allowed_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000100,,,0x00000100,,0x0" complete_cpuset="0x00000100,,,0x00000100,,0x0" allowed_cpuset="0x00000100,,,0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="72" cpuset="0x00000100,,0x0" complete_cpuset="0x00000100,,0x0" allowed_cpuset="0x00000100,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="168" cpuset="0x00000100,,,,,0x0" complete_cpuset="0x00000100,,,,,0x0" allowed_cpuset="0x00000100,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -823,8 +1052,11 @@
             </object>
           </object>
           <object type="Cache" os_index="145" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" allowed_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="145" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" allowed_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="145" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" allowed_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000200,,,0x00000200,,0x0" complete_cpuset="0x00000200,,,0x00000200,,0x0" allowed_cpuset="0x00000200,,,0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -833,8 +1065,11 @@
             </object>
           </object>
           <object type="Cache" os_index="146" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" allowed_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="146" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" allowed_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="146" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" allowed_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000400,,,0x00000400,,0x0" complete_cpuset="0x00000400,,,0x00000400,,0x0" allowed_cpuset="0x00000400,,,0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -843,8 +1078,11 @@
             </object>
           </object>
           <object type="Cache" os_index="147" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" allowed_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="147" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" allowed_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="147" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" allowed_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000800,,,0x00000800,,0x0" complete_cpuset="0x00000800,,,0x00000800,,0x0" allowed_cpuset="0x00000800,,,0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="75" cpuset="0x00000800,,0x0" complete_cpuset="0x00000800,,0x0" allowed_cpuset="0x00000800,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="171" cpuset="0x00000800,,,,,0x0" complete_cpuset="0x00000800,,,,,0x0" allowed_cpuset="0x00000800,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -853,8 +1091,11 @@
             </object>
           </object>
           <object type="Cache" os_index="148" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" allowed_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="148" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" allowed_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="148" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" allowed_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00001000,,,0x00001000,,0x0" complete_cpuset="0x00001000,,,0x00001000,,0x0" allowed_cpuset="0x00001000,,,0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="76" cpuset="0x00001000,,0x0" complete_cpuset="0x00001000,,0x0" allowed_cpuset="0x00001000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="172" cpuset="0x00001000,,,,,0x0" complete_cpuset="0x00001000,,,,,0x0" allowed_cpuset="0x00001000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -863,8 +1104,11 @@
             </object>
           </object>
           <object type="Cache" os_index="149" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" allowed_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="149" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" allowed_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="149" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" allowed_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00002000,,,0x00002000,,0x0" complete_cpuset="0x00002000,,,0x00002000,,0x0" allowed_cpuset="0x00002000,,,0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -873,8 +1117,11 @@
             </object>
           </object>
           <object type="Cache" os_index="150" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" allowed_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="150" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" allowed_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="150" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" allowed_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00004000,,,0x00004000,,0x0" complete_cpuset="0x00004000,,,0x00004000,,0x0" allowed_cpuset="0x00004000,,,0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -883,8 +1130,11 @@
             </object>
           </object>
           <object type="Cache" os_index="151" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" allowed_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="151" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" allowed_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="151" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" allowed_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00008000,,,0x00008000,,0x0" complete_cpuset="0x00008000,,,0x00008000,,0x0" allowed_cpuset="0x00008000,,,0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="79" cpuset="0x00008000,,0x0" complete_cpuset="0x00008000,,0x0" allowed_cpuset="0x00008000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="175" cpuset="0x00008000,,,,,0x0" complete_cpuset="0x00008000,,,,,0x0" allowed_cpuset="0x00008000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -901,9 +1151,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="10" cpuset="0x00ff0000,,,0x00ff0000,,0x0" complete_cpuset="0x00ff0000,,,0x00ff0000,,0x0" allowed_cpuset="0x00ff0000,,,0x00ff0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="160" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" allowed_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="160" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" allowed_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="160" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" allowed_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00010000,,,0x00010000,,0x0" complete_cpuset="0x00010000,,,0x00010000,,0x0" allowed_cpuset="0x00010000,,,0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="80" cpuset="0x00010000,,0x0" complete_cpuset="0x00010000,,0x0" allowed_cpuset="0x00010000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="176" cpuset="0x00010000,,,,,0x0" complete_cpuset="0x00010000,,,,,0x0" allowed_cpuset="0x00010000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -912,8 +1166,11 @@
             </object>
           </object>
           <object type="Cache" os_index="161" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" allowed_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="161" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" allowed_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="161" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" allowed_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00020000,,,0x00020000,,0x0" complete_cpuset="0x00020000,,,0x00020000,,0x0" allowed_cpuset="0x00020000,,,0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="177" cpuset="0x00020000,,,,,0x0" complete_cpuset="0x00020000,,,,,0x0" allowed_cpuset="0x00020000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -922,8 +1179,11 @@
             </object>
           </object>
           <object type="Cache" os_index="162" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" allowed_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="162" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" allowed_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="162" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" allowed_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00040000,,,0x00040000,,0x0" complete_cpuset="0x00040000,,,0x00040000,,0x0" allowed_cpuset="0x00040000,,,0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="178" cpuset="0x00040000,,,,,0x0" complete_cpuset="0x00040000,,,,,0x0" allowed_cpuset="0x00040000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -932,8 +1192,11 @@
             </object>
           </object>
           <object type="Cache" os_index="163" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" allowed_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="163" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" allowed_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="163" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" allowed_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00080000,,,0x00080000,,0x0" complete_cpuset="0x00080000,,,0x00080000,,0x0" allowed_cpuset="0x00080000,,,0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="83" cpuset="0x00080000,,0x0" complete_cpuset="0x00080000,,0x0" allowed_cpuset="0x00080000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="179" cpuset="0x00080000,,,,,0x0" complete_cpuset="0x00080000,,,,,0x0" allowed_cpuset="0x00080000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -942,8 +1205,11 @@
             </object>
           </object>
           <object type="Cache" os_index="164" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" allowed_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="164" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" allowed_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="164" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" allowed_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00100000,,,0x00100000,,0x0" complete_cpuset="0x00100000,,,0x00100000,,0x0" allowed_cpuset="0x00100000,,,0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="84" cpuset="0x00100000,,0x0" complete_cpuset="0x00100000,,0x0" allowed_cpuset="0x00100000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="180" cpuset="0x00100000,,,,,0x0" complete_cpuset="0x00100000,,,,,0x0" allowed_cpuset="0x00100000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -952,8 +1218,11 @@
             </object>
           </object>
           <object type="Cache" os_index="165" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" allowed_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="165" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" allowed_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="165" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" allowed_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00200000,,,0x00200000,,0x0" complete_cpuset="0x00200000,,,0x00200000,,0x0" allowed_cpuset="0x00200000,,,0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="181" cpuset="0x00200000,,,,,0x0" complete_cpuset="0x00200000,,,,,0x0" allowed_cpuset="0x00200000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -962,8 +1231,11 @@
             </object>
           </object>
           <object type="Cache" os_index="166" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" allowed_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="166" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" allowed_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="166" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" allowed_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x00400000,,,0x00400000,,0x0" complete_cpuset="0x00400000,,,0x00400000,,0x0" allowed_cpuset="0x00400000,,,0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="182" cpuset="0x00400000,,,,,0x0" complete_cpuset="0x00400000,,,,,0x0" allowed_cpuset="0x00400000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -972,8 +1244,11 @@
             </object>
           </object>
           <object type="Cache" os_index="167" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" allowed_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="167" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" allowed_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="167" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" allowed_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x00800000,,,0x00800000,,0x0" complete_cpuset="0x00800000,,,0x00800000,,0x0" allowed_cpuset="0x00800000,,,0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="87" cpuset="0x00800000,,0x0" complete_cpuset="0x00800000,,0x0" allowed_cpuset="0x00800000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="183" cpuset="0x00800000,,,,,0x0" complete_cpuset="0x00800000,,,,,0x0" allowed_cpuset="0x00800000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -990,9 +1265,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-4620 v2 @ 2.60GHz"/>
         <info name="CPUStepping" value="4"/>
         <object type="Cache" os_index="11" cpuset="0xff000000,,,0xff000000,,0x0" complete_cpuset="0xff000000,,,0xff000000,,0x0" allowed_cpuset="0xff000000,,,0xff000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="176" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" allowed_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="176" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" allowed_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="176" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" allowed_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x01000000,,,0x01000000,,0x0" complete_cpuset="0x01000000,,,0x01000000,,0x0" allowed_cpuset="0x01000000,,,0x01000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="88" cpuset="0x01000000,,0x0" complete_cpuset="0x01000000,,0x0" allowed_cpuset="0x01000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="184" cpuset="0x01000000,,,,,0x0" complete_cpuset="0x01000000,,,,,0x0" allowed_cpuset="0x01000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -1001,8 +1280,11 @@
             </object>
           </object>
           <object type="Cache" os_index="177" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" allowed_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="177" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" allowed_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="177" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" allowed_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x02000000,,,0x02000000,,0x0" complete_cpuset="0x02000000,,,0x02000000,,0x0" allowed_cpuset="0x02000000,,,0x02000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="185" cpuset="0x02000000,,,,,0x0" complete_cpuset="0x02000000,,,,,0x0" allowed_cpuset="0x02000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -1011,8 +1293,11 @@
             </object>
           </object>
           <object type="Cache" os_index="178" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" allowed_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="178" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" allowed_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="178" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" allowed_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x04000000,,,0x04000000,,0x0" complete_cpuset="0x04000000,,,0x04000000,,0x0" allowed_cpuset="0x04000000,,,0x04000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="186" cpuset="0x04000000,,,,,0x0" complete_cpuset="0x04000000,,,,,0x0" allowed_cpuset="0x04000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -1021,8 +1306,11 @@
             </object>
           </object>
           <object type="Cache" os_index="179" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" allowed_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="179" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" allowed_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="179" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" allowed_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x08000000,,,0x08000000,,0x0" complete_cpuset="0x08000000,,,0x08000000,,0x0" allowed_cpuset="0x08000000,,,0x08000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="91" cpuset="0x08000000,,0x0" complete_cpuset="0x08000000,,0x0" allowed_cpuset="0x08000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="187" cpuset="0x08000000,,,,,0x0" complete_cpuset="0x08000000,,,,,0x0" allowed_cpuset="0x08000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -1031,8 +1319,11 @@
             </object>
           </object>
           <object type="Cache" os_index="180" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" allowed_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="180" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" allowed_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="180" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" allowed_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x10000000,,,0x10000000,,0x0" complete_cpuset="0x10000000,,,0x10000000,,0x0" allowed_cpuset="0x10000000,,,0x10000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="92" cpuset="0x10000000,,0x0" complete_cpuset="0x10000000,,0x0" allowed_cpuset="0x10000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="188" cpuset="0x10000000,,,,,0x0" complete_cpuset="0x10000000,,,,,0x0" allowed_cpuset="0x10000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -1041,8 +1332,11 @@
             </object>
           </object>
           <object type="Cache" os_index="181" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" allowed_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="181" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" allowed_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="181" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" allowed_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x20000000,,,0x20000000,,0x0" complete_cpuset="0x20000000,,,0x20000000,,0x0" allowed_cpuset="0x20000000,,,0x20000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="189" cpuset="0x20000000,,,,,0x0" complete_cpuset="0x20000000,,,,,0x0" allowed_cpuset="0x20000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -1051,8 +1345,11 @@
             </object>
           </object>
           <object type="Cache" os_index="182" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" allowed_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="182" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" allowed_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="182" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" allowed_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x40000000,,,0x40000000,,0x0" complete_cpuset="0x40000000,,,0x40000000,,0x0" allowed_cpuset="0x40000000,,,0x40000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="190" cpuset="0x40000000,,,,,0x0" complete_cpuset="0x40000000,,,,,0x0" allowed_cpuset="0x40000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -1061,8 +1358,11 @@
             </object>
           </object>
           <object type="Cache" os_index="183" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" allowed_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="183" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" allowed_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="183" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" allowed_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x80000000,,,0x80000000,,0x0" complete_cpuset="0x80000000,,,0x80000000,,0x0" allowed_cpuset="0x80000000,,,0x80000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="95" cpuset="0x80000000,,0x0" complete_cpuset="0x80000000,,0x0" allowed_cpuset="0x80000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="191" cpuset="0x80000000,,,,,0x0" complete_cpuset="0x80000000,,,,,0x0" allowed_cpuset="0x80000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>

--- a/tests/hwloc/x86/Intel-KnightsCorner-XeonPhi-SE10P.output
+++ b/tests/hwloc/x86/Intel-KnightsCorner-XeonPhi-SE10P.output
@@ -10,8 +10,11 @@
         <info name="CPUModelNumber" value="1"/>
         <info name="CPUStepping" value="3"/>
         <object type="Cache" os_index="60" cpuset="0x000e0000,,,,,,,0x00000001" complete_cpuset="0x000e0000,,,,,,,0x00000001" allowed_cpuset="0x000e0000,,,,,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="60" cpuset="0x000e0000,,,,,,,0x00000001" complete_cpuset="0x000e0000,,,,,,,0x00000001" allowed_cpuset="0x000e0000,,,,,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="60" cpuset="0x000e0000,,,,,,,0x00000001" complete_cpuset="0x000e0000,,,,,,,0x00000001" allowed_cpuset="0x000e0000,,,,,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="60" cpuset="0x000e0000,,,,,,,0x00000001" complete_cpuset="0x000e0000,,,,,,,0x00000001" allowed_cpuset="0x000e0000,,,,,,,0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="241" cpuset="0x00020000,,,,,,,0x0" complete_cpuset="0x00020000,,,,,,,0x0" allowed_cpuset="0x00020000,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -22,8 +25,11 @@
           </object>
         </object>
         <object type="Cache" os_index="0" cpuset="0x0000001e" complete_cpuset="0x0000001e" allowed_cpuset="0x0000001e" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="0" cpuset="0x0000001e" complete_cpuset="0x0000001e" allowed_cpuset="0x0000001e" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x0000001e" complete_cpuset="0x0000001e" allowed_cpuset="0x0000001e" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="0" cpuset="0x0000001e" complete_cpuset="0x0000001e" allowed_cpuset="0x0000001e" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -34,8 +40,11 @@
           </object>
         </object>
         <object type="Cache" os_index="1" cpuset="0x000001e0" complete_cpuset="0x000001e0" allowed_cpuset="0x000001e0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="1" cpuset="0x000001e0" complete_cpuset="0x000001e0" allowed_cpuset="0x000001e0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x000001e0" complete_cpuset="0x000001e0" allowed_cpuset="0x000001e0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="1" cpuset="0x000001e0" complete_cpuset="0x000001e0" allowed_cpuset="0x000001e0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -46,8 +55,11 @@
           </object>
         </object>
         <object type="Cache" os_index="2" cpuset="0x00001e00" complete_cpuset="0x00001e00" allowed_cpuset="0x00001e00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="2" cpuset="0x00001e00" complete_cpuset="0x00001e00" allowed_cpuset="0x00001e00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00001e00" complete_cpuset="0x00001e00" allowed_cpuset="0x00001e00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="2" cpuset="0x00001e00" complete_cpuset="0x00001e00" allowed_cpuset="0x00001e00" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -58,8 +70,11 @@
           </object>
         </object>
         <object type="Cache" os_index="3" cpuset="0x0001e000" complete_cpuset="0x0001e000" allowed_cpuset="0x0001e000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="3" cpuset="0x0001e000" complete_cpuset="0x0001e000" allowed_cpuset="0x0001e000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="3" cpuset="0x0001e000" complete_cpuset="0x0001e000" allowed_cpuset="0x0001e000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="3" cpuset="0x0001e000" complete_cpuset="0x0001e000" allowed_cpuset="0x0001e000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -70,8 +85,11 @@
           </object>
         </object>
         <object type="Cache" os_index="4" cpuset="0x001e0000" complete_cpuset="0x001e0000" allowed_cpuset="0x001e0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="4" cpuset="0x001e0000" complete_cpuset="0x001e0000" allowed_cpuset="0x001e0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="4" cpuset="0x001e0000" complete_cpuset="0x001e0000" allowed_cpuset="0x001e0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="4" cpuset="0x001e0000" complete_cpuset="0x001e0000" allowed_cpuset="0x001e0000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -82,8 +100,11 @@
           </object>
         </object>
         <object type="Cache" os_index="5" cpuset="0x01e00000" complete_cpuset="0x01e00000" allowed_cpuset="0x01e00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="5" cpuset="0x01e00000" complete_cpuset="0x01e00000" allowed_cpuset="0x01e00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="5" cpuset="0x01e00000" complete_cpuset="0x01e00000" allowed_cpuset="0x01e00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="5" cpuset="0x01e00000" complete_cpuset="0x01e00000" allowed_cpuset="0x01e00000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -94,8 +115,11 @@
           </object>
         </object>
         <object type="Cache" os_index="6" cpuset="0x1e000000" complete_cpuset="0x1e000000" allowed_cpuset="0x1e000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="6" cpuset="0x1e000000" complete_cpuset="0x1e000000" allowed_cpuset="0x1e000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="6" cpuset="0x1e000000" complete_cpuset="0x1e000000" allowed_cpuset="0x1e000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="6" cpuset="0x1e000000" complete_cpuset="0x1e000000" allowed_cpuset="0x1e000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -106,8 +130,11 @@
           </object>
         </object>
         <object type="Cache" os_index="7" cpuset="0x00000001,0xe0000000" complete_cpuset="0x00000001,0xe0000000" allowed_cpuset="0x00000001,0xe0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="7" cpuset="0x00000001,0xe0000000" complete_cpuset="0x00000001,0xe0000000" allowed_cpuset="0x00000001,0xe0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="7" cpuset="0x00000001,0xe0000000" complete_cpuset="0x00000001,0xe0000000" allowed_cpuset="0x00000001,0xe0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="7" cpuset="0x00000001,0xe0000000" complete_cpuset="0x00000001,0xe0000000" allowed_cpuset="0x00000001,0xe0000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -118,8 +145,11 @@
           </object>
         </object>
         <object type="Cache" os_index="8" cpuset="0x0000001e,0x0" complete_cpuset="0x0000001e,0x0" allowed_cpuset="0x0000001e,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="8" cpuset="0x0000001e,0x0" complete_cpuset="0x0000001e,0x0" allowed_cpuset="0x0000001e,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="8" cpuset="0x0000001e,0x0" complete_cpuset="0x0000001e,0x0" allowed_cpuset="0x0000001e,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="8" cpuset="0x0000001e,0x0" complete_cpuset="0x0000001e,0x0" allowed_cpuset="0x0000001e,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="33" cpuset="0x00000002,0x0" complete_cpuset="0x00000002,0x0" allowed_cpuset="0x00000002,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="34" cpuset="0x00000004,0x0" complete_cpuset="0x00000004,0x0" allowed_cpuset="0x00000004,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -130,8 +160,11 @@
           </object>
         </object>
         <object type="Cache" os_index="9" cpuset="0x000001e0,0x0" complete_cpuset="0x000001e0,0x0" allowed_cpuset="0x000001e0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="9" cpuset="0x000001e0,0x0" complete_cpuset="0x000001e0,0x0" allowed_cpuset="0x000001e0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="9" cpuset="0x000001e0,0x0" complete_cpuset="0x000001e0,0x0" allowed_cpuset="0x000001e0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="9" cpuset="0x000001e0,0x0" complete_cpuset="0x000001e0,0x0" allowed_cpuset="0x000001e0,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="37" cpuset="0x00000020,0x0" complete_cpuset="0x00000020,0x0" allowed_cpuset="0x00000020,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="38" cpuset="0x00000040,0x0" complete_cpuset="0x00000040,0x0" allowed_cpuset="0x00000040,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -142,8 +175,11 @@
           </object>
         </object>
         <object type="Cache" os_index="10" cpuset="0x00001e00,0x0" complete_cpuset="0x00001e00,0x0" allowed_cpuset="0x00001e00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="10" cpuset="0x00001e00,0x0" complete_cpuset="0x00001e00,0x0" allowed_cpuset="0x00001e00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="10" cpuset="0x00001e00,0x0" complete_cpuset="0x00001e00,0x0" allowed_cpuset="0x00001e00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="10" cpuset="0x00001e00,0x0" complete_cpuset="0x00001e00,0x0" allowed_cpuset="0x00001e00,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="41" cpuset="0x00000200,0x0" complete_cpuset="0x00000200,0x0" allowed_cpuset="0x00000200,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="42" cpuset="0x00000400,0x0" complete_cpuset="0x00000400,0x0" allowed_cpuset="0x00000400,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -154,8 +190,11 @@
           </object>
         </object>
         <object type="Cache" os_index="11" cpuset="0x0001e000,0x0" complete_cpuset="0x0001e000,0x0" allowed_cpuset="0x0001e000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="11" cpuset="0x0001e000,0x0" complete_cpuset="0x0001e000,0x0" allowed_cpuset="0x0001e000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="11" cpuset="0x0001e000,0x0" complete_cpuset="0x0001e000,0x0" allowed_cpuset="0x0001e000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="11" cpuset="0x0001e000,0x0" complete_cpuset="0x0001e000,0x0" allowed_cpuset="0x0001e000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="45" cpuset="0x00002000,0x0" complete_cpuset="0x00002000,0x0" allowed_cpuset="0x00002000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="46" cpuset="0x00004000,0x0" complete_cpuset="0x00004000,0x0" allowed_cpuset="0x00004000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -166,8 +205,11 @@
           </object>
         </object>
         <object type="Cache" os_index="12" cpuset="0x001e0000,0x0" complete_cpuset="0x001e0000,0x0" allowed_cpuset="0x001e0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="12" cpuset="0x001e0000,0x0" complete_cpuset="0x001e0000,0x0" allowed_cpuset="0x001e0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="12" cpuset="0x001e0000,0x0" complete_cpuset="0x001e0000,0x0" allowed_cpuset="0x001e0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="12" cpuset="0x001e0000,0x0" complete_cpuset="0x001e0000,0x0" allowed_cpuset="0x001e0000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="49" cpuset="0x00020000,0x0" complete_cpuset="0x00020000,0x0" allowed_cpuset="0x00020000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="50" cpuset="0x00040000,0x0" complete_cpuset="0x00040000,0x0" allowed_cpuset="0x00040000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -178,8 +220,11 @@
           </object>
         </object>
         <object type="Cache" os_index="13" cpuset="0x01e00000,0x0" complete_cpuset="0x01e00000,0x0" allowed_cpuset="0x01e00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="13" cpuset="0x01e00000,0x0" complete_cpuset="0x01e00000,0x0" allowed_cpuset="0x01e00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="13" cpuset="0x01e00000,0x0" complete_cpuset="0x01e00000,0x0" allowed_cpuset="0x01e00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="13" cpuset="0x01e00000,0x0" complete_cpuset="0x01e00000,0x0" allowed_cpuset="0x01e00000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="53" cpuset="0x00200000,0x0" complete_cpuset="0x00200000,0x0" allowed_cpuset="0x00200000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="54" cpuset="0x00400000,0x0" complete_cpuset="0x00400000,0x0" allowed_cpuset="0x00400000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -190,8 +235,11 @@
           </object>
         </object>
         <object type="Cache" os_index="14" cpuset="0x1e000000,0x0" complete_cpuset="0x1e000000,0x0" allowed_cpuset="0x1e000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="14" cpuset="0x1e000000,0x0" complete_cpuset="0x1e000000,0x0" allowed_cpuset="0x1e000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="14" cpuset="0x1e000000,0x0" complete_cpuset="0x1e000000,0x0" allowed_cpuset="0x1e000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="14" cpuset="0x1e000000,0x0" complete_cpuset="0x1e000000,0x0" allowed_cpuset="0x1e000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="57" cpuset="0x02000000,0x0" complete_cpuset="0x02000000,0x0" allowed_cpuset="0x02000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="58" cpuset="0x04000000,0x0" complete_cpuset="0x04000000,0x0" allowed_cpuset="0x04000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -202,8 +250,11 @@
           </object>
         </object>
         <object type="Cache" os_index="15" cpuset="0x00000001,0xe0000000,0x0" complete_cpuset="0x00000001,0xe0000000,0x0" allowed_cpuset="0x00000001,0xe0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="15" cpuset="0x00000001,0xe0000000,0x0" complete_cpuset="0x00000001,0xe0000000,0x0" allowed_cpuset="0x00000001,0xe0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="15" cpuset="0x00000001,0xe0000000,0x0" complete_cpuset="0x00000001,0xe0000000,0x0" allowed_cpuset="0x00000001,0xe0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="15" cpuset="0x00000001,0xe0000000,0x0" complete_cpuset="0x00000001,0xe0000000,0x0" allowed_cpuset="0x00000001,0xe0000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="61" cpuset="0x20000000,0x0" complete_cpuset="0x20000000,0x0" allowed_cpuset="0x20000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="62" cpuset="0x40000000,0x0" complete_cpuset="0x40000000,0x0" allowed_cpuset="0x40000000,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -214,8 +265,11 @@
           </object>
         </object>
         <object type="Cache" os_index="16" cpuset="0x0000001e,,0x0" complete_cpuset="0x0000001e,,0x0" allowed_cpuset="0x0000001e,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="16" cpuset="0x0000001e,,0x0" complete_cpuset="0x0000001e,,0x0" allowed_cpuset="0x0000001e,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="16" cpuset="0x0000001e,,0x0" complete_cpuset="0x0000001e,,0x0" allowed_cpuset="0x0000001e,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="16" cpuset="0x0000001e,,0x0" complete_cpuset="0x0000001e,,0x0" allowed_cpuset="0x0000001e,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="65" cpuset="0x00000002,,0x0" complete_cpuset="0x00000002,,0x0" allowed_cpuset="0x00000002,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="66" cpuset="0x00000004,,0x0" complete_cpuset="0x00000004,,0x0" allowed_cpuset="0x00000004,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -226,8 +280,11 @@
           </object>
         </object>
         <object type="Cache" os_index="17" cpuset="0x000001e0,,0x0" complete_cpuset="0x000001e0,,0x0" allowed_cpuset="0x000001e0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="17" cpuset="0x000001e0,,0x0" complete_cpuset="0x000001e0,,0x0" allowed_cpuset="0x000001e0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="17" cpuset="0x000001e0,,0x0" complete_cpuset="0x000001e0,,0x0" allowed_cpuset="0x000001e0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="17" cpuset="0x000001e0,,0x0" complete_cpuset="0x000001e0,,0x0" allowed_cpuset="0x000001e0,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="69" cpuset="0x00000020,,0x0" complete_cpuset="0x00000020,,0x0" allowed_cpuset="0x00000020,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="70" cpuset="0x00000040,,0x0" complete_cpuset="0x00000040,,0x0" allowed_cpuset="0x00000040,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -238,8 +295,11 @@
           </object>
         </object>
         <object type="Cache" os_index="18" cpuset="0x00001e00,,0x0" complete_cpuset="0x00001e00,,0x0" allowed_cpuset="0x00001e00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="18" cpuset="0x00001e00,,0x0" complete_cpuset="0x00001e00,,0x0" allowed_cpuset="0x00001e00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="18" cpuset="0x00001e00,,0x0" complete_cpuset="0x00001e00,,0x0" allowed_cpuset="0x00001e00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="18" cpuset="0x00001e00,,0x0" complete_cpuset="0x00001e00,,0x0" allowed_cpuset="0x00001e00,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="73" cpuset="0x00000200,,0x0" complete_cpuset="0x00000200,,0x0" allowed_cpuset="0x00000200,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="74" cpuset="0x00000400,,0x0" complete_cpuset="0x00000400,,0x0" allowed_cpuset="0x00000400,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -250,8 +310,11 @@
           </object>
         </object>
         <object type="Cache" os_index="19" cpuset="0x0001e000,,0x0" complete_cpuset="0x0001e000,,0x0" allowed_cpuset="0x0001e000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="19" cpuset="0x0001e000,,0x0" complete_cpuset="0x0001e000,,0x0" allowed_cpuset="0x0001e000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="19" cpuset="0x0001e000,,0x0" complete_cpuset="0x0001e000,,0x0" allowed_cpuset="0x0001e000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="19" cpuset="0x0001e000,,0x0" complete_cpuset="0x0001e000,,0x0" allowed_cpuset="0x0001e000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="77" cpuset="0x00002000,,0x0" complete_cpuset="0x00002000,,0x0" allowed_cpuset="0x00002000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="78" cpuset="0x00004000,,0x0" complete_cpuset="0x00004000,,0x0" allowed_cpuset="0x00004000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -262,8 +325,11 @@
           </object>
         </object>
         <object type="Cache" os_index="20" cpuset="0x001e0000,,0x0" complete_cpuset="0x001e0000,,0x0" allowed_cpuset="0x001e0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="20" cpuset="0x001e0000,,0x0" complete_cpuset="0x001e0000,,0x0" allowed_cpuset="0x001e0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="20" cpuset="0x001e0000,,0x0" complete_cpuset="0x001e0000,,0x0" allowed_cpuset="0x001e0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="20" cpuset="0x001e0000,,0x0" complete_cpuset="0x001e0000,,0x0" allowed_cpuset="0x001e0000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="81" cpuset="0x00020000,,0x0" complete_cpuset="0x00020000,,0x0" allowed_cpuset="0x00020000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="82" cpuset="0x00040000,,0x0" complete_cpuset="0x00040000,,0x0" allowed_cpuset="0x00040000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -274,8 +340,11 @@
           </object>
         </object>
         <object type="Cache" os_index="21" cpuset="0x01e00000,,0x0" complete_cpuset="0x01e00000,,0x0" allowed_cpuset="0x01e00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="21" cpuset="0x01e00000,,0x0" complete_cpuset="0x01e00000,,0x0" allowed_cpuset="0x01e00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="21" cpuset="0x01e00000,,0x0" complete_cpuset="0x01e00000,,0x0" allowed_cpuset="0x01e00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="21" cpuset="0x01e00000,,0x0" complete_cpuset="0x01e00000,,0x0" allowed_cpuset="0x01e00000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="85" cpuset="0x00200000,,0x0" complete_cpuset="0x00200000,,0x0" allowed_cpuset="0x00200000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="86" cpuset="0x00400000,,0x0" complete_cpuset="0x00400000,,0x0" allowed_cpuset="0x00400000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -286,8 +355,11 @@
           </object>
         </object>
         <object type="Cache" os_index="22" cpuset="0x1e000000,,0x0" complete_cpuset="0x1e000000,,0x0" allowed_cpuset="0x1e000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="22" cpuset="0x1e000000,,0x0" complete_cpuset="0x1e000000,,0x0" allowed_cpuset="0x1e000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="22" cpuset="0x1e000000,,0x0" complete_cpuset="0x1e000000,,0x0" allowed_cpuset="0x1e000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="22" cpuset="0x1e000000,,0x0" complete_cpuset="0x1e000000,,0x0" allowed_cpuset="0x1e000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="89" cpuset="0x02000000,,0x0" complete_cpuset="0x02000000,,0x0" allowed_cpuset="0x02000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="90" cpuset="0x04000000,,0x0" complete_cpuset="0x04000000,,0x0" allowed_cpuset="0x04000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -298,8 +370,11 @@
           </object>
         </object>
         <object type="Cache" os_index="23" cpuset="0x00000001,0xe0000000,,0x0" complete_cpuset="0x00000001,0xe0000000,,0x0" allowed_cpuset="0x00000001,0xe0000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="23" cpuset="0x00000001,0xe0000000,,0x0" complete_cpuset="0x00000001,0xe0000000,,0x0" allowed_cpuset="0x00000001,0xe0000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="23" cpuset="0x00000001,0xe0000000,,0x0" complete_cpuset="0x00000001,0xe0000000,,0x0" allowed_cpuset="0x00000001,0xe0000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="23" cpuset="0x00000001,0xe0000000,,0x0" complete_cpuset="0x00000001,0xe0000000,,0x0" allowed_cpuset="0x00000001,0xe0000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="93" cpuset="0x20000000,,0x0" complete_cpuset="0x20000000,,0x0" allowed_cpuset="0x20000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="94" cpuset="0x40000000,,0x0" complete_cpuset="0x40000000,,0x0" allowed_cpuset="0x40000000,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -310,8 +385,11 @@
           </object>
         </object>
         <object type="Cache" os_index="24" cpuset="0x0000001e,,,0x0" complete_cpuset="0x0000001e,,,0x0" allowed_cpuset="0x0000001e,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="24" cpuset="0x0000001e,,,0x0" complete_cpuset="0x0000001e,,,0x0" allowed_cpuset="0x0000001e,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="24" cpuset="0x0000001e,,,0x0" complete_cpuset="0x0000001e,,,0x0" allowed_cpuset="0x0000001e,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="24" cpuset="0x0000001e,,,0x0" complete_cpuset="0x0000001e,,,0x0" allowed_cpuset="0x0000001e,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="97" cpuset="0x00000002,,,0x0" complete_cpuset="0x00000002,,,0x0" allowed_cpuset="0x00000002,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="98" cpuset="0x00000004,,,0x0" complete_cpuset="0x00000004,,,0x0" allowed_cpuset="0x00000004,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -322,8 +400,11 @@
           </object>
         </object>
         <object type="Cache" os_index="25" cpuset="0x000001e0,,,0x0" complete_cpuset="0x000001e0,,,0x0" allowed_cpuset="0x000001e0,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="25" cpuset="0x000001e0,,,0x0" complete_cpuset="0x000001e0,,,0x0" allowed_cpuset="0x000001e0,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="25" cpuset="0x000001e0,,,0x0" complete_cpuset="0x000001e0,,,0x0" allowed_cpuset="0x000001e0,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="25" cpuset="0x000001e0,,,0x0" complete_cpuset="0x000001e0,,,0x0" allowed_cpuset="0x000001e0,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="101" cpuset="0x00000020,,,0x0" complete_cpuset="0x00000020,,,0x0" allowed_cpuset="0x00000020,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="102" cpuset="0x00000040,,,0x0" complete_cpuset="0x00000040,,,0x0" allowed_cpuset="0x00000040,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -334,8 +415,11 @@
           </object>
         </object>
         <object type="Cache" os_index="26" cpuset="0x00001e00,,,0x0" complete_cpuset="0x00001e00,,,0x0" allowed_cpuset="0x00001e00,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="26" cpuset="0x00001e00,,,0x0" complete_cpuset="0x00001e00,,,0x0" allowed_cpuset="0x00001e00,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="26" cpuset="0x00001e00,,,0x0" complete_cpuset="0x00001e00,,,0x0" allowed_cpuset="0x00001e00,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="26" cpuset="0x00001e00,,,0x0" complete_cpuset="0x00001e00,,,0x0" allowed_cpuset="0x00001e00,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="105" cpuset="0x00000200,,,0x0" complete_cpuset="0x00000200,,,0x0" allowed_cpuset="0x00000200,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="106" cpuset="0x00000400,,,0x0" complete_cpuset="0x00000400,,,0x0" allowed_cpuset="0x00000400,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -346,8 +430,11 @@
           </object>
         </object>
         <object type="Cache" os_index="27" cpuset="0x0001e000,,,0x0" complete_cpuset="0x0001e000,,,0x0" allowed_cpuset="0x0001e000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="27" cpuset="0x0001e000,,,0x0" complete_cpuset="0x0001e000,,,0x0" allowed_cpuset="0x0001e000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="27" cpuset="0x0001e000,,,0x0" complete_cpuset="0x0001e000,,,0x0" allowed_cpuset="0x0001e000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="27" cpuset="0x0001e000,,,0x0" complete_cpuset="0x0001e000,,,0x0" allowed_cpuset="0x0001e000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="109" cpuset="0x00002000,,,0x0" complete_cpuset="0x00002000,,,0x0" allowed_cpuset="0x00002000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="110" cpuset="0x00004000,,,0x0" complete_cpuset="0x00004000,,,0x0" allowed_cpuset="0x00004000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -358,8 +445,11 @@
           </object>
         </object>
         <object type="Cache" os_index="28" cpuset="0x001e0000,,,0x0" complete_cpuset="0x001e0000,,,0x0" allowed_cpuset="0x001e0000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="28" cpuset="0x001e0000,,,0x0" complete_cpuset="0x001e0000,,,0x0" allowed_cpuset="0x001e0000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="28" cpuset="0x001e0000,,,0x0" complete_cpuset="0x001e0000,,,0x0" allowed_cpuset="0x001e0000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="28" cpuset="0x001e0000,,,0x0" complete_cpuset="0x001e0000,,,0x0" allowed_cpuset="0x001e0000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="113" cpuset="0x00020000,,,0x0" complete_cpuset="0x00020000,,,0x0" allowed_cpuset="0x00020000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="114" cpuset="0x00040000,,,0x0" complete_cpuset="0x00040000,,,0x0" allowed_cpuset="0x00040000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -370,8 +460,11 @@
           </object>
         </object>
         <object type="Cache" os_index="29" cpuset="0x01e00000,,,0x0" complete_cpuset="0x01e00000,,,0x0" allowed_cpuset="0x01e00000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="29" cpuset="0x01e00000,,,0x0" complete_cpuset="0x01e00000,,,0x0" allowed_cpuset="0x01e00000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="29" cpuset="0x01e00000,,,0x0" complete_cpuset="0x01e00000,,,0x0" allowed_cpuset="0x01e00000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="29" cpuset="0x01e00000,,,0x0" complete_cpuset="0x01e00000,,,0x0" allowed_cpuset="0x01e00000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="117" cpuset="0x00200000,,,0x0" complete_cpuset="0x00200000,,,0x0" allowed_cpuset="0x00200000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="118" cpuset="0x00400000,,,0x0" complete_cpuset="0x00400000,,,0x0" allowed_cpuset="0x00400000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -382,8 +475,11 @@
           </object>
         </object>
         <object type="Cache" os_index="30" cpuset="0x1e000000,,,0x0" complete_cpuset="0x1e000000,,,0x0" allowed_cpuset="0x1e000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="30" cpuset="0x1e000000,,,0x0" complete_cpuset="0x1e000000,,,0x0" allowed_cpuset="0x1e000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="30" cpuset="0x1e000000,,,0x0" complete_cpuset="0x1e000000,,,0x0" allowed_cpuset="0x1e000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="30" cpuset="0x1e000000,,,0x0" complete_cpuset="0x1e000000,,,0x0" allowed_cpuset="0x1e000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="121" cpuset="0x02000000,,,0x0" complete_cpuset="0x02000000,,,0x0" allowed_cpuset="0x02000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="122" cpuset="0x04000000,,,0x0" complete_cpuset="0x04000000,,,0x0" allowed_cpuset="0x04000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -394,8 +490,11 @@
           </object>
         </object>
         <object type="Cache" os_index="31" cpuset="0x00000001,0xe0000000,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="31" cpuset="0x00000001,0xe0000000,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="31" cpuset="0x00000001,0xe0000000,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="31" cpuset="0x00000001,0xe0000000,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="125" cpuset="0x20000000,,,0x0" complete_cpuset="0x20000000,,,0x0" allowed_cpuset="0x20000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="126" cpuset="0x40000000,,,0x0" complete_cpuset="0x40000000,,,0x0" allowed_cpuset="0x40000000,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -406,8 +505,11 @@
           </object>
         </object>
         <object type="Cache" os_index="32" cpuset="0x0000001e,,,,0x0" complete_cpuset="0x0000001e,,,,0x0" allowed_cpuset="0x0000001e,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="32" cpuset="0x0000001e,,,,0x0" complete_cpuset="0x0000001e,,,,0x0" allowed_cpuset="0x0000001e,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="32" cpuset="0x0000001e,,,,0x0" complete_cpuset="0x0000001e,,,,0x0" allowed_cpuset="0x0000001e,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="32" cpuset="0x0000001e,,,,0x0" complete_cpuset="0x0000001e,,,,0x0" allowed_cpuset="0x0000001e,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="129" cpuset="0x00000002,,,,0x0" complete_cpuset="0x00000002,,,,0x0" allowed_cpuset="0x00000002,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="130" cpuset="0x00000004,,,,0x0" complete_cpuset="0x00000004,,,,0x0" allowed_cpuset="0x00000004,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -418,8 +520,11 @@
           </object>
         </object>
         <object type="Cache" os_index="33" cpuset="0x000001e0,,,,0x0" complete_cpuset="0x000001e0,,,,0x0" allowed_cpuset="0x000001e0,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="33" cpuset="0x000001e0,,,,0x0" complete_cpuset="0x000001e0,,,,0x0" allowed_cpuset="0x000001e0,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="33" cpuset="0x000001e0,,,,0x0" complete_cpuset="0x000001e0,,,,0x0" allowed_cpuset="0x000001e0,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="33" cpuset="0x000001e0,,,,0x0" complete_cpuset="0x000001e0,,,,0x0" allowed_cpuset="0x000001e0,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="133" cpuset="0x00000020,,,,0x0" complete_cpuset="0x00000020,,,,0x0" allowed_cpuset="0x00000020,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="134" cpuset="0x00000040,,,,0x0" complete_cpuset="0x00000040,,,,0x0" allowed_cpuset="0x00000040,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -430,8 +535,11 @@
           </object>
         </object>
         <object type="Cache" os_index="34" cpuset="0x00001e00,,,,0x0" complete_cpuset="0x00001e00,,,,0x0" allowed_cpuset="0x00001e00,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="34" cpuset="0x00001e00,,,,0x0" complete_cpuset="0x00001e00,,,,0x0" allowed_cpuset="0x00001e00,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="34" cpuset="0x00001e00,,,,0x0" complete_cpuset="0x00001e00,,,,0x0" allowed_cpuset="0x00001e00,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="34" cpuset="0x00001e00,,,,0x0" complete_cpuset="0x00001e00,,,,0x0" allowed_cpuset="0x00001e00,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="137" cpuset="0x00000200,,,,0x0" complete_cpuset="0x00000200,,,,0x0" allowed_cpuset="0x00000200,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="138" cpuset="0x00000400,,,,0x0" complete_cpuset="0x00000400,,,,0x0" allowed_cpuset="0x00000400,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -442,8 +550,11 @@
           </object>
         </object>
         <object type="Cache" os_index="35" cpuset="0x0001e000,,,,0x0" complete_cpuset="0x0001e000,,,,0x0" allowed_cpuset="0x0001e000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="35" cpuset="0x0001e000,,,,0x0" complete_cpuset="0x0001e000,,,,0x0" allowed_cpuset="0x0001e000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="35" cpuset="0x0001e000,,,,0x0" complete_cpuset="0x0001e000,,,,0x0" allowed_cpuset="0x0001e000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="35" cpuset="0x0001e000,,,,0x0" complete_cpuset="0x0001e000,,,,0x0" allowed_cpuset="0x0001e000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="141" cpuset="0x00002000,,,,0x0" complete_cpuset="0x00002000,,,,0x0" allowed_cpuset="0x00002000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="142" cpuset="0x00004000,,,,0x0" complete_cpuset="0x00004000,,,,0x0" allowed_cpuset="0x00004000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -454,8 +565,11 @@
           </object>
         </object>
         <object type="Cache" os_index="36" cpuset="0x001e0000,,,,0x0" complete_cpuset="0x001e0000,,,,0x0" allowed_cpuset="0x001e0000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="36" cpuset="0x001e0000,,,,0x0" complete_cpuset="0x001e0000,,,,0x0" allowed_cpuset="0x001e0000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="36" cpuset="0x001e0000,,,,0x0" complete_cpuset="0x001e0000,,,,0x0" allowed_cpuset="0x001e0000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="36" cpuset="0x001e0000,,,,0x0" complete_cpuset="0x001e0000,,,,0x0" allowed_cpuset="0x001e0000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="145" cpuset="0x00020000,,,,0x0" complete_cpuset="0x00020000,,,,0x0" allowed_cpuset="0x00020000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="146" cpuset="0x00040000,,,,0x0" complete_cpuset="0x00040000,,,,0x0" allowed_cpuset="0x00040000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -466,8 +580,11 @@
           </object>
         </object>
         <object type="Cache" os_index="37" cpuset="0x01e00000,,,,0x0" complete_cpuset="0x01e00000,,,,0x0" allowed_cpuset="0x01e00000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="37" cpuset="0x01e00000,,,,0x0" complete_cpuset="0x01e00000,,,,0x0" allowed_cpuset="0x01e00000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="37" cpuset="0x01e00000,,,,0x0" complete_cpuset="0x01e00000,,,,0x0" allowed_cpuset="0x01e00000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="37" cpuset="0x01e00000,,,,0x0" complete_cpuset="0x01e00000,,,,0x0" allowed_cpuset="0x01e00000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="149" cpuset="0x00200000,,,,0x0" complete_cpuset="0x00200000,,,,0x0" allowed_cpuset="0x00200000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="150" cpuset="0x00400000,,,,0x0" complete_cpuset="0x00400000,,,,0x0" allowed_cpuset="0x00400000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -478,8 +595,11 @@
           </object>
         </object>
         <object type="Cache" os_index="38" cpuset="0x1e000000,,,,0x0" complete_cpuset="0x1e000000,,,,0x0" allowed_cpuset="0x1e000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="38" cpuset="0x1e000000,,,,0x0" complete_cpuset="0x1e000000,,,,0x0" allowed_cpuset="0x1e000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="38" cpuset="0x1e000000,,,,0x0" complete_cpuset="0x1e000000,,,,0x0" allowed_cpuset="0x1e000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="38" cpuset="0x1e000000,,,,0x0" complete_cpuset="0x1e000000,,,,0x0" allowed_cpuset="0x1e000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="153" cpuset="0x02000000,,,,0x0" complete_cpuset="0x02000000,,,,0x0" allowed_cpuset="0x02000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="154" cpuset="0x04000000,,,,0x0" complete_cpuset="0x04000000,,,,0x0" allowed_cpuset="0x04000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -490,8 +610,11 @@
           </object>
         </object>
         <object type="Cache" os_index="39" cpuset="0x00000001,0xe0000000,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="39" cpuset="0x00000001,0xe0000000,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="39" cpuset="0x00000001,0xe0000000,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="39" cpuset="0x00000001,0xe0000000,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="157" cpuset="0x20000000,,,,0x0" complete_cpuset="0x20000000,,,,0x0" allowed_cpuset="0x20000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="158" cpuset="0x40000000,,,,0x0" complete_cpuset="0x40000000,,,,0x0" allowed_cpuset="0x40000000,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -502,8 +625,11 @@
           </object>
         </object>
         <object type="Cache" os_index="40" cpuset="0x0000001e,,,,,0x0" complete_cpuset="0x0000001e,,,,,0x0" allowed_cpuset="0x0000001e,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="40" cpuset="0x0000001e,,,,,0x0" complete_cpuset="0x0000001e,,,,,0x0" allowed_cpuset="0x0000001e,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="40" cpuset="0x0000001e,,,,,0x0" complete_cpuset="0x0000001e,,,,,0x0" allowed_cpuset="0x0000001e,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="40" cpuset="0x0000001e,,,,,0x0" complete_cpuset="0x0000001e,,,,,0x0" allowed_cpuset="0x0000001e,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="161" cpuset="0x00000002,,,,,0x0" complete_cpuset="0x00000002,,,,,0x0" allowed_cpuset="0x00000002,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="162" cpuset="0x00000004,,,,,0x0" complete_cpuset="0x00000004,,,,,0x0" allowed_cpuset="0x00000004,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -514,8 +640,11 @@
           </object>
         </object>
         <object type="Cache" os_index="41" cpuset="0x000001e0,,,,,0x0" complete_cpuset="0x000001e0,,,,,0x0" allowed_cpuset="0x000001e0,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="41" cpuset="0x000001e0,,,,,0x0" complete_cpuset="0x000001e0,,,,,0x0" allowed_cpuset="0x000001e0,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="41" cpuset="0x000001e0,,,,,0x0" complete_cpuset="0x000001e0,,,,,0x0" allowed_cpuset="0x000001e0,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="41" cpuset="0x000001e0,,,,,0x0" complete_cpuset="0x000001e0,,,,,0x0" allowed_cpuset="0x000001e0,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="165" cpuset="0x00000020,,,,,0x0" complete_cpuset="0x00000020,,,,,0x0" allowed_cpuset="0x00000020,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="166" cpuset="0x00000040,,,,,0x0" complete_cpuset="0x00000040,,,,,0x0" allowed_cpuset="0x00000040,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -526,8 +655,11 @@
           </object>
         </object>
         <object type="Cache" os_index="42" cpuset="0x00001e00,,,,,0x0" complete_cpuset="0x00001e00,,,,,0x0" allowed_cpuset="0x00001e00,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="42" cpuset="0x00001e00,,,,,0x0" complete_cpuset="0x00001e00,,,,,0x0" allowed_cpuset="0x00001e00,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="42" cpuset="0x00001e00,,,,,0x0" complete_cpuset="0x00001e00,,,,,0x0" allowed_cpuset="0x00001e00,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="42" cpuset="0x00001e00,,,,,0x0" complete_cpuset="0x00001e00,,,,,0x0" allowed_cpuset="0x00001e00,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="169" cpuset="0x00000200,,,,,0x0" complete_cpuset="0x00000200,,,,,0x0" allowed_cpuset="0x00000200,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="170" cpuset="0x00000400,,,,,0x0" complete_cpuset="0x00000400,,,,,0x0" allowed_cpuset="0x00000400,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -538,8 +670,11 @@
           </object>
         </object>
         <object type="Cache" os_index="43" cpuset="0x0001e000,,,,,0x0" complete_cpuset="0x0001e000,,,,,0x0" allowed_cpuset="0x0001e000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="43" cpuset="0x0001e000,,,,,0x0" complete_cpuset="0x0001e000,,,,,0x0" allowed_cpuset="0x0001e000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="43" cpuset="0x0001e000,,,,,0x0" complete_cpuset="0x0001e000,,,,,0x0" allowed_cpuset="0x0001e000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="43" cpuset="0x0001e000,,,,,0x0" complete_cpuset="0x0001e000,,,,,0x0" allowed_cpuset="0x0001e000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="173" cpuset="0x00002000,,,,,0x0" complete_cpuset="0x00002000,,,,,0x0" allowed_cpuset="0x00002000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="174" cpuset="0x00004000,,,,,0x0" complete_cpuset="0x00004000,,,,,0x0" allowed_cpuset="0x00004000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -550,8 +685,11 @@
           </object>
         </object>
         <object type="Cache" os_index="44" cpuset="0x001e0000,,,,,0x0" complete_cpuset="0x001e0000,,,,,0x0" allowed_cpuset="0x001e0000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="44" cpuset="0x001e0000,,,,,0x0" complete_cpuset="0x001e0000,,,,,0x0" allowed_cpuset="0x001e0000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="44" cpuset="0x001e0000,,,,,0x0" complete_cpuset="0x001e0000,,,,,0x0" allowed_cpuset="0x001e0000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="44" cpuset="0x001e0000,,,,,0x0" complete_cpuset="0x001e0000,,,,,0x0" allowed_cpuset="0x001e0000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="177" cpuset="0x00020000,,,,,0x0" complete_cpuset="0x00020000,,,,,0x0" allowed_cpuset="0x00020000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="178" cpuset="0x00040000,,,,,0x0" complete_cpuset="0x00040000,,,,,0x0" allowed_cpuset="0x00040000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -562,8 +700,11 @@
           </object>
         </object>
         <object type="Cache" os_index="45" cpuset="0x01e00000,,,,,0x0" complete_cpuset="0x01e00000,,,,,0x0" allowed_cpuset="0x01e00000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="45" cpuset="0x01e00000,,,,,0x0" complete_cpuset="0x01e00000,,,,,0x0" allowed_cpuset="0x01e00000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="45" cpuset="0x01e00000,,,,,0x0" complete_cpuset="0x01e00000,,,,,0x0" allowed_cpuset="0x01e00000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="45" cpuset="0x01e00000,,,,,0x0" complete_cpuset="0x01e00000,,,,,0x0" allowed_cpuset="0x01e00000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="181" cpuset="0x00200000,,,,,0x0" complete_cpuset="0x00200000,,,,,0x0" allowed_cpuset="0x00200000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="182" cpuset="0x00400000,,,,,0x0" complete_cpuset="0x00400000,,,,,0x0" allowed_cpuset="0x00400000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -574,8 +715,11 @@
           </object>
         </object>
         <object type="Cache" os_index="46" cpuset="0x1e000000,,,,,0x0" complete_cpuset="0x1e000000,,,,,0x0" allowed_cpuset="0x1e000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="46" cpuset="0x1e000000,,,,,0x0" complete_cpuset="0x1e000000,,,,,0x0" allowed_cpuset="0x1e000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="46" cpuset="0x1e000000,,,,,0x0" complete_cpuset="0x1e000000,,,,,0x0" allowed_cpuset="0x1e000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="46" cpuset="0x1e000000,,,,,0x0" complete_cpuset="0x1e000000,,,,,0x0" allowed_cpuset="0x1e000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="185" cpuset="0x02000000,,,,,0x0" complete_cpuset="0x02000000,,,,,0x0" allowed_cpuset="0x02000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="186" cpuset="0x04000000,,,,,0x0" complete_cpuset="0x04000000,,,,,0x0" allowed_cpuset="0x04000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -586,8 +730,11 @@
           </object>
         </object>
         <object type="Cache" os_index="47" cpuset="0x00000001,0xe0000000,,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="47" cpuset="0x00000001,0xe0000000,,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="47" cpuset="0x00000001,0xe0000000,,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="47" cpuset="0x00000001,0xe0000000,,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="189" cpuset="0x20000000,,,,,0x0" complete_cpuset="0x20000000,,,,,0x0" allowed_cpuset="0x20000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="190" cpuset="0x40000000,,,,,0x0" complete_cpuset="0x40000000,,,,,0x0" allowed_cpuset="0x40000000,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -598,8 +745,11 @@
           </object>
         </object>
         <object type="Cache" os_index="48" cpuset="0x0000001e,,,,,,0x0" complete_cpuset="0x0000001e,,,,,,0x0" allowed_cpuset="0x0000001e,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="48" cpuset="0x0000001e,,,,,,0x0" complete_cpuset="0x0000001e,,,,,,0x0" allowed_cpuset="0x0000001e,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="48" cpuset="0x0000001e,,,,,,0x0" complete_cpuset="0x0000001e,,,,,,0x0" allowed_cpuset="0x0000001e,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="48" cpuset="0x0000001e,,,,,,0x0" complete_cpuset="0x0000001e,,,,,,0x0" allowed_cpuset="0x0000001e,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="193" cpuset="0x00000002,,,,,,0x0" complete_cpuset="0x00000002,,,,,,0x0" allowed_cpuset="0x00000002,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="194" cpuset="0x00000004,,,,,,0x0" complete_cpuset="0x00000004,,,,,,0x0" allowed_cpuset="0x00000004,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -610,8 +760,11 @@
           </object>
         </object>
         <object type="Cache" os_index="49" cpuset="0x000001e0,,,,,,0x0" complete_cpuset="0x000001e0,,,,,,0x0" allowed_cpuset="0x000001e0,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="49" cpuset="0x000001e0,,,,,,0x0" complete_cpuset="0x000001e0,,,,,,0x0" allowed_cpuset="0x000001e0,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="49" cpuset="0x000001e0,,,,,,0x0" complete_cpuset="0x000001e0,,,,,,0x0" allowed_cpuset="0x000001e0,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="49" cpuset="0x000001e0,,,,,,0x0" complete_cpuset="0x000001e0,,,,,,0x0" allowed_cpuset="0x000001e0,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="197" cpuset="0x00000020,,,,,,0x0" complete_cpuset="0x00000020,,,,,,0x0" allowed_cpuset="0x00000020,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="198" cpuset="0x00000040,,,,,,0x0" complete_cpuset="0x00000040,,,,,,0x0" allowed_cpuset="0x00000040,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -622,8 +775,11 @@
           </object>
         </object>
         <object type="Cache" os_index="50" cpuset="0x00001e00,,,,,,0x0" complete_cpuset="0x00001e00,,,,,,0x0" allowed_cpuset="0x00001e00,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="50" cpuset="0x00001e00,,,,,,0x0" complete_cpuset="0x00001e00,,,,,,0x0" allowed_cpuset="0x00001e00,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="50" cpuset="0x00001e00,,,,,,0x0" complete_cpuset="0x00001e00,,,,,,0x0" allowed_cpuset="0x00001e00,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="50" cpuset="0x00001e00,,,,,,0x0" complete_cpuset="0x00001e00,,,,,,0x0" allowed_cpuset="0x00001e00,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="201" cpuset="0x00000200,,,,,,0x0" complete_cpuset="0x00000200,,,,,,0x0" allowed_cpuset="0x00000200,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="202" cpuset="0x00000400,,,,,,0x0" complete_cpuset="0x00000400,,,,,,0x0" allowed_cpuset="0x00000400,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -634,8 +790,11 @@
           </object>
         </object>
         <object type="Cache" os_index="51" cpuset="0x0001e000,,,,,,0x0" complete_cpuset="0x0001e000,,,,,,0x0" allowed_cpuset="0x0001e000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="51" cpuset="0x0001e000,,,,,,0x0" complete_cpuset="0x0001e000,,,,,,0x0" allowed_cpuset="0x0001e000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="51" cpuset="0x0001e000,,,,,,0x0" complete_cpuset="0x0001e000,,,,,,0x0" allowed_cpuset="0x0001e000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="51" cpuset="0x0001e000,,,,,,0x0" complete_cpuset="0x0001e000,,,,,,0x0" allowed_cpuset="0x0001e000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="205" cpuset="0x00002000,,,,,,0x0" complete_cpuset="0x00002000,,,,,,0x0" allowed_cpuset="0x00002000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="206" cpuset="0x00004000,,,,,,0x0" complete_cpuset="0x00004000,,,,,,0x0" allowed_cpuset="0x00004000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -646,8 +805,11 @@
           </object>
         </object>
         <object type="Cache" os_index="52" cpuset="0x001e0000,,,,,,0x0" complete_cpuset="0x001e0000,,,,,,0x0" allowed_cpuset="0x001e0000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="52" cpuset="0x001e0000,,,,,,0x0" complete_cpuset="0x001e0000,,,,,,0x0" allowed_cpuset="0x001e0000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="52" cpuset="0x001e0000,,,,,,0x0" complete_cpuset="0x001e0000,,,,,,0x0" allowed_cpuset="0x001e0000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="52" cpuset="0x001e0000,,,,,,0x0" complete_cpuset="0x001e0000,,,,,,0x0" allowed_cpuset="0x001e0000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="209" cpuset="0x00020000,,,,,,0x0" complete_cpuset="0x00020000,,,,,,0x0" allowed_cpuset="0x00020000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="210" cpuset="0x00040000,,,,,,0x0" complete_cpuset="0x00040000,,,,,,0x0" allowed_cpuset="0x00040000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -658,8 +820,11 @@
           </object>
         </object>
         <object type="Cache" os_index="53" cpuset="0x01e00000,,,,,,0x0" complete_cpuset="0x01e00000,,,,,,0x0" allowed_cpuset="0x01e00000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="53" cpuset="0x01e00000,,,,,,0x0" complete_cpuset="0x01e00000,,,,,,0x0" allowed_cpuset="0x01e00000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="53" cpuset="0x01e00000,,,,,,0x0" complete_cpuset="0x01e00000,,,,,,0x0" allowed_cpuset="0x01e00000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="53" cpuset="0x01e00000,,,,,,0x0" complete_cpuset="0x01e00000,,,,,,0x0" allowed_cpuset="0x01e00000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="213" cpuset="0x00200000,,,,,,0x0" complete_cpuset="0x00200000,,,,,,0x0" allowed_cpuset="0x00200000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="214" cpuset="0x00400000,,,,,,0x0" complete_cpuset="0x00400000,,,,,,0x0" allowed_cpuset="0x00400000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -670,8 +835,11 @@
           </object>
         </object>
         <object type="Cache" os_index="54" cpuset="0x1e000000,,,,,,0x0" complete_cpuset="0x1e000000,,,,,,0x0" allowed_cpuset="0x1e000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="54" cpuset="0x1e000000,,,,,,0x0" complete_cpuset="0x1e000000,,,,,,0x0" allowed_cpuset="0x1e000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="54" cpuset="0x1e000000,,,,,,0x0" complete_cpuset="0x1e000000,,,,,,0x0" allowed_cpuset="0x1e000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="54" cpuset="0x1e000000,,,,,,0x0" complete_cpuset="0x1e000000,,,,,,0x0" allowed_cpuset="0x1e000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="217" cpuset="0x02000000,,,,,,0x0" complete_cpuset="0x02000000,,,,,,0x0" allowed_cpuset="0x02000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="218" cpuset="0x04000000,,,,,,0x0" complete_cpuset="0x04000000,,,,,,0x0" allowed_cpuset="0x04000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -682,8 +850,11 @@
           </object>
         </object>
         <object type="Cache" os_index="55" cpuset="0x00000001,0xe0000000,,,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="55" cpuset="0x00000001,0xe0000000,,,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="55" cpuset="0x00000001,0xe0000000,,,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="55" cpuset="0x00000001,0xe0000000,,,,,,0x0" complete_cpuset="0x00000001,0xe0000000,,,,,,0x0" allowed_cpuset="0x00000001,0xe0000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="221" cpuset="0x20000000,,,,,,0x0" complete_cpuset="0x20000000,,,,,,0x0" allowed_cpuset="0x20000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="222" cpuset="0x40000000,,,,,,0x0" complete_cpuset="0x40000000,,,,,,0x0" allowed_cpuset="0x40000000,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -694,8 +865,11 @@
           </object>
         </object>
         <object type="Cache" os_index="56" cpuset="0x0000001e,,,,,,,0x0" complete_cpuset="0x0000001e,,,,,,,0x0" allowed_cpuset="0x0000001e,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="56" cpuset="0x0000001e,,,,,,,0x0" complete_cpuset="0x0000001e,,,,,,,0x0" allowed_cpuset="0x0000001e,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="56" cpuset="0x0000001e,,,,,,,0x0" complete_cpuset="0x0000001e,,,,,,,0x0" allowed_cpuset="0x0000001e,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="56" cpuset="0x0000001e,,,,,,,0x0" complete_cpuset="0x0000001e,,,,,,,0x0" allowed_cpuset="0x0000001e,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="225" cpuset="0x00000002,,,,,,,0x0" complete_cpuset="0x00000002,,,,,,,0x0" allowed_cpuset="0x00000002,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="226" cpuset="0x00000004,,,,,,,0x0" complete_cpuset="0x00000004,,,,,,,0x0" allowed_cpuset="0x00000004,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -706,8 +880,11 @@
           </object>
         </object>
         <object type="Cache" os_index="57" cpuset="0x000001e0,,,,,,,0x0" complete_cpuset="0x000001e0,,,,,,,0x0" allowed_cpuset="0x000001e0,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="57" cpuset="0x000001e0,,,,,,,0x0" complete_cpuset="0x000001e0,,,,,,,0x0" allowed_cpuset="0x000001e0,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="57" cpuset="0x000001e0,,,,,,,0x0" complete_cpuset="0x000001e0,,,,,,,0x0" allowed_cpuset="0x000001e0,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="57" cpuset="0x000001e0,,,,,,,0x0" complete_cpuset="0x000001e0,,,,,,,0x0" allowed_cpuset="0x000001e0,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="229" cpuset="0x00000020,,,,,,,0x0" complete_cpuset="0x00000020,,,,,,,0x0" allowed_cpuset="0x00000020,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="230" cpuset="0x00000040,,,,,,,0x0" complete_cpuset="0x00000040,,,,,,,0x0" allowed_cpuset="0x00000040,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -718,8 +895,11 @@
           </object>
         </object>
         <object type="Cache" os_index="58" cpuset="0x00001e00,,,,,,,0x0" complete_cpuset="0x00001e00,,,,,,,0x0" allowed_cpuset="0x00001e00,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="58" cpuset="0x00001e00,,,,,,,0x0" complete_cpuset="0x00001e00,,,,,,,0x0" allowed_cpuset="0x00001e00,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="58" cpuset="0x00001e00,,,,,,,0x0" complete_cpuset="0x00001e00,,,,,,,0x0" allowed_cpuset="0x00001e00,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="58" cpuset="0x00001e00,,,,,,,0x0" complete_cpuset="0x00001e00,,,,,,,0x0" allowed_cpuset="0x00001e00,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="233" cpuset="0x00000200,,,,,,,0x0" complete_cpuset="0x00000200,,,,,,,0x0" allowed_cpuset="0x00000200,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="234" cpuset="0x00000400,,,,,,,0x0" complete_cpuset="0x00000400,,,,,,,0x0" allowed_cpuset="0x00000400,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -730,8 +910,11 @@
           </object>
         </object>
         <object type="Cache" os_index="59" cpuset="0x0001e000,,,,,,,0x0" complete_cpuset="0x0001e000,,,,,,,0x0" allowed_cpuset="0x0001e000,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="1">
+          <info name="inclusiveness" value="false"/>
           <object type="Cache" os_index="59" cpuset="0x0001e000,,,,,,,0x0" complete_cpuset="0x0001e000,,,,,,,0x0" allowed_cpuset="0x0001e000,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="59" cpuset="0x0001e000,,,,,,,0x0" complete_cpuset="0x0001e000,,,,,,,0x0" allowed_cpuset="0x0001e000,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+              <info name="inclusiveness" value="false"/>
               <object type="Core" os_index="59" cpuset="0x0001e000,,,,,,,0x0" complete_cpuset="0x0001e000,,,,,,,0x0" allowed_cpuset="0x0001e000,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                 <object type="PU" os_index="237" cpuset="0x00002000,,,,,,,0x0" complete_cpuset="0x00002000,,,,,,,0x0" allowed_cpuset="0x00002000,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 <object type="PU" os_index="238" cpuset="0x00004000,,,,,,,0x0" complete_cpuset="0x00004000,,,,,,,0x0" allowed_cpuset="0x00004000,,,,,,,0x0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>

--- a/tests/hwloc/x86/Intel-Nehalem-2xXeon-X5550.output
+++ b/tests/hwloc/x86/Intel-Nehalem-2xXeon-X5550.output
@@ -11,9 +11,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           X5550  @ 2.67GHz"/>
         <info name="CPUStepping" value="5"/>
         <object type="Cache" os_index="0" cpuset="0x00000f0f" complete_cpuset="0x00000f0f" allowed_cpuset="0x00000f0f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00000101" complete_cpuset="0x00000101" allowed_cpuset="0x00000101" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00000101" complete_cpuset="0x00000101" allowed_cpuset="0x00000101" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="0" cpuset="0x00000101" complete_cpuset="0x00000101" allowed_cpuset="0x00000101" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000101" complete_cpuset="0x00000101" allowed_cpuset="0x00000101" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -22,8 +26,11 @@
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x00000202" complete_cpuset="0x00000202" allowed_cpuset="0x00000202" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x00000202" complete_cpuset="0x00000202" allowed_cpuset="0x00000202" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="1" cpuset="0x00000202" complete_cpuset="0x00000202" allowed_cpuset="0x00000202" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000202" complete_cpuset="0x00000202" allowed_cpuset="0x00000202" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -32,8 +39,11 @@
             </object>
           </object>
           <object type="Cache" os_index="2" cpuset="0x00000404" complete_cpuset="0x00000404" allowed_cpuset="0x00000404" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00000404" complete_cpuset="0x00000404" allowed_cpuset="0x00000404" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="2" cpuset="0x00000404" complete_cpuset="0x00000404" allowed_cpuset="0x00000404" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000404" complete_cpuset="0x00000404" allowed_cpuset="0x00000404" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -42,8 +52,11 @@
             </object>
           </object>
           <object type="Cache" os_index="3" cpuset="0x00000808" complete_cpuset="0x00000808" allowed_cpuset="0x00000808" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="3" cpuset="0x00000808" complete_cpuset="0x00000808" allowed_cpuset="0x00000808" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="3" cpuset="0x00000808" complete_cpuset="0x00000808" allowed_cpuset="0x00000808" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00000808" complete_cpuset="0x00000808" allowed_cpuset="0x00000808" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -60,9 +73,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           X5550  @ 2.67GHz"/>
         <info name="CPUStepping" value="5"/>
         <object type="Cache" os_index="1" cpuset="0x0000f0f0" complete_cpuset="0x0000f0f0" allowed_cpuset="0x0000f0f0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="8" cpuset="0x00001010" complete_cpuset="0x00001010" allowed_cpuset="0x00001010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="8" cpuset="0x00001010" complete_cpuset="0x00001010" allowed_cpuset="0x00001010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="8" cpuset="0x00001010" complete_cpuset="0x00001010" allowed_cpuset="0x00001010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00001010" complete_cpuset="0x00001010" allowed_cpuset="0x00001010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -71,8 +88,11 @@
             </object>
           </object>
           <object type="Cache" os_index="9" cpuset="0x00002020" complete_cpuset="0x00002020" allowed_cpuset="0x00002020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="9" cpuset="0x00002020" complete_cpuset="0x00002020" allowed_cpuset="0x00002020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="9" cpuset="0x00002020" complete_cpuset="0x00002020" allowed_cpuset="0x00002020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00002020" complete_cpuset="0x00002020" allowed_cpuset="0x00002020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -81,8 +101,11 @@
             </object>
           </object>
           <object type="Cache" os_index="10" cpuset="0x00004040" complete_cpuset="0x00004040" allowed_cpuset="0x00004040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="10" cpuset="0x00004040" complete_cpuset="0x00004040" allowed_cpuset="0x00004040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="10" cpuset="0x00004040" complete_cpuset="0x00004040" allowed_cpuset="0x00004040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00004040" complete_cpuset="0x00004040" allowed_cpuset="0x00004040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -91,8 +114,11 @@
             </object>
           </object>
           <object type="Cache" os_index="11" cpuset="0x00008080" complete_cpuset="0x00008080" allowed_cpuset="0x00008080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="11" cpuset="0x00008080" complete_cpuset="0x00008080" allowed_cpuset="0x00008080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="11" cpuset="0x00008080" complete_cpuset="0x00008080" allowed_cpuset="0x00008080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00008080" complete_cpuset="0x00008080" allowed_cpuset="0x00008080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>

--- a/tests/hwloc/x86/Intel-Penryn-4xXeon-X7460.output
+++ b/tests/hwloc/x86/Intel-Penryn-4xXeon-X7460.output
@@ -11,16 +11,22 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           X7460  @ 2.66GHz"/>
         <info name="CPUStepping" value="1"/>
         <object type="Cache" os_index="1" cpuset="0x00111111" complete_cpuset="0x00111111" allowed_cpuset="0x00111111" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="4" cpuset="0x00000011" complete_cpuset="0x00000011" allowed_cpuset="0x00000011" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="8" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="8" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="9" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="9" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -28,15 +34,20 @@
             </object>
           </object>
           <object type="Cache" os_index="5" cpuset="0x00001100" complete_cpuset="0x00001100" allowed_cpuset="0x00001100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="10" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="10" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="11" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="11" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -44,15 +55,20 @@
             </object>
           </object>
           <object type="Cache" os_index="6" cpuset="0x00110000" complete_cpuset="0x00110000" allowed_cpuset="0x00110000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="12" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="12" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="13" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="13" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -68,16 +84,22 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           X7460  @ 2.66GHz"/>
         <info name="CPUStepping" value="1"/>
         <object type="Cache" os_index="0" cpuset="0x00222222" complete_cpuset="0x00222222" allowed_cpuset="0x00222222" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00000022" complete_cpuset="0x00000022" allowed_cpuset="0x00000022" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="0" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="1" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="1" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -85,15 +107,20 @@
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x00002200" complete_cpuset="0x00002200" allowed_cpuset="0x00002200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="2" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="3" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="3" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -101,15 +128,20 @@
             </object>
           </object>
           <object type="Cache" os_index="2" cpuset="0x00220000" complete_cpuset="0x00220000" allowed_cpuset="0x00220000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="4" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="4" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="5" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="5" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -125,16 +157,22 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           X7460  @ 2.66GHz"/>
         <info name="CPUStepping" value="1"/>
         <object type="Cache" os_index="2" cpuset="0x00444444" complete_cpuset="0x00444444" allowed_cpuset="0x00444444" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="8" cpuset="0x00000044" complete_cpuset="0x00000044" allowed_cpuset="0x00000044" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="16" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="16" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="17" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="17" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -142,15 +180,20 @@
             </object>
           </object>
           <object type="Cache" os_index="9" cpuset="0x00004400" complete_cpuset="0x00004400" allowed_cpuset="0x00004400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="18" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="18" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="19" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="19" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -158,15 +201,20 @@
             </object>
           </object>
           <object type="Cache" os_index="10" cpuset="0x00440000" complete_cpuset="0x00440000" allowed_cpuset="0x00440000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="20" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="20" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="21" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="21" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -182,16 +230,22 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           X7460  @ 2.66GHz"/>
         <info name="CPUStepping" value="1"/>
         <object type="Cache" os_index="3" cpuset="0x00888888" complete_cpuset="0x00888888" allowed_cpuset="0x00888888" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="16777216" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="12" cpuset="0x00000088" complete_cpuset="0x00000088" allowed_cpuset="0x00000088" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="24" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="24" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="25" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="25" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -199,15 +253,20 @@
             </object>
           </object>
           <object type="Cache" os_index="13" cpuset="0x00008800" complete_cpuset="0x00008800" allowed_cpuset="0x00008800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="26" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="26" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="27" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="27" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
@@ -215,15 +274,20 @@
             </object>
           </object>
           <object type="Cache" os_index="14" cpuset="0x00880000" complete_cpuset="0x00880000" allowed_cpuset="0x00880000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="3145728" depth="2" cache_linesize="64" cache_associativity="12" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="28" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="28" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>
               </object>
             </object>
             <object type="Cache" os_index="29" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="29" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                 </object>

--- a/tests/hwloc/x86/Intel-SandyBridge-2xXeon-E5-2650.output
+++ b/tests/hwloc/x86/Intel-SandyBridge-2xXeon-E5-2650.output
@@ -11,9 +11,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2650 0 @ 2.00GHz"/>
         <info name="CPUStepping" value="7"/>
         <object type="Cache" os_index="0" cpuset="0x55555555" complete_cpuset="0x55555555" allowed_cpuset="0x55555555" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00010001" complete_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00010001" complete_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="0" cpuset="0x00010001" complete_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00010001" complete_cpuset="0x00010001" allowed_cpuset="0x00010001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -22,8 +26,11 @@
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x00040004" complete_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x00040004" complete_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="1" cpuset="0x00040004" complete_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00040004" complete_cpuset="0x00040004" allowed_cpuset="0x00040004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -32,8 +39,11 @@
             </object>
           </object>
           <object type="Cache" os_index="2" cpuset="0x00100010" complete_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00100010" complete_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="2" cpuset="0x00100010" complete_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00100010" complete_cpuset="0x00100010" allowed_cpuset="0x00100010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -42,8 +52,11 @@
             </object>
           </object>
           <object type="Cache" os_index="3" cpuset="0x00400040" complete_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="3" cpuset="0x00400040" complete_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="3" cpuset="0x00400040" complete_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00400040" complete_cpuset="0x00400040" allowed_cpuset="0x00400040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -52,8 +65,11 @@
             </object>
           </object>
           <object type="Cache" os_index="4" cpuset="0x01000100" complete_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="4" cpuset="0x01000100" complete_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="4" cpuset="0x01000100" complete_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x01000100" complete_cpuset="0x01000100" allowed_cpuset="0x01000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="24" cpuset="0x01000000" complete_cpuset="0x01000000" allowed_cpuset="0x01000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -62,8 +78,11 @@
             </object>
           </object>
           <object type="Cache" os_index="5" cpuset="0x04000400" complete_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="5" cpuset="0x04000400" complete_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="5" cpuset="0x04000400" complete_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x04000400" complete_cpuset="0x04000400" allowed_cpuset="0x04000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="26" cpuset="0x04000000" complete_cpuset="0x04000000" allowed_cpuset="0x04000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -72,8 +91,11 @@
             </object>
           </object>
           <object type="Cache" os_index="6" cpuset="0x10001000" complete_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="6" cpuset="0x10001000" complete_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="6" cpuset="0x10001000" complete_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x10001000" complete_cpuset="0x10001000" allowed_cpuset="0x10001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="28" cpuset="0x10000000" complete_cpuset="0x10000000" allowed_cpuset="0x10000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -82,8 +104,11 @@
             </object>
           </object>
           <object type="Cache" os_index="7" cpuset="0x40004000" complete_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="7" cpuset="0x40004000" complete_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="7" cpuset="0x40004000" complete_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x40004000" complete_cpuset="0x40004000" allowed_cpuset="0x40004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="30" cpuset="0x40000000" complete_cpuset="0x40000000" allowed_cpuset="0x40000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -100,9 +125,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU E5-2650 0 @ 2.00GHz"/>
         <info name="CPUStepping" value="7"/>
         <object type="Cache" os_index="1" cpuset="0xaaaaaaaa" complete_cpuset="0xaaaaaaaa" allowed_cpuset="0xaaaaaaaa" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="20971520" depth="3" cache_linesize="64" cache_associativity="20" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="16" cpuset="0x00020002" complete_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="16" cpuset="0x00020002" complete_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="16" cpuset="0x00020002" complete_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00020002" complete_cpuset="0x00020002" allowed_cpuset="0x00020002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -111,8 +140,11 @@
             </object>
           </object>
           <object type="Cache" os_index="17" cpuset="0x00080008" complete_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="17" cpuset="0x00080008" complete_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="17" cpuset="0x00080008" complete_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00080008" complete_cpuset="0x00080008" allowed_cpuset="0x00080008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -121,8 +153,11 @@
             </object>
           </object>
           <object type="Cache" os_index="18" cpuset="0x00200020" complete_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="18" cpuset="0x00200020" complete_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="18" cpuset="0x00200020" complete_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00200020" complete_cpuset="0x00200020" allowed_cpuset="0x00200020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -131,8 +166,11 @@
             </object>
           </object>
           <object type="Cache" os_index="19" cpuset="0x00800080" complete_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="19" cpuset="0x00800080" complete_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="19" cpuset="0x00800080" complete_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="3" cpuset="0x00800080" complete_cpuset="0x00800080" allowed_cpuset="0x00800080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -141,8 +179,11 @@
             </object>
           </object>
           <object type="Cache" os_index="20" cpuset="0x02000200" complete_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="20" cpuset="0x02000200" complete_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="20" cpuset="0x02000200" complete_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="4" cpuset="0x02000200" complete_cpuset="0x02000200" allowed_cpuset="0x02000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="25" cpuset="0x02000000" complete_cpuset="0x02000000" allowed_cpuset="0x02000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -151,8 +192,11 @@
             </object>
           </object>
           <object type="Cache" os_index="21" cpuset="0x08000800" complete_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="21" cpuset="0x08000800" complete_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="21" cpuset="0x08000800" complete_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="5" cpuset="0x08000800" complete_cpuset="0x08000800" allowed_cpuset="0x08000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="27" cpuset="0x08000000" complete_cpuset="0x08000000" allowed_cpuset="0x08000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -161,8 +205,11 @@
             </object>
           </object>
           <object type="Cache" os_index="22" cpuset="0x20002000" complete_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="22" cpuset="0x20002000" complete_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="22" cpuset="0x20002000" complete_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="6" cpuset="0x20002000" complete_cpuset="0x20002000" allowed_cpuset="0x20002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="29" cpuset="0x20000000" complete_cpuset="0x20000000" allowed_cpuset="0x20000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -171,8 +218,11 @@
             </object>
           </object>
           <object type="Cache" os_index="23" cpuset="0x80008000" complete_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="23" cpuset="0x80008000" complete_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="23" cpuset="0x80008000" complete_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="7" cpuset="0x80008000" complete_cpuset="0x80008000" allowed_cpuset="0x80008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="31" cpuset="0x80000000" complete_cpuset="0x80000000" allowed_cpuset="0x80000000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>

--- a/tests/hwloc/x86/Intel-Westmere-2xXeon-X5650.output
+++ b/tests/hwloc/x86/Intel-Westmere-2xXeon-X5650.output
@@ -11,9 +11,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           X5650  @ 2.67GHz"/>
         <info name="CPUStepping" value="2"/>
         <object type="Cache" os_index="0" cpuset="0x0003f03f" complete_cpuset="0x0003f03f" allowed_cpuset="0x0003f03f" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="12582912" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="0" cpuset="0x00001001" complete_cpuset="0x00001001" allowed_cpuset="0x00001001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="0" cpuset="0x00001001" complete_cpuset="0x00001001" allowed_cpuset="0x00001001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="0" cpuset="0x00001001" complete_cpuset="0x00001001" allowed_cpuset="0x00001001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00001001" complete_cpuset="0x00001001" allowed_cpuset="0x00001001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" allowed_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="12" cpuset="0x00001000" complete_cpuset="0x00001000" allowed_cpuset="0x00001000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -22,8 +26,11 @@
             </object>
           </object>
           <object type="Cache" os_index="1" cpuset="0x00002002" complete_cpuset="0x00002002" allowed_cpuset="0x00002002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="1" cpuset="0x00002002" complete_cpuset="0x00002002" allowed_cpuset="0x00002002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="1" cpuset="0x00002002" complete_cpuset="0x00002002" allowed_cpuset="0x00002002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00002002" complete_cpuset="0x00002002" allowed_cpuset="0x00002002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" allowed_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="13" cpuset="0x00002000" complete_cpuset="0x00002000" allowed_cpuset="0x00002000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -32,8 +39,11 @@
             </object>
           </object>
           <object type="Cache" os_index="2" cpuset="0x00004004" complete_cpuset="0x00004004" allowed_cpuset="0x00004004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="2" cpuset="0x00004004" complete_cpuset="0x00004004" allowed_cpuset="0x00004004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="2" cpuset="0x00004004" complete_cpuset="0x00004004" allowed_cpuset="0x00004004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00004004" complete_cpuset="0x00004004" allowed_cpuset="0x00004004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" allowed_cpuset="0x00000004" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="14" cpuset="0x00004000" complete_cpuset="0x00004000" allowed_cpuset="0x00004000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -42,8 +52,11 @@
             </object>
           </object>
           <object type="Cache" os_index="8" cpuset="0x00008008" complete_cpuset="0x00008008" allowed_cpuset="0x00008008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="8" cpuset="0x00008008" complete_cpuset="0x00008008" allowed_cpuset="0x00008008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="8" cpuset="0x00008008" complete_cpuset="0x00008008" allowed_cpuset="0x00008008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x00008008" complete_cpuset="0x00008008" allowed_cpuset="0x00008008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" allowed_cpuset="0x00000008" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="15" cpuset="0x00008000" complete_cpuset="0x00008000" allowed_cpuset="0x00008000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -52,8 +65,11 @@
             </object>
           </object>
           <object type="Cache" os_index="9" cpuset="0x00010010" complete_cpuset="0x00010010" allowed_cpuset="0x00010010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="9" cpuset="0x00010010" complete_cpuset="0x00010010" allowed_cpuset="0x00010010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="9" cpuset="0x00010010" complete_cpuset="0x00010010" allowed_cpuset="0x00010010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x00010010" complete_cpuset="0x00010010" allowed_cpuset="0x00010010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" allowed_cpuset="0x00000010" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="16" cpuset="0x00010000" complete_cpuset="0x00010000" allowed_cpuset="0x00010000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -62,8 +78,11 @@
             </object>
           </object>
           <object type="Cache" os_index="10" cpuset="0x00020020" complete_cpuset="0x00020020" allowed_cpuset="0x00020020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="10" cpuset="0x00020020" complete_cpuset="0x00020020" allowed_cpuset="0x00020020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="10" cpuset="0x00020020" complete_cpuset="0x00020020" allowed_cpuset="0x00020020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x00020020" complete_cpuset="0x00020020" allowed_cpuset="0x00020020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" allowed_cpuset="0x00000020" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="17" cpuset="0x00020000" complete_cpuset="0x00020000" allowed_cpuset="0x00020000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -80,9 +99,13 @@
         <info name="CPUModel" value="Intel(R) Xeon(R) CPU           X5650  @ 2.67GHz"/>
         <info name="CPUStepping" value="2"/>
         <object type="Cache" os_index="1" cpuset="0x00fc0fc0" complete_cpuset="0x00fc0fc0" allowed_cpuset="0x00fc0fc0" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="12582912" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
+          <info name="inclusiveness" value="true"/>
           <object type="Cache" os_index="16" cpuset="0x00040040" complete_cpuset="0x00040040" allowed_cpuset="0x00040040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="16" cpuset="0x00040040" complete_cpuset="0x00040040" allowed_cpuset="0x00040040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="16" cpuset="0x00040040" complete_cpuset="0x00040040" allowed_cpuset="0x00040040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="0" cpuset="0x00040040" complete_cpuset="0x00040040" allowed_cpuset="0x00040040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" allowed_cpuset="0x00000040" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="18" cpuset="0x00040000" complete_cpuset="0x00040000" allowed_cpuset="0x00040000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -91,8 +114,11 @@
             </object>
           </object>
           <object type="Cache" os_index="17" cpuset="0x00080080" complete_cpuset="0x00080080" allowed_cpuset="0x00080080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="17" cpuset="0x00080080" complete_cpuset="0x00080080" allowed_cpuset="0x00080080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="17" cpuset="0x00080080" complete_cpuset="0x00080080" allowed_cpuset="0x00080080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="1" cpuset="0x00080080" complete_cpuset="0x00080080" allowed_cpuset="0x00080080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" allowed_cpuset="0x00000080" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="19" cpuset="0x00080000" complete_cpuset="0x00080000" allowed_cpuset="0x00080000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -101,8 +127,11 @@
             </object>
           </object>
           <object type="Cache" os_index="18" cpuset="0x00100100" complete_cpuset="0x00100100" allowed_cpuset="0x00100100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="18" cpuset="0x00100100" complete_cpuset="0x00100100" allowed_cpuset="0x00100100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="18" cpuset="0x00100100" complete_cpuset="0x00100100" allowed_cpuset="0x00100100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="2" cpuset="0x00100100" complete_cpuset="0x00100100" allowed_cpuset="0x00100100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="8" cpuset="0x00000100" complete_cpuset="0x00000100" allowed_cpuset="0x00000100" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="20" cpuset="0x00100000" complete_cpuset="0x00100000" allowed_cpuset="0x00100000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -111,8 +140,11 @@
             </object>
           </object>
           <object type="Cache" os_index="24" cpuset="0x00200200" complete_cpuset="0x00200200" allowed_cpuset="0x00200200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="24" cpuset="0x00200200" complete_cpuset="0x00200200" allowed_cpuset="0x00200200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="24" cpuset="0x00200200" complete_cpuset="0x00200200" allowed_cpuset="0x00200200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="8" cpuset="0x00200200" complete_cpuset="0x00200200" allowed_cpuset="0x00200200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="9" cpuset="0x00000200" complete_cpuset="0x00000200" allowed_cpuset="0x00000200" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="21" cpuset="0x00200000" complete_cpuset="0x00200000" allowed_cpuset="0x00200000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -121,8 +153,11 @@
             </object>
           </object>
           <object type="Cache" os_index="25" cpuset="0x00400400" complete_cpuset="0x00400400" allowed_cpuset="0x00400400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="25" cpuset="0x00400400" complete_cpuset="0x00400400" allowed_cpuset="0x00400400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="25" cpuset="0x00400400" complete_cpuset="0x00400400" allowed_cpuset="0x00400400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="9" cpuset="0x00400400" complete_cpuset="0x00400400" allowed_cpuset="0x00400400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="10" cpuset="0x00000400" complete_cpuset="0x00000400" allowed_cpuset="0x00000400" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="22" cpuset="0x00400000" complete_cpuset="0x00400000" allowed_cpuset="0x00400000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
@@ -131,8 +166,11 @@
             </object>
           </object>
           <object type="Cache" os_index="26" cpuset="0x00800800" complete_cpuset="0x00800800" allowed_cpuset="0x00800800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="262144" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">
+            <info name="inclusiveness" value="false"/>
             <object type="Cache" os_index="26" cpuset="0x00800800" complete_cpuset="0x00800800" allowed_cpuset="0x00800800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="8" cache_type="1">
+              <info name="inclusiveness" value="false"/>
               <object type="Cache" os_index="26" cpuset="0x00800800" complete_cpuset="0x00800800" allowed_cpuset="0x00800800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001" cache_size="32768" depth="1" cache_linesize="64" cache_associativity="4" cache_type="2">
+                <info name="inclusiveness" value="false"/>
                 <object type="Core" os_index="10" cpuset="0x00800800" complete_cpuset="0x00800800" allowed_cpuset="0x00800800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001">
                   <object type="PU" os_index="11" cpuset="0x00000800" complete_cpuset="0x00000800" allowed_cpuset="0x00000800" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>
                   <object type="PU" os_index="23" cpuset="0x00800000" complete_cpuset="0x00800000" allowed_cpuset="0x00800000" nodeset="0x00000001" complete_nodeset="0x00000001" allowed_nodeset="0x00000001"/>


### PR DESCRIPTION
Use hwloc_obj_get_info_by_name(cache, "inclusiveness") to get his inclusiveness.