### PR TITLE
plugins.h: fix "might be uninitialized" compiler warning

### DIFF
--- a/include/hwloc/plugins.h
+++ b/include/hwloc/plugins.h
@@ -1,5 +1,6 @@
 /*
  * Copyright © 2013-2016 Inria.  All rights reserved.
+ * Copyright © 2016 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -418,7 +419,7 @@ hwloc_filter_check_osdev_subtype_important(hwloc_obj_osdev_type_t subtype)
 static __hwloc_inline int
 hwloc_filter_check_keep_object_type(hwloc_topology_t topology, hwloc_obj_type_t type)
 {
-  enum hwloc_type_filter_e filter;
+  enum hwloc_type_filter_e filter = HWLOC_TYPE_FILTER_KEEP_NONE;
   hwloc_topology_get_type_filter(topology, type, &filter);
   assert(filter != HWLOC_TYPE_FILTER_KEEP_IMPORTANT); /* IMPORTANT only used for I/O */
   return filter == HWLOC_TYPE_FILTER_KEEP_NONE ? 0 : 1;
@@ -432,7 +433,7 @@ static __hwloc_inline int
 hwloc_filter_check_keep_object(hwloc_topology_t topology, hwloc_obj_t obj)
 {
   hwloc_obj_type_t type = obj->type;
-  enum hwloc_type_filter_e filter;
+  enum hwloc_type_filter_e filter = HWLOC_TYPE_FILTER_KEEP_NONE;
   hwloc_topology_get_type_filter(topology, type, &filter);
   if (filter == HWLOC_TYPE_FILTER_KEEP_NONE)
     return 0;


### PR DESCRIPTION
This commit fixes a warning from clang/OS X:

```
  CC       topology.lo
In file included from /Users/jsquyres/git/hwloc/include/private/components.h:19:0,
                 from /Users/jsquyres/git/hwloc/include/private/private.h:28,
                 from topology.c:29:
topology.c: In function ‘hwloc_topology_load’:
/Users/jsquyres/git/hwloc/include/hwloc/plugins.h:439:6: warning: ‘filter’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   if (filter == HWLOC_TYPE_FILTER_KEEP_IMPORTANT) {
      ^
/Users/jsquyres/git/hwloc/include/hwloc/plugins.h:435:28: note: ‘filter’ was declared here
   enum hwloc_type_filter_e filter;
                            ^
```

Which is interesting, because the issue is in a .h file, but it only shows up when compiling one particular .c file (because the function in question that _might_ initialize the variable in question is in that .c file).  

In short:

``` c
hwloc_topology_get_type_filter(topology, type, &filter);
```

may actually leave `filter` uninitialized if `type` is out of range.  This commit simply ensures to initialize `filter` to `NONE` before calling `hwloc_topology_get_type_filter()`.

Signed-off-by: Jeff Squyres jsquyres@cisco.com
