### PR TITLE
[RFC] stop distributing some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ test-suite.log
 /tests/hwloc/nvml
 
 /tests/hwloc/linux/test-topology.sh
+/tests/hwloc/linux/extra/
 
 /tests/hwloc/linux/gather/test-gather-topology.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ test-suite.log
 /tests/hwloc/ports/liblstopo-port-windows.a
 
 /tests/hwloc/x86/test-topology.sh
+/tests/hwloc/x86/extra/
 
 /tests/hwloc/xml/test-topology.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ test-suite.log
 /tests/hwloc/x86/extra/
 
 /tests/hwloc/xml/test-topology.sh
+/tests/hwloc/xml/extra/
 
 /tests/hwloc/embedded/aclocal.m4
 /tests/hwloc/embedded/autom4te.cache

--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,7 @@ test-suite.log
 /utils/hwloc/test-hwloc-info.sh
 /utils/hwloc/test-*.sh.log
 /utils/hwloc/test-*.sh.trs
+/utils/hwloc/test-hwloc-dump-hwdata/extra
 
 /utils/lstopo/*.o
 /utils/lstopo/lstopo

--- a/config/hwloc_extra.am
+++ b/config/hwloc_extra.am
@@ -1,0 +1,36 @@
+# Copyright © 2009-2016 Inria.  All rights reserved.
+# See COPYING in top-level directory.
+
+# Must be called with:
+# HWLOC_EXTRA_CHECK_DIR= subdirectory containing targets (relative path from top_srcdir)
+# HWLOC_EXTRA_CHECK_TARGET= target filename pattern
+#
+# The caller must have some non-optional checks (so that LOG_DRIVER is defined by automake).
+
+.PHONY: hwloc-extra-check
+hwloc-extra-check:
+	@fail=0; \
+	echo "======================================================"; \
+	if test -d $(top_srcdir)/$(HWLOC_EXTRA_CHECK_DIR); then \
+	  echo "Running extra check from $(HWLOC_EXTRA_CHECK_DIR) ..."; \
+	  for file in `ls $(top_srcdir)/$(HWLOC_EXTRA_CHECK_DIR)/$(HWLOC_EXTRA_CHECK_TARGET)`; do \
+	    name=`echo "$$file" | sed 's/.*\///'`; \
+	    $(LOG_DRIVER) --test-name "$$name" --log-file "$$name.log" --trs-file "$$name.trs" -- $(LOG_COMPILER) $(top_srcdir)/$(HWLOC_EXTRA_CHECK_DIR)/"$$file"; \
+	    if grep "^[	 ]*:test-result:[	 ]*FAIL" "$$name.trs" >/dev/null 2>&1; then fail=`expr $$fail + 1`; fi; \
+	  done; \
+	else \
+	  echo "Extra check directory $(HWLOC_EXTRA_CHECK_DIR) missing."; \
+	fi; \
+	if test x$$fail != x0; then \
+	  echo "======================================================"; \
+          echo "# FAIL:  $$fail"; \
+	  exit 1; \
+	fi; \
+	echo "======================================================"
+
+.PHONY: hwloc-extra-check-clean
+hwloc-extra-check-clean:
+	@for file in `ls $(top_srcdir)/$(HWLOC_EXTRA_CHECK_DIR)/$(HWLOC_EXTRA_CHECK_TARGET)`; do \
+	  name=`echo "$$file" | sed 's/.*\///'`; \
+	  $(RM) "$$name.trs" "$$name.log"; \
+        done

--- a/tests/hwloc/linux/Makefile.am
+++ b/tests/hwloc/linux/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2009-2015 Inria.  All rights reserved.
+# Copyright © 2009-2016 Inria.  All rights reserved.
 # Copyright © 2009-2011 Université Bordeaux
 # Copyright © 2009-2010 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
@@ -164,3 +164,11 @@ EXTRA_DIST = $(sysfs_outputs) $(sysfs_tarballs) $(sysfs_excludes) $(sysfs_option
 LOG_COMPILER = $(builddir)/test-topology.sh
 
 SUBDIRS = . gather
+
+
+# Non-distributed tests in extra/*.output
+HWLOC_EXTRA_CHECK_DIR = tests/hwloc/linux/extra
+HWLOC_EXTRA_CHECK_TARGET = *.output
+include ../../../config/hwloc_extra.am
+check-local: hwloc-extra-check
+clean-local: hwloc-extra-check-clean

--- a/tests/hwloc/linux/test-topology.sh.in
+++ b/tests/hwloc/linux/test-topology.sh.in
@@ -3,7 +3,7 @@
 
 #
 # Copyright © 2009 CNRS
-# Copyright © 2009-2015 Inria.  All rights reserved.
+# Copyright © 2009-2016 Inria.  All rights reserved.
 # Copyright © 2009-2011 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
@@ -109,7 +109,7 @@ actual_options="$topology".options
 
 # if there's a .source file, use the tarball name it contains instead of $topology
 if [ -f "$topology".source ] ; then
-    actual_source="$HWLOC_top_srcdir"/tests/hwloc/linux/`cat "$topology".source`
+    actual_source=`dirname $topology`/`cat "$topology".source`
 else
     actual_source="$topology".tar.bz2
 fi
@@ -120,7 +120,7 @@ if [ -f "$topology".env ] ; then
 fi
 
 # use an absolute path for tar options because tar is invoked from the temp directory
-actual_exclude="$HWLOC_top_srcdir/tests/hwloc/linux/`basename $topology`".exclude
+actual_exclude="$HWLOC_top_builddir/tests/hwloc/linux/`dirname $topology`/`basename $topology`".exclude
 [ -f "$actual_exclude" ] && tar_options="--exclude-from=$actual_exclude"
 
 result=1

--- a/tests/hwloc/x86/Makefile.am
+++ b/tests/hwloc/x86/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2015 Inria.  All rights reserved.
+# Copyright © 2015-2016 Inria.  All rights reserved.
 # See COPYING in top-level directory.
 
 AM_CFLAGS = $(HWLOC_CFLAGS)
@@ -57,3 +57,12 @@ endif HWLOC_HAVE_BUNZIPP
 EXTRA_DIST = $(cpuid_outputs) $(cpuid_tarballs) $(cpuid_options) $(cpuid_envs)
 
 LOG_COMPILER = $(builddir)/test-topology.sh
+
+
+# Non-distributed tests in extra/*.output
+HWLOC_EXTRA_CHECK_DIR = tests/hwloc/x86/extra
+HWLOC_EXTRA_CHECK_TARGET = *.output
+include ../../../config/hwloc_extra.am
+check-local: hwloc-extra-check
+clean-local: hwloc-extra-check-clean
+

--- a/tests/hwloc/xml/Makefile.am
+++ b/tests/hwloc/xml/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2009-2015 Inria.  All rights reserved.
+# Copyright © 2009-2016 Inria.  All rights reserved.
 # Copyright © 2009-2010 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
@@ -70,3 +70,12 @@ TESTS = $(xml_outputs)
 EXTRA_DIST = $(xml_outputs) $(xml_source) $(xml_options) $(xml_envs)
 
 LOG_COMPILER = $(HWLOC_top_builddir)/tests/hwloc/xml/test-topology.sh
+
+
+# Non-distributed tests in extra/*.output
+HWLOC_EXTRA_CHECK_DIR = tests/hwloc/xml/extra
+HWLOC_EXTRA_CHECK_TARGET = *.{xml,output}
+include ../../../config/hwloc_extra.am
+check-local: hwloc-extra-check
+clean-local: hwloc-extra-check-clean
+

--- a/utils/hwloc/test-hwloc-dump-hwdata/Makefile.am
+++ b/utils/hwloc/test-hwloc-dump-hwdata/Makefile.am
@@ -15,3 +15,12 @@ endif HWLOC_HAVE_BUNZIPP
 EXTRA_DIST = $(dumps)
 
 LOG_COMPILER = $(builddir)/test-hwloc-dump-hwdata.sh
+
+
+# Non-distributed tests in extra/*.output
+HWLOC_EXTRA_CHECK_DIR = utils/hwloc/test-hwloc-dump-hwdata/extra
+HWLOC_EXTRA_CHECK_TARGET = *.tar.bz2
+include ../../../config/hwloc_extra.am
+check-local: hwloc-extra-check
+clean-local: hwloc-extra-check-clean
+


### PR DESCRIPTION
Our release tarballs are currently about 4MB, with about 700kB of tests/hwloc/linux tarballs. Not too bad. But things are expected to get worse with KNL tarballs for different MCDRAM/Clustering configs (100kB each), newer x86 CPUID tarballs, netloc stuff, etc.

This PR makes tests/hwloc/{linux,xml,x86}/ and utils/hwloc/test-hwloc-dump-hwdata/ support running optional tests under an "extra" subdirectory. Those tests would be in GIT but not in tarballs.

The same code could be used to move tests to another repository if git clones become too heavy (currently 35MB). Something like cloning hwloc-extra/ at the root the main hwloc clone and having tests subdirectories tests/hwloc/linux run additional tests in hwloc-extra/tests/hwloc/linux. We would warn at the end of configure when building from GIT without that extra repository.
