### PR TITLE
bind.c: fix silly compiler warning

### DIFF
--- a/hwloc/bind.c
+++ b/hwloc/bind.c
@@ -2,7 +2,7 @@
  * Copyright © 2009 CNRS
  * Copyright © 2009-2015 Inria.  All rights reserved.
  * Copyright © 2009-2010, 2012 Université Bordeaux
- * Copyright © 2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2011-2015 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -447,7 +447,7 @@ hwloc_get_area_membind(hwloc_topology_t topology, const void *addr, size_t len, 
 void *
 hwloc_alloc_heap(hwloc_topology_t topology __hwloc_attribute_unused, size_t len)
 {
-  void *p;
+  void *p = NULL;
 #if defined(hwloc_getpagesize) && defined(HAVE_POSIX_MEMALIGN)
   errno = posix_memalign(&p, hwloc_getpagesize(), len);
   if (errno)


### PR DESCRIPTION
clang on OS X warns that p may be uninitialized.  Best I can figure, it's assuming posix_memalign() may fail to fill &p and still return an errno of 0.  Technically -- on a buggy system -- that can happen.  So we might as well initialize p to be NULL just to cover all cases / be defensive.

@bgoglin Got any objections to this minor warning squash?