### PR TITLE
always insert OpenCL osdev even when we cannot find their locality

### DIFF
--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2017 Inria.  All rights reserved.
+ * Copyright © 2009-2018 Inria.  All rights reserved.
  * Copyright © 2009-2013 Université Bordeaux
  * Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
@@ -2111,11 +2111,8 @@ For reference, ::hwloc_topology_t modification operations include
   objects inside the tree, changing the topology depth, etc.
 
   <tt>hwloc_distances_add()</tt> and <tt>hwloc_distances_remove()</tt>
-  (see \ref hwlocality_distances_get) modify the list of distance structures
+  (see \ref hwlocality_distances_add) modify the list of distance structures
   in the topology, and the former may even insert new Group objects.
-  <tt>hwloc_distances_get()</tt> and its variant may also modify
-  internal distance structures to refresh according to previous
-  topology changes (if some objects were previously removed).
 
   <tt>hwloc_topology_restrict()</tt> modifies the topology even more
   dramatically by removing some objects.
@@ -2124,6 +2121,20 @@ For reference, ::hwloc_topology_t modification operations include
   after insertion or restriction, it is strongly advised to not rely on any such
   guarantee and always re-consult the topology to reacquire new
   instances of objects.  </dd>
+
+<dt>Consulting distances</dt>
+  <dd>
+  <tt>hwloc_distances_get()</tt> and its variants are thread-safe
+  except if the topology was recently modified
+  (because distances may involve objects that were removed).
+
+  Whenever the topology is modified (see above), one dummy (but valid)
+  <tt>hwloc_distances_get()</tt> call should be performed in the same
+  thread-safe context to force the refresh of internal distances structures.
+
+  Once this refresh has been performed, multiple <tt>hwloc_distances_get()</tt>
+  may then be performed concurrently by multiple threads.
+  </dd>
 
 <dt>Locating topologies</dt>
 

--- a/hwloc/distances.c
+++ b/hwloc/distances.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2010-2017 Inria.  All rights reserved.
+ * Copyright © 2010-2018 Inria.  All rights reserved.
  * Copyright © 2011-2012 Université Bordeaux
  * Copyright © 2011 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
