### PR TITLE
make_snapshot_tarball: update nightly filename

### DIFF
--- a/contrib/nightly/make_snapshot_tarball
+++ b/contrib/nightly/make_snapshot_tarball
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright © 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright © 2006-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright © 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -166,26 +166,31 @@ do_command "git clone $giturl hwloc"
 cd hwloc
 do_command "git checkout $gitbranch"
 
-# Find the "git describe" string for this branch (remove a leading "hwloc-"
-# prefix, if there is one).
-describe=`git describe --tags --always | sed -e s/^hwloc-//`
+# Nightly tarballs are named in this format:
+# hwloc-${BRANCHNAME}-${YYYYMMDDHHMM}-${SHORTHASH}.tar.${COMPRESSION}
+timestamp=`date '+%Y%m%d%H%M'`
+githash=`git log -n 1 '--pretty=format:%h'`
+version="$gitbranch-$timestamp-$githash"
 if test -n "$debug"; then
-    echo "** found $gitbranch describe: $describe"
+    echo "*** This snapshot version: $version"
 fi
-version=$describe
 
 # if there's a $destdir/latest_snapshot.txt, see if anything has
-# happened since the describe listed in that file
+# happened since the version listed in that file
 if test -f "$destdir/latest_snapshot.txt"; then
-    snapshot_describe=`cat $destdir/latest_snapshot.txt`
+    snapshot_version=`cat $destdir/latest_snapshot.txt`
     if test -n "$debug"; then
-        echo "** last snapshot describe: $snapshot_describe"
+        echo "*** Last snapshot version: $snapshot_version"
     fi
 
     # Do we need a new snapshot?
-    if test "$describe" = "$snapshot_describe"; then
+    # Snip the timestamp out of the versions and compare just
+    # ${BRANCHNAME}-${SHORTHASH}.
+    compare_version="$gitbranch-$githash"
+    compare_snapshot_version=`echo $snapshot_version | perl -pi -e 's/^([a-z]+)-(\d+)-(.*+)$/$1-$3/'`
+    if test "$compare_version" = "$compare_snapshot_version"; then
         if test -n "$debug"; then
-            echo "** git $gitbranch describe is same as latest_snapshot -- not doing anything"
+            echo "*** Our branch/git hash is the same as the last snapshot -- not doing anything"
         fi
         # Since we didn't do anything, there's no point in leaving the clone we
         # just created
@@ -198,14 +203,14 @@ if test -f "$destdir/latest_snapshot.txt"; then
 fi
 
 if test -n "$debug"; then
-    echo "** making snapshot for describe: $describe"
+    echo "*** Houston: we're a go to make snapshot $version"
 fi
 
 # Ensure that VERSION is set to indicate that it wants a snapshot, and
 # insert the actual value that we want (so that hwloc_get_version.sh
 # will report exactly that version).
-sed -e 's/^snapshot=.*/snapshot=1/' \
-    -e 's/^snapshot_version=.*/snapshot_version='$describe/ \
+sed -e 's/^repo_rev=.*/repo_rev='$githash/ \
+    -e 's/^tarball_version=.*/tarball_version='$version/ \
     VERSION > VERSION.new
 cp -f VERSION.new VERSION
 rm -f VERSION.new


### PR DESCRIPTION
Nightly snapshots will now be named:

hwloc-${BRANCHNAME}-${YYYYMMDDHHMM}-${SHORTHASH}.tar.${COMPRESSION}.

Essentially cherry-picked from Open MPI:

* open-mpi/ompi@78d1e4ebff45fe0c3ca291cdf37de145510062d9
* open-mpi/ompi@a47ad865d320a91f633378da744f7c60affc45dd

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>