### PR TITLE
Update topology-solaris.c

### DIFF
--- a/hwloc/topology-solaris.c
+++ b/hwloc/topology-solaris.c
@@ -428,6 +428,8 @@ hwloc_look_lgrp(struct hwloc_topology *topology)
       hwloc_distances_set(topology, HWLOC_OBJ_NUMANODE, curlgrp, indexes, glob_lgrps, distances, 0 /* OS cannot force */);
     }
 #endif /* HAVE_LGRP_LATENCY_COOKIE */
+  
+    free(glob_lgrps);
   }
   lgrp_fini(cookie);
 }


### PR DESCRIPTION
On line #431 'glob_lgrps' has a memory leak, which is an error. However, I'm not able to test this, so I'd appreciate a second pair of eyes, i.e. code review.

Found by https://github.com/bryongloden/cppcheck