@@ -590,6 +590,11 @@ hwloc__distances_get(hwloc_topology_t topology,
 
   /* we could refresh only the distances that match, but we won't have many distances anyway,
    * so performance is totally negligible.
+   *
+   * This is also useful in multithreaded apps that modify the topology.
+   * They can call any valid hwloc_distances_get() to force a refresh after
+   * changing the topology, so that future concurrent get() won't cause
+   * concurrent refresh().
    */
   hwloc_internal_distances_refresh(topology);
 

--- a/hwloc/topology-opencl.c
+++ b/hwloc/topology-opencl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2017 Inria.  All rights reserved.
+ * Copyright © 2012-2018 Inria.  All rights reserved.
  * Copyright © 2013 Université Bordeaux.  All right reserved.
  * See COPYING in top-level directory.
  */
@@ -104,10 +104,10 @@ hwloc_opencl_discover(struct hwloc_backend *backend)
 
       buffer[0] = '\0';
 #ifdef CL_DEVICE_BOARD_NAME_AMD
-      clGetDeviceInfo(device_ids[i], CL_DEVICE_BOARD_NAME_AMD, sizeof(buffer), buffer, NULL);
-#else
-      clGetDeviceInfo(device_ids[i], CL_DEVICE_NAME, sizeof(buffer), buffer, NULL);
+      clret = clGetDeviceInfo(device_ids[i], CL_DEVICE_BOARD_NAME_AMD, sizeof(buffer), buffer, NULL);
+      if (CL_SUCCESS != clret || buffer[0] == '\0')
 #endif
+        clGetDeviceInfo(device_ids[i], CL_DEVICE_NAME, sizeof(buffer), buffer, NULL);
       if (buffer[0] != '\0')
 	hwloc_obj_add_info(osdev, "GPUModel", buffer);
 

--- a/hwloc/topology-opencl.c
+++ b/hwloc/topology-opencl.c
@@ -63,6 +63,11 @@ hwloc_opencl_discover(struct hwloc_backend *backend)
 
       hwloc_debug("This is opencl%ud%u\n", j, i);
 
+      clGetDeviceInfo(device_ids[i], CL_DEVICE_TYPE, sizeof(type), &type, NULL);
+      if (type == CL_DEVICE_TYPE_CPU)
+	/* we don't want CPU opencl devices */
+	continue;
+
       osdev = hwloc_alloc_setup_object(topology, HWLOC_OBJ_OS_DEVICE, HWLOC_UNKNOWN_INDEX);
       snprintf(buffer, sizeof(buffer), "opencl%ud%u", j, i);
       osdev->name = strdup(buffer);
@@ -72,13 +77,10 @@ hwloc_opencl_discover(struct hwloc_backend *backend)
       osdev->subtype = strdup("OpenCL");
       hwloc_obj_add_info(osdev, "Backend", "OpenCL");
 
-      clGetDeviceInfo(device_ids[i], CL_DEVICE_TYPE, sizeof(type), &type, NULL);
       if (type == CL_DEVICE_TYPE_GPU)
 	hwloc_obj_add_info(osdev, "OpenCLDeviceType", "GPU");
       else if (type == CL_DEVICE_TYPE_ACCELERATOR)
 	hwloc_obj_add_info(osdev, "OpenCLDeviceType", "Accelerator");
-      else if (type == CL_DEVICE_TYPE_CPU)
-	hwloc_obj_add_info(osdev, "OpenCLDeviceType", "CPU");
       else if (type == CL_DEVICE_TYPE_CUSTOM)
 	hwloc_obj_add_info(osdev, "OpenCLDeviceType", "Custom");
       else

--- a/hwloc/topology-opencl.c
+++ b/hwloc/topology-opencl.c
@@ -63,19 +63,6 @@ hwloc_opencl_discover(struct hwloc_backend *backend)
 
       hwloc_debug("This is opencl%ud%u\n", j, i);
 
-#ifdef CL_DEVICE_TOPOLOGY_AMD
-      clret = clGetDeviceInfo(device_ids[i], CL_DEVICE_TOPOLOGY_AMD, sizeof(amdtopo), &amdtopo, NULL);
-      if (CL_SUCCESS != clret) {
-	hwloc_debug("no AMD-specific device information: %d\n", clret);
-	continue;
-      } else if (CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD != amdtopo.raw.type) {
-	hwloc_debug("AMD-specific device topology reports non-PCIe device type: %u\n", amdtopo.raw.type);
-	continue;
-      }
-#else
-      continue;
-#endif
-
       osdev = hwloc_alloc_setup_object(topology, HWLOC_OBJ_OS_DEVICE, HWLOC_UNKNOWN_INDEX);
       snprintf(buffer, sizeof(buffer), "opencl%ud%u", j, i);
       osdev->name = strdup(buffer);
@@ -135,9 +122,18 @@ hwloc_opencl_discover(struct hwloc_backend *backend)
 
       parent = NULL;
 #ifdef CL_DEVICE_TOPOLOGY_AMD
-      parent = hwloc_pcidisc_find_by_busid(topology, 0, (unsigned)amdtopo.pcie.bus, (unsigned)amdtopo.pcie.device, (unsigned)amdtopo.pcie.function);
-      if (!parent)
-	parent = hwloc_pcidisc_find_busid_parent(topology, 0, (unsigned)amdtopo.pcie.bus, (unsigned)amdtopo.pcie.device, (unsigned)amdtopo.pcie.function);
+      clret = clGetDeviceInfo(device_ids[i], CL_DEVICE_TOPOLOGY_AMD, sizeof(amdtopo), &amdtopo, NULL);
+      if (CL_SUCCESS != clret) {
+	hwloc_debug("no AMD-specific device information: %d\n", clret);
+      } else if (CL_DEVICE_TOPOLOGY_TYPE_PCIE_AMD != amdtopo.raw.type) {
+	hwloc_debug("AMD-specific device topology reports non-PCIe device type: %u\n", amdtopo.raw.type);
+      } else {
+	parent = hwloc_pcidisc_find_by_busid(topology, 0, (unsigned)amdtopo.pcie.bus, (unsigned)amdtopo.pcie.device, (unsigned)amdtopo.pcie.function);
+	if (!parent)
+	  parent = hwloc_pcidisc_find_busid_parent(topology, 0, (unsigned)amdtopo.pcie.bus, (unsigned)amdtopo.pcie.device, (unsigned)amdtopo.pcie.function);
+      }
+#else
+      hwloc_debug("No locality information found.\n");
 #endif
       if (!parent)
 	parent = hwloc_get_root_obj(topology);

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -3620,9 +3620,12 @@ hwloc_topology_load (struct hwloc_topology *topology)
   /* Mark distances objs arrays as invalid since we may have removed objects
    * from the topology after adding the distances (remove_empty, etc).
    * It would be hard to actually verify whether it's needed.
-   * We'll refresh them if users ever actually look at distances.
    */
   hwloc_internal_distances_invalidate_cached_objs(topology);
+  /* And refresh distances so that multithreaded concurrent distances_get()
+   * don't refresh() concurrently (disallowed).
+   */
+  hwloc_internal_distances_refresh(topology);
 
   topology->is_loaded = 1;
   return 0;

--- a/include/hwloc/opencl.h
+++ b/include/hwloc/opencl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2017 Inria.  All rights reserved.
+ * Copyright © 2012-2018 Inria.  All rights reserved.
  * Copyright © 2013 Université Bordeaux.  All right reserved.
  * See COPYING in top-level directory.
  */
@@ -130,10 +130,15 @@ hwloc_opencl_get_device_osdev_by_index(hwloc_topology_t topology,
         return NULL;
 }
 
-/** \brief Get the hwloc OS device object corresponding to OpenCL device \p device.
+/** \brief Get the hwloc OS device object corresponding to OpenCL device \p deviceX.
  *
- * Return the hwloc OS device object that describes the given
- * OpenCL device \p device. Return NULL if there is none.
+ * Use OpenCL device attributes to find the corresponding hwloc OS device object.
+ * Return NULL if there is none or if useful attributes are not available.
+ *
+ * This function currently only works on AMD OpenCL devices that support
+ * the CL_DEVICE_TOPOLOGY_AMD extension. hwloc_opencl_get_device_osdev_by_index()
+ * should be preferred whenever possible, i.e. when platform and device index
+ * are known.
  *
  * Topology \p topology and device \p device must match the local machine.
  * I/O devices detection and the OpenCL component must be enabled in the topology.

--- a/tests/hwloc/cuda.c
+++ b/tests/hwloc/cuda.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2010-2015 Inria.  All rights reserved.
+ * Copyright © 2010-2018 Inria.  All rights reserved.
  * Copyright © 2011 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
  */
@@ -66,7 +66,8 @@ int main(void)
 
     assert(osdev->attr->osdev.type == HWLOC_OBJ_OSDEV_COPROC);
 
-    value = hwloc_obj_get_info_by_name(osdev, "CoProcType");
+    value = osdev->subtype;
+    assert(value);
     err = strcmp(value, "CUDA");
     assert(!err);
 

--- a/tests/hwloc/cudart.c
+++ b/tests/hwloc/cudart.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2010-2015 Inria.  All rights reserved.
+ * Copyright © 2010-2018 Inria.  All rights reserved.
  * Copyright © 2011 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
  */
@@ -51,7 +51,8 @@ int main(void)
 
     assert(osdev->attr->osdev.type == HWLOC_OBJ_OSDEV_COPROC);
 
-    value = hwloc_obj_get_info_by_name(osdev, "CoProcType");
+    value = osdev->subtype;
+    assert(value);
     err = strcmp(value, "CUDA");
     assert(!err);
 

--- a/tests/hwloc/intel-mic.c
+++ b/tests/hwloc/intel-mic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013-2015 Inria.  All rights reserved.
+ * Copyright © 2013-2018 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -38,7 +38,8 @@ int main(void)
 
     assert(osdev->attr->osdev.type == HWLOC_OBJ_OSDEV_COPROC);
 
-    value = hwloc_obj_get_info_by_name(osdev, "CoProcType");
+    value = osdev->subtype;
+    assert(value);
     err = strcmp(value, "MIC");
     assert(!err);
 

--- a/tests/hwloc/opencl.c
+++ b/tests/hwloc/opencl.c
@@ -55,7 +55,13 @@ int main(void)
       unsigned p, d;
 
       osdev = hwloc_opencl_get_device_osdev_by_index(topology, i, j);
-      assert(osdev); /* we currently insert all OpenCL devices, even CPU devices */
+      /* we currently insert all OpenCL devices, except CPU devices */
+      if (!osdev) {
+	cl_device_type type;
+	clGetDeviceInfo(device_ids[i], CL_DEVICE_TYPE, sizeof(type), &type, NULL);
+	assert(type == CL_DEVICE_TYPE_CPU);
+	continue;
+      }
 
       /* try to get it from PCI locality (only works with AMD extensions) */
       osdev2 = hwloc_opencl_get_device_osdev(topology, device_ids[j]);

--- a/tests/hwloc/opencl.c
+++ b/tests/hwloc/opencl.c
@@ -54,12 +54,13 @@ int main(void)
       const char *value;
       unsigned p, d;
 
-      osdev = hwloc_opencl_get_device_osdev(topology, device_ids[j]);
-      osdev2 = hwloc_opencl_get_device_osdev_by_index(topology, i, j);
-      assert(osdev == osdev2);
-      if (!osdev) {
-	printf("no osdev for platform %u device %u\n", i, j);
-	continue;
+      osdev = hwloc_opencl_get_device_osdev_by_index(topology, i, j);
+      assert(osdev); /* we currently insert all OpenCL devices, even CPU devices */
+
+      /* try to get it from PCI locality (only works with AMD extensions) */
+      osdev2 = hwloc_opencl_get_device_osdev(topology, device_ids[j]);
+      if (osdev2) {
+        assert(osdev == osdev2);
       }
 
       ancestor = hwloc_get_non_io_ancestor_obj(topology, osdev);

--- a/tests/hwloc/opencl.c
+++ b/tests/hwloc/opencl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2017 Inria.  All rights reserved.
+ * Copyright © 2012-2018 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -91,7 +91,8 @@ int main(void)
 
       assert(osdev->attr->osdev.type == HWLOC_OBJ_OSDEV_COPROC);
 
-      value = hwloc_obj_get_info_by_name(osdev, "CoProcType");
+      value = osdev->subtype;
+      assert(value);
       err = strcmp(value, "OpenCL");
       assert(!err);
 


### PR DESCRIPTION
All devices get their Vendor/Model names as GPUVendor/GPUModel, which looks wrong for CPU OpenCL devices (htird item below), and things like "Accelerator" and "Custom" that are already listed in the OpenCL specs.

Co-Processor(OpenCL) L#11 (Backend=OpenCL OpenCLDeviceType=GPU GPUVendor="NVIDIA Corporation" GPUModel="Tesla M2075" OpenCLPlatformIndex=0 OpenCLPlatformName="NVIDIA CUDA" OpenCLPlatformDeviceIndex=2 OpenCLComputeUnits=14 OpenCLGlobalMemorySize=5428224) "opencl0d0"

Co-Processor(OpenCL) L#6 (Backend=OpenCL OpenCLDeviceType=GPU GPUVendor="Advanced Micro Devices, Inc." GPUModel="AMD Radeon R9 200 / HD 7900 Series" OpenCLPlatformIndex=0 OpenCLPlatformName="AMD Accelerated Parallel Processing" OpenCLPlatformDeviceIndex=1 OpenCLComputeUnits=32 OpenCLGlobalMemorySize=3087360) "opencl0d1"

Co-Processor(OpenCL) L#7 (Backend=OpenCL OpenCLDeviceType=CPU GPUVendor=GenuineIntel GPUModel="Intel(R) Xeon(R) CPU E5-2650 0 @ 2.00GHz" OpenCLPlatformIndex=0 OpenCLPlatformName="AMD Accelerated Parallel Processing" OpenCLPlatformDeviceIndex=2 OpenCLComputeUnits=32 OpenCLGlobalMemorySize=32869688) "opencl0d2"


Changing GPUVendor/GPUModel to Vendor/Model as explained in #280 may be annoying for backward compat. Maybe just keep GPU prefix for GPUs and remove it for others (we never exposed anything but GPUs in v1.x).