### PR TITLE
Properly handle realloc() failures

### DIFF
--- a/hwloc/topology-xml-nolibxml.c
+++ b/hwloc/topology-xml-nolibxml.c
@@ -677,7 +677,7 @@ hwloc___nolibxml_prepare_export(hwloc_topology_t topology, char *xmlbuffer, int 
 static int
 hwloc_nolibxml_export_buffer(hwloc_topology_t topology, char **bufferp, int *buflenp)
 {
-  char *buffer;
+  char *buffer, *tmpbuffer;
   size_t bufferlen, res;
 
   bufferlen = 16384; /* random guess for large enough default */
@@ -685,8 +685,15 @@ hwloc_nolibxml_export_buffer(hwloc_topology_t topology, char **bufferp, int *buf
   res = hwloc___nolibxml_prepare_export(topology, buffer, (int)bufferlen);
 
   if (res > bufferlen) {
-    buffer = realloc(buffer, res);
-    hwloc___nolibxml_prepare_export(topology, buffer, (int)res);
+    tmpbuffer = realloc(buffer, res);
+    if (tmpbuffer != NULL) {
+      buffer = tmpbuffer;
+      hwloc___nolibxml_prepare_export(topology, buffer, (int)res);
+    }
+    else {
+      free(buffer);
+      /* And handle error */
+    }
   }
 
   *bufferp = buffer;

--- a/hwloc/topology-xml-nolibxml.c
+++ b/hwloc/topology-xml-nolibxml.c
@@ -319,7 +319,7 @@ hwloc_nolibxml_read_file(const char *xmlpath, char **bufferp, size_t *buflenp)
   FILE * file;
   size_t buflen, offset, readlen;
   struct stat statbuf;
-  char *buffer;
+  char *buffer, *tmpbuffer;
   size_t ret;
 
   if (!strcmp(xmlpath, "-"))
@@ -350,9 +350,10 @@ hwloc_nolibxml_read_file(const char *xmlpath, char **bufferp, size_t *buflenp)
       break;
 
     buflen *= 2;
-    buffer = realloc(buffer, buflen+1);
-    if (!buffer)
+    tmpbuffer = realloc(buffer, buflen+1);
+    if (!tmpbuffer)
       goto out_with_file;
+    buffer = tmpbuffer;
     readlen = buflen/2;
   }
 

--- a/hwloc/topology-xml-nolibxml.c
+++ b/hwloc/topology-xml-nolibxml.c
@@ -776,7 +776,7 @@ hwloc___nolibxml_prepare_export_diff(hwloc_topology_diff_t diff, const char *ref
 static int
 hwloc_nolibxml_export_diff_buffer(hwloc_topology_diff_t diff, const char *refname, char **bufferp, int *buflenp)
 {
-  char *buffer;
+  char *buffer, *tmpbuffer;
   size_t bufferlen, res;
 
   bufferlen = 16384; /* random guess for large enough default */
@@ -784,8 +784,15 @@ hwloc_nolibxml_export_diff_buffer(hwloc_topology_diff_t diff, const char *refnam
   res = hwloc___nolibxml_prepare_export_diff(diff, refname, buffer, (int)bufferlen);
 
   if (res > bufferlen) {
-    buffer = realloc(buffer, res);
-    hwloc___nolibxml_prepare_export_diff(diff, refname, buffer, (int)res);
+    tmpbuffer = realloc(buffer, res);
+    if (tmpbuffer != NULL) {
+      buffer = tmpbuffer;
+      hwloc___nolibxml_prepare_export_diff(diff, refname, buffer, (int)res);
+    }
+    else {
+      free(buffer);
+      /* And handle error */
+    }
   }
 
   *bufferp = buffer;


### PR DESCRIPTION
`[hwloc/topology-linux.c:1787]: (error) Common realloc mistake: 'maps' nulled but not freed upon failure`

Passing one pointer into realloc() and assigning the result directly into that same pointer variable can cause a memory leak if the reallocation fails, because the original allocation will still exist. The correct way to do this is to use a temporary pointer variable.

Credit 1: http://stackoverflow.com/a/11548901
Credit 2: https://github.com/RRZE-HPC/likwid/issues/44

Found by https://github.com/bryongloden/cppcheck