### PR TITLE
Prevent crashes and memory leaks in out-of-memory cases

### DIFF
--- a/hwloc/bitmap.c
+++ b/hwloc/bitmap.c
@@ -79,16 +79,13 @@ struct hwloc_bitmap_s * hwloc_bitmap_alloc(void)
   struct hwloc_bitmap_s * set;
 
   set = malloc(sizeof(struct hwloc_bitmap_s));
-  if (!set) {
-    errno = ENOMEM;
+  if (!set)
     return NULL;
-  }
 
   set->ulongs_count = 1;
   set->ulongs_allocated = 64/sizeof(unsigned long);
   set->ulongs = malloc(64);
   if (!set->ulongs) {
-    errno = ENOMEM;
     free(set);
     return NULL;
   }
@@ -191,14 +188,12 @@ struct hwloc_bitmap_s * hwloc_bitmap_dup(const struct hwloc_bitmap_s * old)
 
   new = malloc(sizeof(struct hwloc_bitmap_s));
   if (!new) {
-    errno = ENOMEM;
     return NULL;
   }
 
   new->ulongs = malloc(old->ulongs_allocated * sizeof(unsigned long));
   if (!new->ulongs) {
     free(new);
-    errno = ENOMEM;
     return NULL;
   }
   new->ulongs_allocated = old->ulongs_allocated;

--- a/hwloc/bitmap.c
+++ b/hwloc/bitmap.c
@@ -79,13 +79,16 @@ struct hwloc_bitmap_s * hwloc_bitmap_alloc(void)
   struct hwloc_bitmap_s * set;
 
   set = malloc(sizeof(struct hwloc_bitmap_s));
-  if (!set)
+  if (!set) {
+    errno = ENOMEM;
     return NULL;
+  }
 
   set->ulongs_count = 1;
   set->ulongs_allocated = 64/sizeof(unsigned long);
   set->ulongs = malloc(64);
   if (!set->ulongs) {
+    errno = ENOMEM;
     free(set);
     return NULL;
   }
@@ -187,12 +190,15 @@ struct hwloc_bitmap_s * hwloc_bitmap_dup(const struct hwloc_bitmap_s * old)
   HWLOC__BITMAP_CHECK(old);
 
   new = malloc(sizeof(struct hwloc_bitmap_s));
-  if (!new)
+  if (!new) {
+    errno = ENOMEM;
     return NULL;
+  }
 
   new->ulongs = malloc(old->ulongs_allocated * sizeof(unsigned long));
   if (!new->ulongs) {
     free(new);
+    errno = ENOMEM;
     return NULL;
   }
   new->ulongs_allocated = old->ulongs_allocated;

--- a/hwloc/components.c
+++ b/hwloc/components.c
@@ -585,9 +585,8 @@ nextname:
 	}
       }
       int err = hwloc_disc_component_try_enable(topology, comp, NULL, 0 /* defaults, not envvar forced */);
-      if (err < -1) {
+      if (err < -1)
         return err;
-      }
 nextcomp:
       comp = comp->next;
     }

--- a/hwloc/components.c
+++ b/hwloc/components.c
@@ -488,14 +488,14 @@ hwloc_disc_component_try_enable(struct hwloc_topology *topology,
   if (!backend) {
     if (hwloc_components_verbose || envvar_forced)
       fprintf(stderr, "Failed to instantiate discovery component `%s'\n", comp->name);
-    return -1;
+    return -2;
   }
 
   backend->envvar_forced = envvar_forced;
   return hwloc_backend_enable(topology, backend);
 }
 
-void
+int
 hwloc_disc_components_enable_others(struct hwloc_topology *topology)
 {
   struct hwloc_disc_component *comp;
@@ -584,7 +584,10 @@ nextname:
 	    curenv++;
 	}
       }
-      hwloc_disc_component_try_enable(topology, comp, NULL, 0 /* defaults, not envvar forced */);
+      int err = hwloc_disc_component_try_enable(topology, comp, NULL, 0 /* defaults, not envvar forced */);
+      if (err < -1) {
+        return err;
+      }
 nextcomp:
       comp = comp->next;
     }
@@ -604,6 +607,7 @@ nextcomp:
   }
 
   free(env);
+  return 0;
 }
 
 void

