### PR TITLE
hwloc.m4: fix compiler warning in embedded mode

### DIFF
--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -673,6 +673,8 @@ EOF])
     AS_IF([test "$hwloc_mode" != "embedded"],
         [AC_CHECK_HEADERS([valgrind/valgrind.h])
          AC_CHECK_DECLS([RUNNING_ON_VALGRIND],,[:],[[#include <valgrind/valgrind.h>]])
+	],[
+	 AC_DEFINE([HAVE_DECL_RUNNING_ON_VALGRIND], [0], [Embedded mode; just assume we do not have Valgrind support])
 	])
 
     AC_CHECK_HEADERS([pthread_np.h])


### PR DESCRIPTION
Ensure that HAVE_DECL_RUNNING_ON_VALGRIND is always defined, even when
we're in embedded mode.  Fixes #197.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@bgoglin Have a look