### PR TITLE
Update topology-synthetic.c

### DIFF
--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -966,6 +966,7 @@ static int hwloc_topology_export_synthetic_indexes(struct hwloc_topology * topol
   unsigned step = 1;
   unsigned nr_loops = 0;
   struct hwloc_synthetic_intlv_loop_s *loops = NULL;
+  struct hwloc_synthetic_intlv_loop_s *temp = NULL;
   hwloc_obj_t cur;
   unsigned i, j;
   ssize_t tmplen = buflen;
@@ -992,8 +993,8 @@ static int hwloc_topology_export_synthetic_indexes(struct hwloc_topology * topol
 	break;
 
     nr_loops++;
-    loops = realloc(loops, nr_loops*sizeof(*loops));
-    if (!loops)
+    temp = realloc(loops, nr_loops*sizeof(*loops));
+    if (temp == NULL)
       goto exportall;
     loops[nr_loops-1].step = i;
     loops[nr_loops-1].nb = j;


### PR DESCRIPTION
Hey there @bgoglin, I am able to test this locally, and my patch is building. This is one of the 14 realloc() errors I mentioned in https://github.com/open-mpi/hwloc/pull/202. I realize this may not be the most efficient way to propose a file change, but I'm unable to edit https://github.com/open-mpi/hwloc/blob/master/hwloc/topology-synthetic.c and amend it to https://github.com/open-mpi/hwloc/pull/202 using the website GUI. If this is an issue, give me a shout out, and maybe we can come up with something different for future patches related to https://github.com/open-mpi/hwloc/pull/202.