### PR TITLE
RFC: Remove libnuma dependency

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -111,6 +111,7 @@ Version 2.0.0
     anymore, they should be passed in HWLOC_XMLFILE or HWLOC_SYNTHETIC instead.
   + HWLOC_COMPONENTS takes precedence over other environment variables
     for selecting components.
+  + Remove the dependency on libnuma on Linux.
 
 
 Version 1.11.2

--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -572,13 +572,13 @@ EOF])
          AC_MSG_RESULT([yes])],
         [AC_MSG_RESULT([no])])
 
-    AC_MSG_CHECKING([for working syscall])
+    AC_MSG_CHECKING([for working syscall with 6 parameters])
     AC_LINK_IFELSE([
       AC_LANG_PROGRAM([[
           #include <unistd.h>
           #include <sys/syscall.h>
-          ]], [[syscall(1, 2, 3);]])],
-        [AC_DEFINE([HWLOC_HAVE_SYSCALL], [1], [Define to 1 if function `syscall' is available])
+          ]], [[syscall(0, 1, 2, 3, 4, 5, 6);]])],
+        [AC_DEFINE([HWLOC_HAVE_SYSCALL], [1], [Define to 1 if function `syscall' is available with 6 parameters])
          AC_MSG_RESULT([yes])],
         [AC_MSG_RESULT([no])])
 
@@ -670,41 +670,6 @@ EOF])
       AC_DEFINE([HWLOC_HAVE_PTHREAD_GETTHRDS_NP], 1, `Define to 1 if you have pthread_getthrds_np')
     )
     AC_CHECK_FUNCS([cpuset_setid])
-
-    # Linux libnuma support
-    hwloc_linux_libnuma_happy=no
-    if test "x$enable_libnuma" != "xno"; then
-        hwloc_linux_libnuma_happy=yes
-        AC_CHECK_HEADERS([numaif.h], [
-            AC_CHECK_LIB([numa], [numa_available], [HWLOC_LINUX_LIBNUMA_LIBS="-lnuma"], [hwloc_linux_libnuma_happy=no])
-        ], [hwloc_linux_libnuma_happy=no])
-    fi
-    AC_SUBST(HWLOC_LINUX_LIBNUMA_LIBS)
-    # If we asked for Linux libnuma support but couldn't deliver, fail
-    HWLOC_LIBS="$HWLOC_LIBS $HWLOC_LINUX_LIBNUMA_LIBS"
-    AS_IF([test "$enable_libnuma" = "yes" -a "$hwloc_linux_libnuma_happy" = "no"],
-          [AC_MSG_WARN([Specified --enable-libnuma switch, but could not])
-           AC_MSG_WARN([find appropriate support])
-           AC_MSG_ERROR([Cannot continue])])
-    if test "x$hwloc_linux_libnuma_happy" = "xyes"; then
-      tmp_save_LIBS="$LIBS"
-      LIBS="$LIBS $HWLOC_LINUX_LIBNUMA_LIBS"
-
-      AC_CHECK_LIB([numa], [set_mempolicy], [
-	enable_set_mempolicy=yes
-	AC_DEFINE([HWLOC_HAVE_SET_MEMPOLICY], [1], [Define to 1 if set_mempolicy is available.])
-      ])
-      AC_CHECK_LIB([numa], [mbind], [
-	enable_mbind=yes
-	AC_DEFINE([HWLOC_HAVE_MBIND], [1], [Define to 1 if mbind is available.])
-      ])
-      AC_CHECK_LIB([numa], [migrate_pages], [
-	enable_migrate_pages=yes
-	AC_DEFINE([HWLOC_HAVE_MIGRATE_PAGES], [1], [Define to 1 if migrate_pages is available.])
-      ])
-
-      LIBS="$tmp_save_LIBS"
-    fi
 
     # Linux libudev support
     if test "x$enable_libudev" != xno; then
@@ -1162,12 +1127,12 @@ AC_DEFUN([HWLOC_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL([HWLOC_HAVE_GCC], [test "x$GCC" = "xyes"])
         AM_CONDITIONAL([HWLOC_HAVE_MS_LIB], [test "x$HWLOC_MS_LIB" != "x"])
         AM_CONDITIONAL([HWLOC_HAVE_OPENAT], [test "x$hwloc_have_openat" = "xyes"])
-        AM_CONDITIONAL([HWLOC_HAVE_LINUX_LIBNUMA],
-                       [test "x$hwloc_have_linux_libnuma" = "xyes"])
         AM_CONDITIONAL([HWLOC_HAVE_SCHED_SETAFFINITY],
                        [test "x$hwloc_have_sched_setaffinity" = "xyes"])
         AM_CONDITIONAL([HWLOC_HAVE_PTHREAD],
                        [test "x$hwloc_have_pthread" = "xyes"])
+        AM_CONDITIONAL([HWLOC_HAVE_LINUX_LIBNUMA],
+                       [test "x$hwloc_have_linux_libnuma" = "xyes"])
         AM_CONDITIONAL([HWLOC_HAVE_LIBIBVERBS],
                        [test "x$hwloc_have_libibverbs" = "xyes"])
 	AM_CONDITIONAL([HWLOC_HAVE_CUDA],
@@ -1183,8 +1148,6 @@ AC_DEFUN([HWLOC_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL([HWLOC_HAVE_PCIACCESS], [test "$hwloc_pciaccess_happy" = "yes"])
         AM_CONDITIONAL([HWLOC_HAVE_OPENCL], [test "$hwloc_opencl_happy" = "yes"])
         AM_CONDITIONAL([HWLOC_HAVE_NVML], [test "$hwloc_nvml_happy" = "yes"])
-        AM_CONDITIONAL([HWLOC_HAVE_SET_MEMPOLICY], [test "x$enable_set_mempolicy" != "xno"])
-        AM_CONDITIONAL([HWLOC_HAVE_MBIND], [test "x$enable_mbind" != "xno"])
         AM_CONDITIONAL([HWLOC_HAVE_BUNZIPP], [test "x$BUNZIPP" != "xfalse"])
 
         AM_CONDITIONAL([HWLOC_BUILD_DOXYGEN],

--- a/config/hwloc_internal.m4
+++ b/config/hwloc_internal.m4
@@ -1,6 +1,6 @@
 dnl -*- Autoconf -*-
 dnl
-dnl Copyright © 2009-2015 Inria.  All rights reserved.
+dnl Copyright © 2010-2016 Inria.  All rights reserved.
 dnl Copyright © 2009, 2011 Université Bordeaux
 dnl Copyright © 2004-2005 The Trustees of Indiana University and Indiana
 dnl                         University Research and Technology
@@ -93,11 +93,6 @@ AC_DEFUN([HWLOC_DEFINE_ARGS],[
     AC_ARG_ENABLE([gl],
 		  AS_HELP_STRING([--disable-gl],
 				 [Disable the GL display device discovery]))
-
-    # Linux libnuma
-    AC_ARG_ENABLE([libnuma],
-                  AS_HELP_STRING([--disable-libnuma],
-                                 [Disable the Linux libnuma]))
 
     # LibUdev
     AC_ARG_ENABLE([libudev],

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # -*- shell-script -*-
 #
 # Copyright © 2009      CNRS
-# Copyright © 2009-2015 Inria.  All rights reserved.
+# Copyright © 2009-2016 Inria.  All rights reserved.
 # Copyright © 2009, 2011-2012      Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 #
@@ -252,11 +252,6 @@ Graphical output (Cairo):    $hwloc_cairo_happy
 XML input / output:          $hwloc_xml_status
 Netloc functionality:        $netloc_happy
 EOF
-
-# Linux specific support
-AS_IF([test "$hwloc_linux" = "yes"], [cat <<EOF
-libnuma memory support:      $hwloc_linux_libnuma_happy
-EOF])
 
 # Plugin support
 hwloc_plugin_summary=$hwloc_have_plugins

--- a/contrib/windows/private_config.h
+++ b/contrib/windows/private_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009, 2011, 2012 CNRS.  All rights reserved.
- * Copyright © 2009-2015 Inria.  All rights reserved.
+ * Copyright © 2009-2016 Inria.  All rights reserved.
  * Copyright © 2009, 2011, 2012, 2015 Université Bordeaux.  All rights reserved.
  * Copyright © 2009 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -476,12 +476,6 @@
 /* Define to 1 if building the Linux PCI component */
 /* #undef HWLOC_HAVE_LINUXPCI */
 
-/* Define to 1 if mbind is available. */
-/* #undef HWLOC_HAVE_MBIND */
-
-/* Define to 1 if migrate_pages is available. */
-/* #undef HWLOC_HAVE_MIGRATE_PAGES */
-
 /* Define to 1 if you have the `NVML' library. */
 /* #undef HWLOC_HAVE_NVML */
 
@@ -504,9 +498,6 @@
 
 /* Define to 1 if glibc provides a prototype of sched_setaffinity() */
 #define HWLOC_HAVE_SCHED_SETAFFINITY 1
-
-/* Define to 1 if set_mempolicy is available. */
-/* #undef HWLOC_HAVE_SET_MEMPOLICY */
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HWLOC_HAVE_STDINT_H 1

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -124,9 +124,6 @@ is configured and build.
 
 The hwloc core may also benefit from the following development packages:
 <ul>
-<li>libnuma for memory binding and migration support on Linux
-    (<tt>numactl-devel</tt> or <tt>libnuma-dev</tt> package).
-</li>
 <li>libpciaccess for full I/O device discovery
     (<tt>libpciaccess-devel</tt> or <tt>libpciaccess-dev</tt> package).
     On Linux, PCI discovery may still be performed (without vendor/device names)


### PR DESCRIPTION
@jsquyres This came up during the OMPI dev meeting when discussing with @markalle. Platform-MPI currently dlopens libnuma.so instead of keeping the hardwired dependency in libhwloc.so. I figured we could try to just remove the libnuma dependency entirely. It's easy, except when redefining the missing syscalls. I still need to check whether syscall() is well supported with 6 parameters on reasonably old distros running on NUMA machines.

Likely for hwloc v2.0 only, except if somebody is sure this can safely go to v1.11.3.