### PR TITLE
[RFC] Insert right objects before the left ones

### DIFF
--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -808,7 +808,7 @@ hwloc__look_synthetic(struct hwloc_topology *topology,
       break;
   }
 
-  os_index = curlevel->next_os_index++;
+  os_index = curlevel->totalwidth - (++curlevel->next_os_index);
   if (curlevel->index_array)
     os_index = curlevel->index_array[os_index];
   else if (hwloc_obj_type_is_cache(type) || type == HWLOC_OBJ_GROUP)


### PR DESCRIPTION
Not really useful as long as we don't have hundreds of children within a single object. The quadratic complexity is negligible on current machines since we usually have tens of children max. Mostly useful for large synthetic topologies so far.

Check whether the first commit in the PR decreases performance before merging.

Otherwise just keep that code here until machines really need that sort of optimization. The Linux backend will need a reverse foreach loop.