--- a/hwloc/diff.c
+++ b/hwloc/diff.c
@@ -405,8 +405,7 @@ hwloc_apply_diff_one(hwloc_topology_t topology,
 			for(i=0; i<obj->infos_count; i++) {
 				if (!strcmp(obj->infos[i].name, name)
 				    && !strcmp(obj->infos[i].value, oldvalue)) {
-					free(obj->infos[i].value);
-					obj->infos[i].value = strdup(newvalue);
+					obj->infos[i].value = newvalue;
 					found = 1;
 					break;
 				}

--- a/hwloc/misc.c
+++ b/hwloc/misc.c
@@ -99,6 +99,9 @@ void hwloc_add_uname_info(struct hwloc_topology *topology __hwloc_attribute_unus
 #ifdef HAVE_UNAME
   struct utsname _utsname, *utsname;
 
+  if (!topology->levels[0][0])
+    return;
+
   if (hwloc_obj_get_info_by_name(topology->levels[0][0], "OSName"))
     /* don't annotate twice */
     return;

--- a/hwloc/topology-cuda.c
+++ b/hwloc/topology-cuda.c
@@ -81,7 +81,7 @@ hwloc_cuda_discover(struct hwloc_backend *backend)
     cuda_device->depth = (unsigned) HWLOC_TYPE_DEPTH_UNKNOWN;
     cuda_device->attr->osdev.type = HWLOC_OBJ_OSDEV_COPROC;
 
-    cuda_device->subtype = strdup("CUDA");
+    cuda_device->subtype = "CUDA";
     hwloc_obj_add_info(cuda_device, "Backend", "CUDA");
     hwloc_obj_add_info(cuda_device, "GPUVendor", "NVIDIA Corporation");
 

--- a/hwloc/topology-opencl.c
+++ b/hwloc/topology-opencl.c
@@ -88,7 +88,7 @@ hwloc_opencl_discover(struct hwloc_backend *backend)
       osdev->depth = (unsigned) HWLOC_TYPE_DEPTH_UNKNOWN;
       osdev->attr->osdev.type = HWLOC_OBJ_OSDEV_COPROC;
 
-      osdev->subtype = strdup("OpenCL");
+      osdev->subtype = "OpenCL";
       hwloc_obj_add_info(osdev, "Backend", "OpenCL");
 
       clGetDeviceInfo(device_ids[i], CL_DEVICE_TYPE, sizeof(type), &type, NULL);

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -247,7 +247,7 @@ static void fill_amd_cache(struct procinfo *infos, unsigned level, hwloc_obj_cac
 
 /* Fetch information from the processor itself thanks to cpuid and store it in
  * infos for summarize to analyze them globally */
-static void look_proc(struct hwloc_backend *backend, struct procinfo *infos, unsigned highest_cpuid, unsigned highest_ext_cpuid, unsigned *features, enum cpuid_type cpuid_type, struct cpuiddump *src_cpuiddump)
+static int look_proc(struct hwloc_backend *backend, struct procinfo *infos, unsigned highest_cpuid, unsigned highest_ext_cpuid, unsigned *features, enum cpuid_type cpuid_type, struct cpuiddump *src_cpuiddump)
 {
   struct hwloc_x86_backend_data_s *data = backend->private_data;
   unsigned eax, ebx, ecx = 0, edx;
@@ -501,6 +501,10 @@ static void look_proc(struct hwloc_backend *backend, struct procinfo *infos, uns
     }
 
     cache = infos->cache = malloc(infos->numcaches * sizeof(*infos->cache));
+    if (!cache) {
+      errno = ENOMEM;
+      return -2;
+    }
 
     for (cachenum = 0; ; cachenum++) {
       unsigned long linesize, linepart, ways, sets;
@@ -558,6 +562,10 @@ static void look_proc(struct hwloc_backend *backend, struct procinfo *infos, uns
     if (level) {
       infos->levels = level;
       infos->otherids = malloc(level * sizeof(*infos->otherids));
+      if (!infos->otherids) {
+        errno = ENOMEM;
+        return -2;
+      }
       for (level = 0; ; level++) {
 	ecx = level;
 	eax = 0x0b;
@@ -641,6 +649,8 @@ static void look_proc(struct hwloc_backend *backend, struct procinfo *infos, uns
     data->apicid_unique = 0;
   else
     hwloc_bitmap_set(data->apicid_set, infos->apicid);
+
+  return 0;
 }
 
 static void
@@ -663,12 +673,15 @@ hwloc_x86_add_cpuinfos(hwloc_obj_t obj, struct procinfo *info, int nodup)
 }
 
 /* Analyse information stored in infos, and build/annotate topology levels accordingly */
-static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int fulldiscovery)
+static int summarize(struct hwloc_backend *backend, struct procinfo *infos, int fulldiscovery)
 {
   struct hwloc_topology *topology = backend->topology;
   struct hwloc_x86_backend_data_s *data = backend->private_data;
   unsigned nbprocs = data->nbprocs;
   hwloc_bitmap_t complete_cpuset = hwloc_bitmap_alloc();
+  if (!complete_cpuset) {
+    return -2;
+  }
   unsigned i, j, l, level;
   int one = -1;
   hwloc_bitmap_t remaining_cpuset;
@@ -681,10 +694,14 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int
 
   if (one == -1) {
     hwloc_bitmap_free(complete_cpuset);
-    return;
+    return 0;
   }
 
   remaining_cpuset = hwloc_bitmap_alloc();
+  if (!remaining_cpuset) {
+    hwloc_bitmap_free(complete_cpuset);
+    return -2;
+  }
 
   /* Ideally, when fulldiscovery=0, we could add any object that doesn't exist yet.
    * But what if the x86 and the native backends disagree because one is buggy? Which one to trust?
@@ -719,6 +736,9 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int
       } else {
 	/* Annotate packages previously-existing packages */
 	hwloc_bitmap_t set = hwloc_bitmap_alloc();
+	if (!set) {
+	  return -2;
+	}
 	hwloc_bitmap_set(set, i);
 	package = hwloc_get_next_obj_covering_cpuset_by_type(topology, set, HWLOC_OBJ_PACKAGE, NULL);
 	hwloc_bitmap_free(set);
@@ -753,6 +773,9 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int
       }
 
       node_cpuset = hwloc_bitmap_alloc();
+      if (!node_cpuset) {
+        return -2;
+      }
       for (j = i; j < nbprocs; j++) {
 	if (infos[j].nodeid == (unsigned) -1) {
 	  hwloc_bitmap_clr(remaining_cpuset, j);
@@ -765,8 +788,15 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int
         }
       }
       node = hwloc_alloc_setup_object(topology, HWLOC_OBJ_NUMANODE, nodeid);
+      if (!node) {
+        return -2;
+      }
       node->cpuset = node_cpuset;
       node->nodeset = hwloc_bitmap_alloc();
+      if (!node->nodeset) {
+        hwloc_free_unlinked_object(node);
+        return -1;
+      }
       hwloc_bitmap_set(node->nodeset, nodeid);
       hwloc_debug_1arg_bitmap("os node %u has cpuset %s\n",
           nodeid, node_cpuset);
@@ -931,6 +961,9 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int
 	}
 
 	puset = hwloc_bitmap_alloc();
+	if (!puset)
+	  return -2;
+
 	hwloc_bitmap_set(puset, i);
 	cache = hwloc_get_next_obj_covering_cpuset_by_type(topology, puset, otype, NULL);
 	hwloc_bitmap_free(puset);
@@ -947,6 +980,9 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int
 	  unsigned cacheid = infos[i].cache[l].cacheid;
 	  /* Now look for others sharing it */
 	  cache_cpuset = hwloc_bitmap_alloc();
+	  if (!cache_cpuset) {
+	    return -2;
+	  }
 	  for (j = i; j < nbprocs; j++) {
 	    unsigned l2;
 	    for (l2 = 0; l2 < infos[j].numcaches; l2++) {
@@ -964,6 +1000,9 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int
 	    }
 	  }
 	  cache = hwloc_alloc_setup_object(topology, otype, -1);
+	  if (!cache) {
+	    return -2;
+	  }
 	  cache->attr->cache.depth = level;
 	  cache->attr->cache.size = infos[i].cache[l].size;
 	  cache->attr->cache.linesize = infos[i].cache[l].linesize;
@@ -984,6 +1023,7 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, int
 
   hwloc_bitmap_free(remaining_cpuset);
   hwloc_bitmap_free(complete_cpuset);
+  return 0;
 }
 
 static int
@@ -1001,11 +1041,19 @@ look_procs(struct hwloc_backend *backend, struct procinfo *infos, int fulldiscov
 
   if (!data->src_cpuiddump_path) {
     orig_cpuset = hwloc_bitmap_alloc();
-    if (get_cpubind(topology, orig_cpuset, HWLOC_CPUBIND_STRICT)) {
-      hwloc_bitmap_free(orig_cpuset);
+    if (!orig_cpuset) {
       return -1;
     }
+    int ret = get_cpubind(topology, orig_cpuset, HWLOC_CPUBIND_STRICT);
+    if (ret < 0) {
+      hwloc_bitmap_free(orig_cpuset);
+      return ret;
+    }
     set = hwloc_bitmap_alloc();
+    if (!set) {
+      errno = ENOMEM;
+      return -2;
+    }
   }
 
   for (i = 0; i < nbprocs; i++) {
@@ -1021,7 +1069,10 @@ look_procs(struct hwloc_backend *backend, struct procinfo *infos, int fulldiscov
       }
     }
 
-    look_proc(backend, &infos[i], highest_cpuid, highest_ext_cpuid, features, cpuid_type, src_cpuiddump);
+    int ret = look_proc(backend, &infos[i], highest_cpuid, highest_ext_cpuid, features, cpuid_type, src_cpuiddump);
+    if (ret < 0) {
+      return ret;
+    }
 
     if (data->src_cpuiddump_path) {
       cpuiddump_free(src_cpuiddump);
@@ -1036,8 +1087,13 @@ look_procs(struct hwloc_backend *backend, struct procinfo *infos, int fulldiscov
 
   if (!data->apicid_unique)
     fulldiscovery = 0;
-  else
-    summarize(backend, infos, fulldiscovery);
+  else {
+    int ret = summarize(backend, infos, fulldiscovery);
+    if (ret < 0) {
+      return ret;
+    }
+  }
+
   return 0;
 }
 
@@ -1202,8 +1258,7 @@ int hwloc_look_x86(struct hwloc_backend *backend, int fulldiscovery)
   if (nbprocs == 1) {
     /* only one processor, no need to bind */
     look_proc(backend, &infos[0], highest_cpuid, highest_ext_cpuid, features, cpuid_type, src_cpuiddump);
-    summarize(backend, infos, fulldiscovery);
-    ret = 0;
+    ret = summarize(backend, infos, fulldiscovery);
   }
 
 out_with_os_state:
@@ -1253,8 +1308,10 @@ hwloc_x86_discover(struct hwloc_backend *backend)
     }
 
     /* several object types were added, we can't easily complete, just do partial discovery */
-    hwloc_topology_reconnect(topology, 0);
-    ret = hwloc_look_x86(backend, 0);
+    if ((ret = hwloc_topology_reconnect(topology, 0)) < -1)
+      return ret;
+    if ((ret = hwloc_look_x86(backend, 0)) < 0)
+      return ret;
     if (ret)
       hwloc_obj_add_info(topology->levels[0][0], "Backend", "x86");
     return 0;
@@ -1395,12 +1452,20 @@ hwloc_x86_component_instantiate(struct hwloc_disc_component *component,
   /* default values */
   data->is_knl = 0;
   data->apicid_set = hwloc_bitmap_alloc();
+  if (!data->apicid_set) {
+    errno = ENOMEM;
+    goto out_with_backend;
+  }
   data->apicid_unique = 1;
   data->src_cpuiddump_path = NULL;
 
   src_cpuiddump_path = getenv("HWLOC_CPUID_PATH");
   if (src_cpuiddump_path) {
     hwloc_bitmap_t set = hwloc_bitmap_alloc();
+    if (!set) {
+      errno = ENOMEM;
+      goto out_with_backend;
+    }
     if (!hwloc_x86_check_cpuiddump_input(src_cpuiddump_path, set)) {
       backend->is_thissystem = 0;
       data->src_cpuiddump_path = strdup(src_cpuiddump_path);

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -177,7 +177,7 @@ hwloc_fallback_nbprocessors(struct hwloc_topology *topology) {
 /*
  * Use the given number of processors to set a PU level.
  */
-void
+int
 hwloc_setup_pu_level(struct hwloc_topology *topology,
 		     unsigned nb_pus)
 {
@@ -187,8 +187,12 @@ hwloc_setup_pu_level(struct hwloc_topology *topology,
   hwloc_debug("%s", "\n\n * CPU cpusets *\n\n");
   for (cpu=0,oscpu=0; cpu<nb_pus; oscpu++)
     {
-      obj = hwloc_alloc_setup_object(topology, HWLOC_OBJ_PU, oscpu);
-      obj->cpuset = hwloc_bitmap_alloc();
+      if (!(obj = hwloc_alloc_setup_object(topology, HWLOC_OBJ_PU, oscpu))) {
+        return -2;
+      }
+      if (!(obj->cpuset = hwloc_bitmap_alloc())) {
+        return -2;
+      }
       hwloc_bitmap_only(obj->cpuset, oscpu);
 
       hwloc_debug_2args_bitmap("cpu %u (os %u) has cpuset %s\n",
@@ -197,6 +201,8 @@ hwloc_setup_pu_level(struct hwloc_topology *topology,
 
       cpu++;
     }
+
+  return 0;
 }
 
 /* Traverse children of a parent */
@@ -308,7 +314,7 @@ void hwloc__free_infos(struct hwloc_obj_info_s *infos, unsigned count)
   free(infos);
 }
 
-void hwloc__add_info(struct hwloc_obj_info_s **infosp, unsigned *countp, const char *name, const char *value)
+int hwloc__add_info(struct hwloc_obj_info_s **infosp, unsigned *countp, const char *name, const char *value)
 {
   unsigned count = *countp;
   struct hwloc_obj_info_s *infos = *infosp;
@@ -319,13 +325,22 @@ void hwloc__add_info(struct hwloc_obj_info_s **infosp, unsigned *countp, const c
     struct hwloc_obj_info_s *tmpinfos = realloc(infos, alloccount*sizeof(*infos));
     if (!tmpinfos)
       /* failed to allocate, ignore this info */
-      return;
+      return 0;
     infos = tmpinfos;
   }
   infos[count].name = strdup(name);
   infos[count].value = value ? strdup(value) : NULL;
+  if (!infos[count].name || (value && !infos[count].value)) {
+    free(infos[count].name);
+    free(infos[count].value);
+    infos[count].name = NULL;
+    infos[count].value = NULL;
+    errno = ENOMEM;
+    return -2;
+  }
   *infosp = infos;
   *countp = count+1;
+  return 0;
 }
 
 char ** hwloc__find_info_slot(struct hwloc_obj_info_s **infosp, unsigned *countp, const char *name)
@@ -379,9 +394,9 @@ void hwloc__move_infos(struct hwloc_obj_info_s **dst_infosp, unsigned *dst_count
   /* dst_infos not modified */
 }
 
-void hwloc_obj_add_info(hwloc_obj_t obj, const char *name, const char *value)
+int hwloc_obj_add_info(hwloc_obj_t obj, const char *name, const char *value)
 {
-  hwloc__add_info(&obj->infos, &obj->infos_count, name, value);
+  return hwloc__add_info(&obj->infos, &obj->infos_count, name, value);
 }
 
 void hwloc_obj_add_info_nodup(hwloc_obj_t obj, const char *name, const char *value, int nodup)
@@ -1312,11 +1327,21 @@ hwloc_alloc_setup_object(hwloc_topology_t topology,
 			 hwloc_obj_type_t type, signed os_index)
 {
   struct hwloc_obj *obj = malloc(sizeof(*obj));
+  if (!obj) {
+    errno = ENOMEM;
+    return 0;
+  }
+
   memset(obj, 0, sizeof(*obj));
   obj->type = type;
   obj->os_index = os_index;
   obj->gp_index = topology->next_gp_index++;
   obj->attr = malloc(sizeof(*obj->attr));
+  if (!obj->attr) {
+    errno = ENOMEM;
+    free(obj);
+    return NULL;
+  }
   memset(obj->attr, 0, sizeof(*obj->attr));
   /* do not allocate the cpuset here, let the caller do it */
   return obj;
@@ -1568,7 +1593,7 @@ collect_proc_cpuset(hwloc_obj_t obj, hwloc_obj_t sys)
 
 /* While traversing down and up, propagate the disallowed cpus by
  * and'ing them to and from the first object that has a cpuset */
-static void
+static int
 propagate_unused_cpuset(hwloc_obj_t obj, hwloc_obj_t sys)
 {
   hwloc_obj_t child;
@@ -1577,6 +1602,8 @@ propagate_unused_cpuset(hwloc_obj_t obj, hwloc_obj_t sys)
     if (sys) {
       /* We are already given a pointer to an system object, update it and update ourselves */
       hwloc_bitmap_t mask = hwloc_bitmap_alloc();
+      if (!mask)
+        return -1;
 
       /* Apply the topology cpuset */
       hwloc_bitmap_and(obj->cpuset, obj->cpuset, sys->cpuset);
@@ -1586,7 +1613,12 @@ propagate_unused_cpuset(hwloc_obj_t obj, hwloc_obj_t sys)
 	hwloc_bitmap_and(obj->complete_cpuset, obj->complete_cpuset, sys->complete_cpuset);
       } else {
 	obj->complete_cpuset = hwloc_bitmap_dup(sys->complete_cpuset);
-	hwloc_bitmap_and(obj->complete_cpuset, obj->complete_cpuset, obj->cpuset);
+        if (obj->complete_cpuset)
+	  hwloc_bitmap_and(obj->complete_cpuset, obj->complete_cpuset, obj->cpuset);
+        else {
+          hwloc_bitmap_free(mask);
+          return -1;
+        }
       }
 
       /* Update allowed cpusets */
@@ -1602,7 +1634,12 @@ propagate_unused_cpuset(hwloc_obj_t obj, hwloc_obj_t sys)
       } else {
 	/* Just take it as such */
 	obj->allowed_cpuset = hwloc_bitmap_dup(sys->allowed_cpuset);
-	hwloc_bitmap_and(obj->allowed_cpuset, obj->allowed_cpuset, obj->cpuset);
+        if (obj->allowed_cpuset)
+	  hwloc_bitmap_and(obj->allowed_cpuset, obj->allowed_cpuset, obj->cpuset);
+        else {
+          hwloc_bitmap_free(mask);
+          return -1;
+        }
       }
 
       hwloc_bitmap_free(mask);
@@ -1622,9 +1659,14 @@ propagate_unused_cpuset(hwloc_obj_t obj, hwloc_obj_t sys)
     }
   }
 
-  for_each_child(child, obj)
-    propagate_unused_cpuset(child, sys);
+  for_each_child(child, obj) {
+    int ret = propagate_unused_cpuset(child, sys);
+    if (ret < 0)
+      return ret;
+  }
   /* No PU under I/O or Misc */
+  
+  return 0;
 }
 
 /* Setup object cpusets/nodesets by OR'ing its children. */
@@ -1660,7 +1702,7 @@ hwloc_obj_add_children_sets(hwloc_obj_t obj)
 }
 
 /* Propagate nodesets up and down */
-static void
+static int
 propagate_nodeset(hwloc_obj_t obj, hwloc_obj_t sys)
 {
   hwloc_obj_t child;
@@ -1669,10 +1711,19 @@ propagate_nodeset(hwloc_obj_t obj, hwloc_obj_t sys)
 
   if (!sys && obj->nodeset) {
     sys = obj;
-    if (!obj->complete_nodeset)
+    if (!obj->complete_nodeset) {
       obj->complete_nodeset = hwloc_bitmap_dup(obj->nodeset);
-    if (!obj->allowed_nodeset)
+      if (!obj->complete_nodeset) {
+        return -2;
+      }
+    }
+    
+    if (!obj->allowed_nodeset) {
       obj->allowed_nodeset = hwloc_bitmap_dup(obj->nodeset);
+      if (!obj->allowed_nodeset) {
+        return -2;
+      }
+    }
   }
 
   if (sys) {
@@ -1680,15 +1731,23 @@ propagate_nodeset(hwloc_obj_t obj, hwloc_obj_t sys)
       /* Some existing nodeset coming from above, to possibly propagate down */
       parent_nodeset = obj->nodeset;
       parent_weight = hwloc_bitmap_weight(parent_nodeset);
-    } else
+    } else {
       obj->nodeset = hwloc_bitmap_alloc();
+      if (!obj->nodeset) {
+        return -2;
+      }
+    }
   }
 
   for_each_child(child, obj) {
     /* Propagate singleton nodesets down */
     if (parent_weight == 1) {
-      if (!child->nodeset)
+      if (!child->nodeset) {
         child->nodeset = hwloc_bitmap_dup(obj->nodeset);
+        if (!child->nodeset) {
+          return -2;
+        }
+      }
       else if (!hwloc_bitmap_isequal(child->nodeset, parent_nodeset)) {
         hwloc_debug_bitmap("Oops, parent nodeset %s", parent_nodeset);
         hwloc_debug_bitmap(" is different from child nodeset %s, ignoring the child one\n", child->nodeset);
@@ -1697,21 +1756,28 @@ propagate_nodeset(hwloc_obj_t obj, hwloc_obj_t sys)
     }
 
     /* Recurse */
-    propagate_nodeset(child, sys);
+    int ret = propagate_nodeset(child, sys);
+    if (ret < 0)
+      return ret;
 
     /* Propagate children nodesets up */
     if (sys && child->nodeset)
       hwloc_bitmap_or(obj->nodeset, obj->nodeset, child->nodeset);
   }
   /* No nodeset under I/O or Misc */
+  return 0;
 }
 
 /* Propagate allowed and complete nodesets */
-static void
+static int
 propagate_nodesets(hwloc_obj_t obj)
 {
   hwloc_bitmap_t mask = hwloc_bitmap_alloc();
   hwloc_obj_t child;
+
+  if (!mask) {
+    return -2;
+  }
 
   for_each_child(child, obj) {
     if (obj->nodeset) {
@@ -1720,6 +1786,8 @@ propagate_nodesets(hwloc_obj_t obj)
         hwloc_bitmap_and(child->complete_nodeset, child->complete_nodeset, obj->complete_nodeset);
       } else if (child->nodeset) {
         child->complete_nodeset = hwloc_bitmap_dup(obj->complete_nodeset);
+        if (!child->complete_nodeset)
+          return -2;
         hwloc_bitmap_and(child->complete_nodeset, child->complete_nodeset, child->nodeset);
       } /* else the child doesn't have nodeset information, we can not provide a complete nodeset */
 
@@ -1728,11 +1796,16 @@ propagate_nodesets(hwloc_obj_t obj)
         hwloc_bitmap_and(child->allowed_nodeset, child->allowed_nodeset, obj->allowed_nodeset);
       } else if (child->nodeset) {
         child->allowed_nodeset = hwloc_bitmap_dup(obj->allowed_nodeset);
+        if (!child->allowed_nodeset)
+          return -2;
+
         hwloc_bitmap_and(child->allowed_nodeset, child->allowed_nodeset, child->nodeset);
       }
     }
 
-    propagate_nodesets(child);
+    int ret = propagate_nodesets(child);
+    if (ret < 0)
+      return ret;
 
     if (obj->nodeset) {
       /* Update allowed nodesets up */
@@ -1750,13 +1823,20 @@ propagate_nodesets(hwloc_obj_t obj)
     /* Apply complete nodeset to nodeset and allowed_nodeset */
     if (obj->complete_nodeset)
       hwloc_bitmap_and(obj->nodeset, obj->nodeset, obj->complete_nodeset);
-    else
+    else {
       obj->complete_nodeset = hwloc_bitmap_dup(obj->nodeset);
+      if (!obj->complete_nodeset)
+        return -2;
+    }
     if (obj->allowed_nodeset)
       hwloc_bitmap_and(obj->allowed_nodeset, obj->allowed_nodeset, obj->complete_nodeset);
-    else
+    else {
       obj->allowed_nodeset = hwloc_bitmap_dup(obj->nodeset);
+      if (!obj->allowed_nodeset)
+        return -2;
+    }
   }
+  return 0;
 }
 
 static void
@@ -2060,6 +2140,10 @@ hwloc_propagate_symmetric_subtree(hwloc_topology_t topology, hwloc_obj_t root)
    * just walk down the first child in each tree and compare their depth and arities
    */
   array = malloc(root->arity * sizeof(*array));
+  if (!array) {
+    errno = ENOMEM;
+    return;
+  }
   memcpy(array, root->children, root->arity * sizeof(*array));
   while (1) {
     unsigned i;
@@ -2104,7 +2188,7 @@ static void hwloc_set_group_depth(hwloc_topology_t topology)
  *
  * Can be called several times, so may have to update the array.
  */
-static void
+static int
 hwloc_connect_children(hwloc_obj_t parent)
 {
   unsigned n, oldn = parent->arity;
@@ -2124,7 +2208,10 @@ hwloc_connect_children(hwloc_obj_t parent)
     if (n >= oldn || parent->children[n] != child)
       ok = 0;
     /* recurse */
-    hwloc_connect_children(child);
+
+    int ret = hwloc_connect_children(child);
+    if (ret < 0)
+      return ret;
   }
   parent->last_child = prev_child;
   parent->arity = n;
@@ -2142,6 +2229,10 @@ hwloc_connect_children(hwloc_obj_t parent)
   if (oldn < n) {
     free(parent->children);
     parent->children = malloc(n * sizeof(*parent->children));
+    if (!parent->children) {
+      errno = ENOMEM;
+      return -2;
+    }
   }
   /* refill */
   for (n = 0, child = parent->first_child;
@@ -2160,7 +2251,9 @@ hwloc_connect_children(hwloc_obj_t parent)
     child->parent = parent;
     child->sibling_rank = n;
     child->prev_sibling = prev_child;
-    hwloc_connect_children(child);
+    int ret = hwloc_connect_children(child);
+    if (ret < 0)
+      return ret;
   }
   parent->io_arity = n;
 
@@ -2173,9 +2266,14 @@ hwloc_connect_children(hwloc_obj_t parent)
     child->parent = parent;
     child->sibling_rank = n;
     child->prev_sibling = prev_child;
-    hwloc_connect_children(child);
+
+    int ret = hwloc_connect_children(child);
+    if (ret < 0)
+      return ret;
   }
   parent->misc_arity = n;
+
+  return 0;
 }
 
 /*
@@ -2425,9 +2523,21 @@ hwloc_connect_levels(hwloc_topology_t topology)
 
     /* New level.  */
     taken_objs = malloc((n_taken_objs + 1) * sizeof(taken_objs[0]));
+    if (!taken_objs) {
+      free(objs);
+      errno = ENOMEM;
+      return -2;
+    }
+
     /* New list of pending objects.  */
     if (n_objs - n_taken_objs + n_new_objs) {
       new_objs = malloc((n_objs - n_taken_objs + n_new_objs) * sizeof(new_objs[0]));
+      if (!new_objs) {
+        free(objs);
+        free(taken_objs);
+        errno = ENOMEM;
+        return -2;
+      }
     } else {
 #ifdef HWLOC_DEBUG
       assert(!n_new_objs);
@@ -2485,7 +2595,7 @@ hwloc_connect_levels(hwloc_topology_t topology)
 	free(taken_objs);
 	free(new_objs);
 	errno = ENOMEM;
-	return -1;
+	return -2;
       }
       topology->levels = tmplevels;
       topology->level_nbobjects = tmpnbobjs;
@@ -2524,10 +2634,13 @@ hwloc_topology_reconnect(struct hwloc_topology *topology, unsigned long flags)
   if (!topology->modified)
     return 0;
 
-  hwloc_connect_children(topology->levels[0][0]);
+  int ret = hwloc_connect_children(topology->levels[0][0]);
+  if (ret < -1)
+      return ret;
 
-  if (hwloc_connect_levels(topology) < 0)
-    return -1;
+  ret = hwloc_connect_levels(topology);
+  if (ret < 0)
+    return ret;
 
   hwloc_connect_io_misc_levels(topology);
 
@@ -2536,7 +2649,8 @@ hwloc_topology_reconnect(struct hwloc_topology *topology, unsigned long flags)
   return 0;
 }
 
-void hwloc_alloc_obj_cpusets(hwloc_obj_t obj)
+int
+hwloc_alloc_obj_cpusets(hwloc_obj_t obj)
 {
   if (!obj->cpuset)
     obj->cpuset = hwloc_bitmap_alloc_full();
@@ -2550,6 +2664,14 @@ void hwloc_alloc_obj_cpusets(hwloc_obj_t obj)
     obj->complete_nodeset = hwloc_bitmap_alloc();
   if (!obj->allowed_nodeset)
     obj->allowed_nodeset = hwloc_bitmap_alloc_full();
+  
+  if (!obj->cpuset || !obj->complete_cpuset || !obj->allowed_cpuset 
+    || !obj->nodeset || !obj->complete_nodeset || !obj->allowed_nodeset) {
+    errno = ENOMEM;
+    return -2;
+  }
+
+  return 0;
 }
 
 /* Main discovery loop */
@@ -2606,7 +2728,9 @@ hwloc_discover(struct hwloc_topology *topology)
       goto next_cpubackend;
     if (!backend->discover)
       goto next_cpubackend;
-    backend->discover(backend);
+    if (backend->discover(backend) < -1)
+      return -1;
+
     hwloc_debug_print_objects(0, topology->levels[0][0]);
 
 next_cpubackend:
@@ -2634,7 +2758,8 @@ next_cpubackend:
   }
   hwloc_debug("%s", "\nPropagate disallowed cpus down and up\n");
   hwloc_bitmap_and(topology->levels[0][0]->allowed_cpuset, topology->levels[0][0]->allowed_cpuset, topology->levels[0][0]->cpuset);
-  propagate_unused_cpuset(topology->levels[0][0], NULL);
+  if (propagate_unused_cpuset(topology->levels[0][0], NULL) < 0)
+    return -1;
 
   /* Backends must allocate root->*nodeset.
    *
@@ -2652,10 +2777,20 @@ next_cpubackend:
   /* If there's no NUMA node, add one with all the memory */
   if (hwloc_bitmap_iszero(topology->levels[0][0]->complete_nodeset)) {
     hwloc_obj_t node = hwloc_alloc_setup_object(topology, HWLOC_OBJ_NUMANODE, 0);
+    if (!node) {
+      return -2;
+    }
     node->cpuset = hwloc_bitmap_dup(topology->levels[0][0]->cpuset); /* requires root cpuset to be initialized above */
     node->complete_cpuset = hwloc_bitmap_dup(topology->levels[0][0]->complete_cpuset); /* requires root cpuset to be initialized above */
     node->allowed_cpuset = hwloc_bitmap_dup(topology->levels[0][0]->allowed_cpuset); /* requires root cpuset to be initialized above */
     node->nodeset = hwloc_bitmap_alloc();
+    if (!node->cpuset || !node->complete_cpuset || !node->allowed_cpuset || !node->nodeset) {
+      hwloc_bitmap_free(node->cpuset);
+      hwloc_bitmap_free(node->complete_cpuset);
+      hwloc_bitmap_free(node->allowed_cpuset);
+      free(node);
+      return -2;
+    }
     /* other nodesets will be filled below */
     hwloc_bitmap_set(node->nodeset, 0);
     memcpy(&node->memory, &topology->levels[0][0]->memory, sizeof(node->memory));
@@ -2663,8 +2798,12 @@ next_cpubackend:
     hwloc_insert_object_by_cpuset(topology, node);
   }
   hwloc_debug("%s", "\nPropagate nodesets\n");
-  propagate_nodeset(topology->levels[0][0], NULL);
-  propagate_nodesets(topology->levels[0][0]);
+  int ret = propagate_nodeset(topology->levels[0][0], NULL);
+  if (ret < 0)
+    return ret;
+  ret = propagate_nodesets(topology->levels[0][0]);
+  if (ret < 0)
+    return ret;
 
   hwloc_debug_print_objects(0, topology->levels[0][0]);
 
@@ -2780,7 +2919,7 @@ next_noncpubackend:
 /* To be called before discovery is actually launched,
  * Resets everything in case a previous load initialized some stuff.
  */
-void
+int
 hwloc_topology_setup_defaults(struct hwloc_topology *topology)
 {
   struct hwloc_obj *root_obj;
@@ -2818,8 +2957,17 @@ hwloc_topology_setup_defaults(struct hwloc_topology *topology)
    * since the OS backend may still change the object into something else
    * (for instance System)
    */
+  if (!topology->levels[0]) {
+    return -1;
+  }
   root_obj = hwloc_alloc_setup_object(topology, HWLOC_OBJ_MACHINE, 0);
+  if (!root_obj) {
+    free(topology->levels[0]);
+    topology->levels[0] = NULL;
+    return -1;
+  }
   topology->levels[0][0] = root_obj;
+  return 0;
 }
 
 static void hwloc__topology_filter_init(struct hwloc_topology *topology);
@@ -2830,8 +2978,10 @@ hwloc_topology_init (struct hwloc_topology **topologyp)
   struct hwloc_topology *topology;
 
   topology = malloc (sizeof (struct hwloc_topology));
-  if(!topology)
+  if (!topology) {
+    errno = ENOMEM;
     return -1;
+  }
 
   hwloc_components_init();
   hwloc_backends_init(topology);
@@ -2851,6 +3001,13 @@ hwloc_topology_init (struct hwloc_topology **topologyp)
   topology->nb_levels_allocated = 16; /* enough for default 9 levels = Mach+Pack+NUMA+L3+L2+L1d+L1i+Co+PU */
   topology->levels = calloc(topology->nb_levels_allocated, sizeof(*topology->levels));
   topology->level_nbobjects = calloc(topology->nb_levels_allocated, sizeof(*topology->level_nbobjects));
+  if (!topology->support.discovery || !topology->support.cpubind || !topology->support.membind || !topology->levels || !topology->level_nbobjects) {
+    topology->first_dist = 0;
+    topology->nb_levels = 0;
+    memset(topology->slevels, 0, sizeof(topology->slevels));
+    hwloc_topology_destroy(topology);
+    return -1;
+  }
 
   hwloc__topology_filter_init(topology);
 
@@ -2861,7 +3018,11 @@ hwloc_topology_init (struct hwloc_topology **topologyp)
   topology->userdata_not_decoded = 0;
 
   /* Make the topology look like something coherent but empty */
-  hwloc_topology_setup_defaults(topology);
+  int ret = hwloc_topology_setup_defaults(topology);
+  if (ret < 0) {
+    hwloc_topology_destroy(topology);
+    return -1;
+  }
 
   *topologyp = topology;
   return 0;
@@ -3047,9 +3208,12 @@ hwloc_topology_clear (struct hwloc_topology *topology)
   /* no need to set to NULL after free() since callers will call setup_defaults() or just destroy the rest of the topology */
   unsigned l;
   hwloc_internal_distances_destroy(topology);
-  hwloc_free_object_and_children(topology->levels[0][0]);
-  for (l=0; l<topology->nb_levels; l++)
-    free(topology->levels[l]);
+  if (topology->levels && topology->levels[0] && topology->levels[0][0])
+    hwloc_free_object_and_children(topology->levels[0][0]);
+  if (topology->nb_levels) {
+    for (l=0; l<topology->nb_levels; l++)
+      free(topology->levels[l]);
+  }
   for(l=0; l<HWLOC_NR_SLEVELS; l++)
     free(topology->slevels[l].objs);
 }
@@ -3130,7 +3294,9 @@ hwloc_topology_load (struct hwloc_topology *topology)
   }
 
   /* instantiate all possible other backends now */
-  hwloc_disc_components_enable_others(topology);
+  err = hwloc_disc_components_enable_others(topology);
+  if (err < -1)
+    return -1;
   /* now that backends are enabled, update the thissystem flag and some callbacks */
   hwloc_backends_is_thissystem(topology);
   hwloc_backends_find_callbacks(topology);

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -935,7 +935,7 @@ hwloc_obj_get_info_by_name(hwloc_obj_t obj, const char *name) __hwloc_attribute_
  * \note If \p value contains some non-printable characters, they will
  * be dropped when exporting to XML, see hwloc_topology_export_xml() in hwloc/export.h.
  */
-HWLOC_DECLSPEC void hwloc_obj_add_info(hwloc_obj_t obj, const char *name, const char *value);
+HWLOC_DECLSPEC int hwloc_obj_add_info(hwloc_obj_t obj, const char *name, const char *value);
 
 /** @} */
 

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -356,7 +356,7 @@ struct hwloc_obj_memory_s {
 struct hwloc_obj {
   /* physical information */
   hwloc_obj_type_t type;		/**< \brief Type of object */
-  char *subtype;			/**< \brief Subtype string to better describe the type field. */
+  const char *subtype;			/**< \brief Subtype string to better describe the type field. */
 
   unsigned os_index;			/**< \brief OS-provided physical index number.
 					 * It is not guaranteed unique across the entire machine,
@@ -579,8 +579,8 @@ union hwloc_obj_attr_u {
  * \sa hwlocality_info_attr
  */
 struct hwloc_obj_info_s {
-  char *name;	/**< \brief Info name */
-  char *value;	/**< \brief Info value */
+  const char *name;	/**< \brief Info name */
+  const char *value;	/**< \brief Info value */
 };
 
 /** @} */

--- a/include/hwloc/inlines.h
+++ b/include/hwloc/inlines.h
@@ -111,13 +111,9 @@ static __hwloc_inline const char *
 hwloc_obj_get_info_by_name(hwloc_obj_t obj, const char *name)
 {
   unsigned i;
-  for(i=0; i<obj->infos_count; i++) {
-    if (!obj->infos[i].name)
-      return NULL;
-
+  for(i=0; i<obj->infos_count; i++)
     if (!strcmp(obj->infos[i].name, name))
       return obj->infos[i].value;
-  }
   return NULL;
 }
 

--- a/include/hwloc/inlines.h
+++ b/include/hwloc/inlines.h
@@ -111,9 +111,13 @@ static __hwloc_inline const char *
 hwloc_obj_get_info_by_name(hwloc_obj_t obj, const char *name)
 {
   unsigned i;
-  for(i=0; i<obj->infos_count; i++)
+  for(i=0; i<obj->infos_count; i++) {
+    if (!obj->infos[i].name)
+      return NULL;
+
     if (!strcmp(obj->infos[i].name, name))
       return obj->infos[i].value;
+  }
   return NULL;
 }
 

--- a/include/private/components.h
+++ b/include/private/components.h
@@ -24,7 +24,7 @@ extern int hwloc_disc_component_force_enable(struct hwloc_topology *topology,
 					     int envvar_forced, /* 1 if forced through envvar, 0 if forced through API */
 					     int type, const char *name,
 					     const void *data1, const void *data2, const void *data3);
-extern void hwloc_disc_components_enable_others(struct hwloc_topology *topology);
+extern int hwloc_disc_components_enable_others(struct hwloc_topology *topology);
 
 /* Compute the topology is_thissystem flag and find some callbacks based on enabled backends */
 extern void hwloc_backends_is_thissystem(struct hwloc_topology *topology);

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -148,8 +148,8 @@ struct hwloc_topology {
   unsigned backend_excludes;
 };
 
-extern void hwloc_alloc_obj_cpusets(hwloc_obj_t obj);
-extern void hwloc_setup_pu_level(struct hwloc_topology *topology, unsigned nb_pus);
+extern int hwloc_alloc_obj_cpusets(hwloc_obj_t obj);
+extern int hwloc_setup_pu_level(struct hwloc_topology *topology, unsigned nb_pus);
 extern int hwloc_get_sysctlbyname(const char *name, int64_t *n);
 extern int hwloc_get_sysctl(int name[], unsigned namelen, int *n);
 extern unsigned hwloc_fallback_nbprocessors(struct hwloc_topology *topology);
@@ -157,7 +157,7 @@ extern unsigned hwloc_fallback_nbprocessors(struct hwloc_topology *topology);
 extern int hwloc__object_cpusets_compare_first(hwloc_obj_t obj1, hwloc_obj_t obj2);
 extern void hwloc__reorder_children(hwloc_obj_t parent);
 
-extern void hwloc_topology_setup_defaults(struct hwloc_topology *topology);
+extern int hwloc_topology_setup_defaults(struct hwloc_topology *topology);
 extern void hwloc_topology_clear(struct hwloc_topology *topology);
 
 extern void hwloc_pci_discovery_init(struct hwloc_topology *topology);
@@ -179,7 +179,7 @@ extern int hwloc_pci_belowroot_apply_locality(struct hwloc_topology *topology);
 
 HWLOC_DECLSPEC extern const char * hwloc_pci_class_string(unsigned short class_id);
 
-extern void hwloc__add_info(struct hwloc_obj_info_s **infosp, unsigned *countp, const char *name, const char *value);
+extern int hwloc__add_info(struct hwloc_obj_info_s **infosp, unsigned *countp, const char *name, const char *value);
 extern char ** hwloc__find_info_slot(struct hwloc_obj_info_s **infosp, unsigned *countp, const char *name);
 extern void hwloc__move_infos(struct hwloc_obj_info_s **dst_infosp, unsigned *dst_countp, struct hwloc_obj_info_s **src_infosp, unsigned *src_countp);
 extern void hwloc__free_infos(struct hwloc_obj_info_s *infos, unsigned count);

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -180,9 +180,9 @@ extern int hwloc_pci_belowroot_apply_locality(struct hwloc_topology *topology);
 HWLOC_DECLSPEC extern const char * hwloc_pci_class_string(unsigned short class_id);
 
 extern int hwloc__add_info(struct hwloc_obj_info_s **infosp, unsigned *countp, const char *name, const char *value);
-extern char ** hwloc__find_info_slot(struct hwloc_obj_info_s **infosp, unsigned *countp, const char *name);
+extern const char ** hwloc__find_info_slot(struct hwloc_obj_info_s **infosp, unsigned *countp, const char *name);
 extern void hwloc__move_infos(struct hwloc_obj_info_s **dst_infosp, unsigned *dst_countp, struct hwloc_obj_info_s **src_infosp, unsigned *src_countp);
-extern void hwloc__free_infos(struct hwloc_obj_info_s *infos, unsigned count);
+extern void hwloc__free_infos(struct hwloc_obj_info_s *infos);
 
 /* set native OS binding hooks */
 extern void hwloc_set_native_binding_hooks(struct hwloc_binding_hooks *hooks, struct hwloc_topology_support *support);

--- a/utils/hwloc/hwloc-annotate.c
+++ b/utils/hwloc/hwloc-annotate.c
@@ -46,10 +46,6 @@ static void apply(hwloc_topology_t topology, hwloc_obj_t obj)
 	unsigned i,j;
 	if (clearinfos) {
 		/* this may be considered dangerous, applications should not modify objects directly */
-		for(i=0; i<obj->infos_count; i++) {
-			free(obj->infos[i].name);
-			free(obj->infos[i].value);
-		}
 		free(obj->infos);
 		obj->infos = NULL;
 		obj->infos_count = 0;
@@ -63,8 +59,6 @@ static void apply(hwloc_topology_t topology, hwloc_obj_t obj)
 			for(i=0, j=0; i<obj->infos_count; i++) {
 				if (!strcmp(infoname, obj->infos[i].name)) {
 					/* remove info */
-					free(obj->infos[i].name);
-					free(obj->infos[i].value);
 					obj->infos[i].name = NULL;
 				} else {
 					if (i != j) {

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -86,7 +86,7 @@ static hwloc_obj_t insert_task(hwloc_topology_t topology, hwloc_cpuset_t cpuset,
   if (!obj)
     fprintf(stderr, "Failed to insert process `%s'\n", name);
   else
-    obj->subtype = strdup("Process");
+    obj->subtype = "Process";
 
   return obj;
 }


### PR DESCRIPTION
This pull request is a successor of a previous one: #247. Current set of changes fixes more problems. Current test which performs 200000 (or more) iterations of hwloc_topology_init/hwloc_topology_destroy does not crash and does not leak. Memory allocations are failed randomly during the test execution. Please review made changes when you have time.