### PR TITLE
Move local_memory to NUMA node specific attrs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -32,6 +32,9 @@ Version 2.0.0
   + Topologies always have at least one NUMA object. On non-NUMA machines,
     a single NUMA object is added to describe the entire machine memory.
     The NUMA level cannot be ignored anymore.
+  + obj->memory is removed.
+    - local_memory and page_types are now in obj->attr->numanode
+    - total_memory moves obj->total_memory.
   + The HWLOC_OBJ_CACHE type is replaced with 8 types HWLOC_OBJ_L[1-5]CACHE
     and HWLOC_OBJ_L[1-3]ICACHE that remove the need to disambiguate levels
     when looking for caches with _by_type() functions.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -319,9 +319,9 @@ man3_objects_DATA = \
         $(DOX_MAN_DIR)/man3/hwlocality_objects.3 \
         $(DOX_MAN_DIR)/man3/hwloc_obj.3 \
         $(DOX_MAN_DIR)/man3/hwloc_obj_t.3 \
-        $(DOX_MAN_DIR)/man3/hwloc_obj_memory_s.3 \
-        $(DOX_MAN_DIR)/man3/hwloc_obj_memory_s_hwloc_obj_memory_page_type_s.3 \
         $(DOX_MAN_DIR)/man3/hwloc_obj_attr_u.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_obj_attr_u_hwloc_numanode_attr_s.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_obj_attr_u_hwloc_numanode_attr_s_hwloc_memory_page_type_s.3 \
         $(DOX_MAN_DIR)/man3/hwloc_obj_attr_u_hwloc_bridge_attr_s.3 \
         $(DOX_MAN_DIR)/man3/hwloc_obj_attr_u_hwloc_cache_attr_s.3 \
         $(DOX_MAN_DIR)/man3/hwloc_obj_attr_u_hwloc_group_attr_s.3 \

--- a/doc/examples/nodeset+membind+policy.c
+++ b/doc/examples/nodeset+membind+policy.c
@@ -69,7 +69,7 @@ int main(void)
   hwloc_bitmap_foreach_begin(i, set) {
     obj = hwloc_get_numanode_obj_by_os_index(topology, i);
     printf("  node #%u (OS index %u) with %llu bytes of memory\n",
-	   obj->logical_index, i, (unsigned long long) obj->memory.local_memory);
+	   obj->logical_index, i, (unsigned long long) obj->attr->numanode.local_memory);
   } hwloc_bitmap_foreach_end();
   hwloc_bitmap_free(set);
 
@@ -130,7 +130,7 @@ int main(void)
   hwloc_bitmap_foreach_begin(i, set) {
     obj = hwloc_get_numanode_obj_by_os_index(topology, i);
     printf("  node #%u (OS index %u) with %llu bytes of memory\n",
-	   obj->logical_index, i, (unsigned long long) obj->memory.local_memory);
+	   obj->logical_index, i, (unsigned long long) obj->attr->numanode.local_memory);
   } hwloc_bitmap_foreach_end();
   hwloc_bitmap_free(set);
 

--- a/hwloc/topology-aix.c
+++ b/hwloc/topology-aix.c
@@ -639,15 +639,15 @@ look_rset(int sdl, hwloc_obj_type_t type, struct hwloc_topology *topology, int l
       case HWLOC_OBJ_NUMANODE:
 	obj->nodeset = hwloc_bitmap_alloc();
 	hwloc_bitmap_set(obj->nodeset, i);
-	obj->memory.local_memory = 0; /* TODO: odd, rs_getinfo(rad, R_MEMSIZE, 0) << 10 returns the total memory ... */
-	obj->memory.page_types_len = 2;
-	obj->memory.page_types = malloc(2*sizeof(*obj->memory.page_types));
-	memset(obj->memory.page_types, 0, 2*sizeof(*obj->memory.page_types));
-	obj->memory.page_types[0].size = hwloc_getpagesize();
+	obj->attr->numanode.local_memory = 0; /* TODO: odd, rs_getinfo(rad, R_MEMSIZE, 0) << 10 returns the total memory ... */
+	obj->attr->numanode.page_types_len = 2;
+	obj->attr->numanode.page_types = malloc(2*sizeof(*obj->attr->numanode.page_types));
+	memset(obj->attr->numanode.page_types, 0, 2*sizeof(*obj->attr->numanode.page_types));
+	obj->attr->numanode.page_types[0].size = hwloc_getpagesize();
 #if HAVE_DECL__SC_LARGE_PAGESIZE
-	obj->memory.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
+	obj->attr->numanode.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
 #endif
-	/* TODO: obj->memory.page_types[1].count = rs_getinfo(rset, R_LGPGFREE, 0) / hugepagesize */
+	/* TODO: obj->attr->numanode.page_types[1].count = rs_getinfo(rset, R_LGPGFREE, 0) / hugepagesize */
 	break;
       case HWLOC_OBJ_L2CACHE:
 	obj->attr->cache.size = _system_configuration.L2_cache_size;

--- a/hwloc/topology-bgq.c
+++ b/hwloc/topology-bgq.c
@@ -66,7 +66,7 @@ hwloc_look_bgq(struct hwloc_backend *backend)
   set = hwloc_bitmap_alloc();
   hwloc_bitmap_set(set, 0);
   obj->nodeset = set;
-  obj->memory.local_memory = 16ULL*1024*1024*1024ULL;
+  obj->attr->numanode.local_memory = 16ULL*1024*1024*1024ULL;
   hwloc_insert_object_by_cpuset(topology, obj);
 
   set = hwloc_bitmap_alloc();

--- a/hwloc/topology-darwin.c
+++ b/hwloc/topology-darwin.c
@@ -224,13 +224,13 @@ hwloc_look_darwin(struct hwloc_backend *backend)
           } else {
             hwloc_debug_1arg_bitmap("node %u has cpuset %s\n",
                 j, obj->cpuset);
-	    obj->memory.local_memory = cachesize[i];
-	    obj->memory.page_types_len = 2;
-	    obj->memory.page_types = malloc(2*sizeof(*obj->memory.page_types));
-	    memset(obj->memory.page_types, 0, 2*sizeof(*obj->memory.page_types));
-	    obj->memory.page_types[0].size = hwloc_getpagesize();
+	    obj->attr->numanode.local_memory = cachesize[i];
+	    obj->attr->numanode.page_types_len = 2;
+	    obj->attr->numanode.page_types = malloc(2*sizeof(*obj->attr->numanode.page_types));
+	    memset(obj->attr->numanode.page_types, 0, 2*sizeof(*obj->attr->numanode.page_types));
+	    obj->attr->numanode.page_types[0].size = hwloc_getpagesize();
 #if HAVE_DECL__SC_LARGE_PAGESIZE
-	    obj->memory.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
+	    obj->attr->numanode.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
 #endif
           }
 

--- a/hwloc/topology-freebsd.c
+++ b/hwloc/topology-freebsd.c
@@ -172,7 +172,7 @@ hwloc_freebsd_node_meminfo_info(struct hwloc_topology *topology)
        unsigned long physmem;
        size_t len = sizeof(physmem);
        sysctl(mib, 2, &physmem, &len, NULL, 0);
-       topology->levels[0][0]->memory.local_memory = physmem;
+       topology->machine_memory.local_memory = physmem;
        /* we don't know anything about NUMA nodes in this backend.
         * let another backend or the core move that memory to the right NUMA node */
 }

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -2404,7 +2404,7 @@ hwloc_sysfs_node_meminfo_info(struct hwloc_topology *topology,
     } else {
       /* get hugepage size from machine-specific meminfo since there is no size in node-specific meminfo,
        * hwloc_get_procfs_meminfo_info must have been called earlier */
-      meminfo_hugepages_size = topology->levels[0][0]->memory.page_types[1].size;
+      meminfo_hugepages_size = topology->machine_memory.page_types[1].size;
       /* use what we found in meminfo */
       if (meminfo_hugepages_size) {
         memory->page_types[1].count = meminfo_hugepages_count;
@@ -4418,22 +4418,13 @@ hwloc_look_linuxfs(struct hwloc_backend *backend)
    */
 
   /* Get the machine memory attributes */
-  hwloc_get_procfs_meminfo_info(topology, data, &topology->levels[0][0]->memory);
+  hwloc_get_procfs_meminfo_info(topology, data, &topology->machine_memory);
 
   /* Gather NUMA information. Must be after hwloc_get_procfs_meminfo_info so that the hugepage size is known */
   if (sysfs_node_path)
     look_sysfsnode(topology, data, sysfs_node_path, &nbnodes);
   else
     nbnodes = 0;
-
-  /* if we found some numa nodes, the machine object has no local memory */
-  if (nbnodes) {
-    unsigned i;
-    topology->levels[0][0]->memory.local_memory = 0;
-    if (topology->levels[0][0]->memory.page_types)
-      for(i=0; i<topology->levels[0][0]->memory.page_types_len; i++)
-	topology->levels[0][0]->memory.page_types[i].count = 0;
-  }
 
   /**********************
    * Misc

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -2262,7 +2262,7 @@ hwloc_parse_meminfo_info(struct hwloc_linux_backend_data_s *data,
 static void
 hwloc_parse_hugepages_info(struct hwloc_linux_backend_data_s *data,
 			   const char *dirpath,
-			   struct hwloc_obj_memory_s *memory,
+			   struct hwloc_numanode_attr_s *memory,
 			   uint64_t *remaining_local_memory)
 {
   DIR *dir;
@@ -2295,7 +2295,7 @@ hwloc_parse_hugepages_info(struct hwloc_linux_backend_data_s *data,
 static void
 hwloc_get_procfs_meminfo_info(struct hwloc_topology *topology,
 			      struct hwloc_linux_backend_data_s *data,
-			      struct hwloc_obj_memory_s *memory)
+			      struct hwloc_numanode_attr_s *memory)
 {
   uint64_t meminfo_hugepages_count, meminfo_hugepages_size = 0;
   struct stat st;
@@ -2366,7 +2366,7 @@ static void
 hwloc_sysfs_node_meminfo_info(struct hwloc_topology *topology,
 			      struct hwloc_linux_backend_data_s *data,
 			      const char *syspath, int node,
-			      struct hwloc_obj_memory_s *memory)
+			      struct hwloc_numanode_attr_s *memory)
 {
   char path[SYSFS_NUMA_NODE_PATH_LEN];
   char meminfopath[SYSFS_NUMA_NODE_PATH_LEN];
@@ -3136,7 +3136,7 @@ look_sysfsnode(struct hwloc_topology *topology,
 	    node->nodeset = hwloc_bitmap_alloc();
 	    hwloc_bitmap_set(node->nodeset, osnode);
 	  }
-          hwloc_sysfs_node_meminfo_info(topology, data, path, osnode, &node->memory);
+          hwloc_sysfs_node_meminfo_info(topology, data, path, osnode, &node->attr->numanode);
 
 	  nodes[i] = node;
           hwloc_debug_1arg_bitmap("os node %u has cpuset %s\n",

--- a/hwloc/topology-netbsd.c
+++ b/hwloc/topology-netbsd.c
@@ -141,7 +141,7 @@ hwloc_netbsd_node_meminfo_info(struct hwloc_topology *topology)
   unsigned long physmem;
   size_t len = sizeof(physmem);
   sysctl(mib, 2, &physmem, &len, NULL, 0);
-  topology->levels[0][0]->memory.local_memory = physmem;
+  topology->machine_memory.local_memory = physmem;
 }
 #endif
 

--- a/hwloc/topology-solaris.c
+++ b/hwloc/topology-solaris.c
@@ -438,13 +438,13 @@ lgrp_build_numanodes(struct hwloc_topology *topology,
     nodes[(*nr_nodes)++] = obj;
 
     hwloc_debug("NUMA node %ld has %lldkB\n", nids[i], mem_size/1024);
-    obj->memory.local_memory = mem_size;
-    obj->memory.page_types_len = 2;
-    obj->memory.page_types = malloc(2*sizeof(*obj->memory.page_types));
-    memset(obj->memory.page_types, 0, 2*sizeof(*obj->memory.page_types));
-    obj->memory.page_types[0].size = hwloc_getpagesize();
+    obj->attr->numanode.local_memory = mem_size;
+    obj->attr->numanode.page_types_len = 2;
+    obj->attr->numanode.page_types = malloc(2*sizeof(*obj->attr->numanode.page_types));
+    memset(obj->attr->numanode.page_types, 0, 2*sizeof(*obj->attr->numanode.page_types));
+    obj->attr->numanode.page_types[0].size = hwloc_getpagesize();
 #if HAVE_DECL__SC_LARGE_PAGESIZE
-    obj->memory.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
+    obj->attr->numanode.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
 #endif
 
     n = lgrp_cpus(cookie, nids[i], pids, npids, LGRP_CONTENT_HIERARCHY);

--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -708,12 +708,12 @@ hwloc_synthetic__post_look_hooks(struct hwloc_synthetic_level_data_s *curlevel,
   case HWLOC_OBJ_MACHINE:
     break;
   case HWLOC_OBJ_NUMANODE:
-    obj->memory.local_memory = curlevel->memorysize;
-    obj->memory.page_types_len = 1;
-    obj->memory.page_types = malloc(sizeof(*obj->memory.page_types));
-    memset(obj->memory.page_types, 0, sizeof(*obj->memory.page_types));
-    obj->memory.page_types[0].size = 4096;
-    obj->memory.page_types[0].count = curlevel->memorysize / 4096;
+    obj->attr->numanode.local_memory = curlevel->memorysize;
+    obj->attr->numanode.page_types_len = 1;
+    obj->attr->numanode.page_types = malloc(sizeof(*obj->attr->numanode.page_types));
+    memset(obj->attr->numanode.page_types, 0, sizeof(*obj->attr->numanode.page_types));
+    obj->attr->numanode.page_types[0].size = 4096;
+    obj->attr->numanode.page_types[0].count = curlevel->memorysize / 4096;
     break;
   case HWLOC_OBJ_PACKAGE:
     break;
@@ -1069,9 +1069,9 @@ static int hwloc_topology_export_synthetic_obj_attr(struct hwloc_topology * topo
 	     prefix, (unsigned long long) obj->attr->cache.size);
     prefix = separator;
   }
-  if (obj->memory.local_memory) {
+  if (obj->type == HWLOC_OBJ_NUMANODE && obj->attr->numanode.local_memory) {
     snprintf(memsize, sizeof(memsize), "%smemory=%llu",
-	     prefix, (unsigned long long) obj->memory.local_memory);
+	     prefix, (unsigned long long) obj->attr->numanode.local_memory);
     prefix = separator;
   }
   if (obj->type == HWLOC_OBJ_PU || obj->type == HWLOC_OBJ_NUMANODE) {

--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -708,6 +708,12 @@ hwloc_synthetic__post_look_hooks(struct hwloc_synthetic_level_data_s *curlevel,
   case HWLOC_OBJ_MACHINE:
     break;
   case HWLOC_OBJ_NUMANODE:
+    obj->memory.local_memory = curlevel->memorysize;
+    obj->memory.page_types_len = 1;
+    obj->memory.page_types = malloc(sizeof(*obj->memory.page_types));
+    memset(obj->memory.page_types, 0, sizeof(*obj->memory.page_types));
+    obj->memory.page_types[0].size = 4096;
+    obj->memory.page_types[0].count = curlevel->memorysize / 4096;
     break;
   case HWLOC_OBJ_PACKAGE:
     break;
@@ -736,14 +742,6 @@ hwloc_synthetic__post_look_hooks(struct hwloc_synthetic_level_data_s *curlevel,
     /* Should never happen */
     assert(0);
     break;
-  }
-  if (curlevel->memorysize && !hwloc_obj_type_is_cache(obj->type)) {
-    obj->memory.local_memory = curlevel->memorysize;
-    obj->memory.page_types_len = 1;
-    obj->memory.page_types = malloc(sizeof(*obj->memory.page_types));
-    memset(obj->memory.page_types, 0, sizeof(*obj->memory.page_types));
-    obj->memory.page_types[0].size = 4096;
-    obj->memory.page_types[0].count = curlevel->memorysize / 4096;
   }
 }
 

--- a/hwloc/topology-windows.c
+++ b/hwloc/topology-windows.c
@@ -814,15 +814,15 @@ hwloc_look_windows(struct hwloc_backend *backend)
 	      hwloc_bitmap_set(obj->nodeset, id);
 	      if ((GetNumaAvailableMemoryNodeExProc && GetNumaAvailableMemoryNodeExProc(id, &avail))
 	       || (GetNumaAvailableMemoryNodeProc && GetNumaAvailableMemoryNodeProc(id, &avail)))
-		obj->memory.local_memory = avail;
-	      obj->memory.page_types_len = 2;
-	      obj->memory.page_types = malloc(2 * sizeof(*obj->memory.page_types));
-	      memset(obj->memory.page_types, 0, 2 * sizeof(*obj->memory.page_types));
-	      obj->memory.page_types_len = 1;
-	      obj->memory.page_types[0].size = SystemInfo.dwPageSize;
+		obj->attr->numanode.local_memory = avail;
+	      obj->attr->numanode.page_types_len = 2;
+	      obj->attr->numanode.page_types = malloc(2 * sizeof(*obj->attr->numanode.page_types));
+	      memset(obj->attr->numanode.page_types, 0, 2 * sizeof(*obj->attr->numanode.page_types));
+	      obj->attr->numanode.page_types_len = 1;
+	      obj->attr->numanode.page_types[0].size = SystemInfo.dwPageSize;
 #if HAVE_DECL__SC_LARGE_PAGESIZE
-	      obj->memory.page_types_len++;
-	      obj->memory.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
+	      obj->attr->numanode.page_types_len++;
+	      obj->attr->numanode.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
 #endif
 	      break;
 	    }
@@ -981,14 +981,14 @@ hwloc_look_windows(struct hwloc_backend *backend)
 	      hwloc_bitmap_set(obj->nodeset, id);
 	      if ((GetNumaAvailableMemoryNodeExProc && GetNumaAvailableMemoryNodeExProc(id, &avail))
 	       || (GetNumaAvailableMemoryNodeProc && GetNumaAvailableMemoryNodeProc(id, &avail)))
-	        obj->memory.local_memory = avail;
-	      obj->memory.page_types = malloc(2 * sizeof(*obj->memory.page_types));
-	      memset(obj->memory.page_types, 0, 2 * sizeof(*obj->memory.page_types));
-	      obj->memory.page_types_len = 1;
-	      obj->memory.page_types[0].size = SystemInfo.dwPageSize;
+	        obj->attr->numanode.local_memory = avail;
+	      obj->attr->numanode.page_types = malloc(2 * sizeof(*obj->attr->numanode.page_types));
+	      memset(obj->attr->numanode.page_types, 0, 2 * sizeof(*obj->attr->numanode.page_types));
+	      obj->attr->numanode.page_types_len = 1;
+	      obj->attr->numanode.page_types[0].size = SystemInfo.dwPageSize;
 #if HAVE_DECL__SC_LARGE_PAGESIZE
-	      obj->memory.page_types_len++;
-	      obj->memory.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
+	      obj->attr->numanode.page_types_len++;
+	      obj->attr->numanode.page_types[1].size = sysconf(_SC_LARGE_PAGESIZE);
 #endif
 	      break;
 	    }

--- a/hwloc/traversal.c
+++ b/hwloc/traversal.c
@@ -422,25 +422,25 @@ hwloc_obj_attr_snprintf(char * __hwloc_restrict string, size_t size, hwloc_obj_t
   /* print memory attributes */
   res = 0;
   if (verbose) {
-    if (obj->memory.local_memory)
+    if (obj->type == HWLOC_OBJ_NUMANODE && obj->attr->numanode.local_memory)
       res = hwloc_snprintf(tmp, tmplen, "%slocal=%lu%s%stotal=%lu%s",
 			   prefix,
-			   (unsigned long) hwloc_memory_size_printf_value(obj->memory.local_memory, verbose),
-			   hwloc_memory_size_printf_unit(obj->memory.local_memory, verbose),
+			   (unsigned long) hwloc_memory_size_printf_value(obj->attr->numanode.local_memory, verbose),
+			   hwloc_memory_size_printf_unit(obj->attr->numanode.local_memory, verbose),
 			   separator,
-			   (unsigned long) hwloc_memory_size_printf_value(obj->memory.total_memory, verbose),
-			   hwloc_memory_size_printf_unit(obj->memory.total_memory, verbose));
-    else if (obj->memory.total_memory)
+			   (unsigned long) hwloc_memory_size_printf_value(obj->total_memory, verbose),
+			   hwloc_memory_size_printf_unit(obj->total_memory, verbose));
+    else if (obj->total_memory)
       res = hwloc_snprintf(tmp, tmplen, "%stotal=%lu%s",
 			   prefix,
-			   (unsigned long) hwloc_memory_size_printf_value(obj->memory.total_memory, verbose),
-			   hwloc_memory_size_printf_unit(obj->memory.total_memory, verbose));
+			   (unsigned long) hwloc_memory_size_printf_value(obj->total_memory, verbose),
+			   hwloc_memory_size_printf_unit(obj->total_memory, verbose));
   } else {
-    if (obj->memory.local_memory)
+    if (obj->type == HWLOC_OBJ_NUMANODE && obj->attr->numanode.local_memory)
       res = hwloc_snprintf(tmp, tmplen, "%s%lu%s",
 			   prefix,
-			   (unsigned long) hwloc_memory_size_printf_value(obj->memory.local_memory, verbose),
-			   hwloc_memory_size_printf_unit(obj->memory.local_memory, verbose));
+			   (unsigned long) hwloc_memory_size_printf_value(obj->attr->numanode.local_memory, verbose),
+			   hwloc_memory_size_printf_unit(obj->attr->numanode.local_memory, verbose));
   }
   if (res < 0)
     return -1;

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -341,24 +341,6 @@ enum hwloc_compare_types_e {
 
 union hwloc_obj_attr_u;
 
-/** \brief Object memory */
-struct hwloc_obj_memory_s {
-  hwloc_uint64_t total_memory; /**< \brief Total memory (in bytes) in this object and its children */
-  hwloc_uint64_t local_memory; /**< \brief Local memory (in bytes) */
-
-  /** \brief Size of array \p page_types */
-  unsigned page_types_len;
-  /** \brief Array of local memory page types, \c NULL if no local memory and \p page_types is 0.
-   *
-   * The array is sorted by increasing \p size fields.
-   * It contains \p page_types_len slots.
-   */
-  struct hwloc_obj_memory_page_type_s {
-    hwloc_uint64_t size;	/**< \brief Size of pages */
-    hwloc_uint64_t count;	/**< \brief Number of pages of this size */
-  } * page_types;
-};
-
 /** \brief Structure of a topology object
  *
  * Applications must not modify any field except \p hwloc_obj.userdata.
@@ -380,7 +362,7 @@ struct hwloc_obj {
 					 * a name string is more useful than numerical indexes.
 					 */
 
-  struct hwloc_obj_memory_s memory;	/**< \brief Memory attributes */
+  hwloc_uint64_t total_memory; /**< \brief Total memory (in bytes) in NUMA nodes below this object. */
 
   union hwloc_obj_attr_u *attr;		/**< \brief Object type-specific Attributes,
 					 * may be \c NULL if no attribute value was found */
@@ -556,6 +538,21 @@ typedef struct hwloc_obj * hwloc_obj_t;
 
 /** \brief Object type-specific Attributes */
 union hwloc_obj_attr_u {
+  /** \brief NUMA node-specific Object Attributes */
+  struct hwloc_numanode_attr_s {
+    hwloc_uint64_t local_memory; /**< \brief Local memory (in bytes) */
+    unsigned page_types_len; /**< \brief Size of array \p page_types */
+    /** \brief Array of local memory page types, \c NULL if no local memory and \p page_types is 0.
+     *
+     * The array is sorted by increasing \p size fields.
+     * It contains \p page_types_len slots.
+     */
+    struct hwloc_memory_page_type_s {
+      hwloc_uint64_t size;	/**< \brief Size of pages */
+      hwloc_uint64_t count;	/**< \brief Number of pages of this size */
+    } * page_types;
+  } numanode;
+
   /** \brief Cache-specific Object Attributes */
   struct hwloc_cache_attr_s {
     hwloc_uint64_t size;		  /**< \brief Size of cache in bytes */

--- a/include/hwloc/linux-libnuma.h
+++ b/include/hwloc/linux-libnuma.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2014 Inria.  All rights reserved.
+ * Copyright © 2009-2017 Inria.  All rights reserved.
  * Copyright © 2009-2010, 2012 Université Bordeaux
  * See COPYING in top-level directory.
  */
@@ -196,7 +196,7 @@ hwloc_cpuset_to_linux_libnuma_bitmask(hwloc_topology_t topology, hwloc_const_cpu
   if (!bitmask)
     return NULL;
   while ((node = hwloc_get_next_obj_covering_cpuset_by_depth(topology, cpuset, depth, node)) != NULL)
-    if (node->memory.local_memory)
+    if (node->attr->numanode.local_memory)
       numa_bitmask_setbit(bitmask, node->os_index);
   return bitmask;
 }
@@ -221,7 +221,7 @@ hwloc_nodeset_to_linux_libnuma_bitmask(hwloc_topology_t topology, hwloc_const_no
   if (!bitmask)
     return NULL;
   while ((node = hwloc_get_next_obj_by_depth(topology, depth, node)) != NULL)
-    if (hwloc_bitmap_isset(nodeset, node->os_index) && node->memory.local_memory)
+    if (hwloc_bitmap_isset(nodeset, node->os_index) && node->attr->numanode.local_memory)
       numa_bitmask_setbit(bitmask, node->os_index);
   return bitmask;
 }

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -94,15 +94,14 @@ extern "C" {
 #define hwloc_compare_types_e HWLOC_NAME(compare_types_e)
 #define HWLOC_TYPE_UNORDERED HWLOC_NAME_CAPS(TYPE_UNORDERED)
 
-#define hwloc_obj_memory_s HWLOC_NAME(obj_memory_s)
-#define hwloc_obj_memory_page_type_s HWLOC_NAME(obj_memory_page_type_s)
-
 #define hwloc_obj HWLOC_NAME(obj)
 #define hwloc_obj_t HWLOC_NAME(obj_t)
 
 #define hwloc_obj_info_s HWLOC_NAME(obj_info_s)
 
 #define hwloc_obj_attr_u HWLOC_NAME(obj_attr_u)
+#define hwloc_numanode_attr_s HWLOC_NAME(numanode_attr_s)
+#define hwloc_memory_page_type_s HWLOC_NAME(memory_page_type_s)
 #define hwloc_cache_attr_s HWLOC_NAME(cache_attr_s)
 #define hwloc_group_attr_s HWLOC_NAME(group_attr_s)
 #define hwloc_pcidev_attr_s HWLOC_NAME(pcidev_attr_s)

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -154,7 +154,7 @@ struct hwloc_topology {
    * temporarily stored there by OSes that only provide this without NUMA information,
    * and actually used later by the core.
    */
-  struct hwloc_obj_memory_s machine_memory;
+  struct hwloc_numanode_attr_s machine_memory;
 
   /* list of enabled backends. */
   struct hwloc_backend * backends;

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -150,6 +150,12 @@ struct hwloc_topology {
   float grouping_accuracies[5];
   unsigned grouping_next_subkind;
 
+  /* machine-wide memory.
+   * temporarily stored there by OSes that only provide this without NUMA information,
+   * and actually used later by the core.
+   */
+  struct hwloc_obj_memory_s machine_memory;
+
   /* list of enabled backends. */
   struct hwloc_backend * backends;
   unsigned backend_excludes;

--- a/tests/hwloc/hwloc_get_area_memlocation.c
+++ b/tests/hwloc/hwloc_get_area_memlocation.c
@@ -49,7 +49,7 @@ int main(void)
   node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, node);
   if (!node)
     goto out_with_buffer;
-  if (!node->memory.local_memory)
+  if (!node->attr->numanode.local_memory)
     goto next1;
   printf("binding to 1st node and touching 1st quarter\n");
   err = hwloc_set_area_membind(topology, buffer, LEN, node->nodeset, HWLOC_MEMBIND_BIND, HWLOC_MEMBIND_BYNODESET);
@@ -71,7 +71,7 @@ int main(void)
   node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, node);
   if (!node)
     goto out_with_nomorenodes;
-  if (!node->memory.local_memory)
+  if (!node->attr->numanode.local_memory)
     goto next2;
   printf("binding to 2nd node and touching 2nd quarter\n");
   err = hwloc_set_area_membind(topology, buffer, LEN, node->nodeset, HWLOC_MEMBIND_BIND, HWLOC_MEMBIND_BYNODESET);
@@ -89,7 +89,7 @@ int main(void)
   node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, node);
   if (!node)
     goto out_with_nomorenodes;
-  if (!node->memory.local_memory)
+  if (!node->attr->numanode.local_memory)
     goto next3;
   printf("binding to 3rd node and touching 3rd quarter\n");
   err = hwloc_set_area_membind(topology, buffer, LEN, node->nodeset, HWLOC_MEMBIND_BIND, HWLOC_MEMBIND_BYNODESET);
@@ -107,7 +107,7 @@ int main(void)
   node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, node);
   if (!node)
     goto out_with_nomorenodes;
-  if (!node->memory.local_memory)
+  if (!node->attr->numanode.local_memory)
     goto next4;
   printf("binding to 4th node and touching 4th quarter\n");
   err = hwloc_set_area_membind(topology, buffer, LEN, node->nodeset, HWLOC_MEMBIND_BIND, HWLOC_MEMBIND_BYNODESET);

--- a/tests/hwloc/hwloc_topology_diff.c
+++ b/tests/hwloc/hwloc_topology_diff.c
@@ -47,21 +47,14 @@ int main(void)
   printf("add a similar info to topo1, and change memory sizes\n");
   obj = hwloc_get_root_obj(topo2);
   hwloc_obj_add_info(obj, "Foo", "Bar2");
-  obj->memory.local_memory += 128*4096;
 
   obj = hwloc_get_obj_by_type(topo2, HWLOC_OBJ_NUMANODE, 0);
-  obj->memory.local_memory += 32*4096;
+  obj->attr->numanode.local_memory += 32*4096;
 
   printf("check that topo2 is now properly diff'ed\n");
   err = hwloc_topology_diff_build(topo1, topo2, 0, &diff);
   assert(err == 0);
   tmpdiff = diff;
-  assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR);
-  assert(tmpdiff->obj_attr.obj_depth == 0);
-  assert(tmpdiff->obj_attr.obj_index == 0);
-  assert(tmpdiff->obj_attr.diff.generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR_SIZE);
-  assert(tmpdiff->obj_attr.diff.uint64.newvalue - tmpdiff->obj_attr.diff.uint64.oldvalue == 128*4096);
-  tmpdiff = tmpdiff->generic.next;
   assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR);
   assert(tmpdiff->obj_attr.obj_depth == 0);
   assert(tmpdiff->obj_attr.obj_index == 0);
@@ -124,12 +117,6 @@ int main(void)
   assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR);
   assert(tmpdiff->obj_attr.obj_depth == 0);
   assert(tmpdiff->obj_attr.obj_index == 0);
-  assert(tmpdiff->obj_attr.diff.generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR_SIZE);
-  assert(tmpdiff->obj_attr.diff.uint64.newvalue - tmpdiff->obj_attr.diff.uint64.oldvalue == 128*4096);
-  tmpdiff = tmpdiff->generic.next;
-  assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR);
-  assert(tmpdiff->obj_attr.obj_depth == 0);
-  assert(tmpdiff->obj_attr.obj_index == 0);
   assert(tmpdiff->obj_attr.diff.generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR_INFO);
   err = strcmp(tmpdiff->obj_attr.diff.string.name, "Foo");
   assert(!err);
@@ -166,8 +153,6 @@ int main(void)
   tmpdiff = diff;
   assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR);
   tmpdiff = tmpdiff->generic.next;
-  assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR);
-  tmpdiff = tmpdiff->generic.next;
   assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_TOO_COMPLEX);
   tmpdiff = tmpdiff->generic.next;
   assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR);
@@ -183,7 +168,7 @@ int main(void)
   assert(err == 0);
   assert(diff);
   err = hwloc_topology_diff_apply(topo2, diff, HWLOC_TOPOLOGY_DIFF_APPLY_REVERSE);
-  assert(err == -3);
+  assert(err == -2);
   hwloc_topology_diff_destroy(diff);
 
   hwloc_topology_destroy(topo3);

--- a/tests/hwloc/hwloc_topology_restrict.c
+++ b/tests/hwloc/hwloc_topology_restrict.c
@@ -63,7 +63,7 @@ static void check(int has_groups, unsigned nbnodes, unsigned nbcores, unsigned n
   assert(nb == nbcores);
   nb = hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU);
   assert(nb == nbpus);
-  total_memory = hwloc_get_root_obj(topology)->memory.total_memory;
+  total_memory = hwloc_get_root_obj(topology)->total_memory;
   assert(total_memory == nbnodes * 1024*1024*1024); /* synthetic topology puts 1GB per node */
 }
 

--- a/tests/hwloc/linux-libnuma.c
+++ b/tests/hwloc/linux-libnuma.c
@@ -43,11 +43,11 @@ int main(void)
   while ((node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, node)) != NULL) {
     hwloc_bitmap_or(set, set, node->cpuset);
     if (hwloc_bitmap_iszero(node->cpuset)) {
-      if (node->memory.local_memory)
+      if (node->attr->numanode.local_memory)
         hwloc_bitmap_set(nocpubutmemnodeset, node->os_index);
       else
 	hwloc_bitmap_set(nocpunomemnodeset, node->os_index);
-    } else if (!node->memory.local_memory) {
+    } else if (!node->attr->numanode.local_memory) {
       hwloc_bitmap_set(nomembutcpunodeset, node->os_index);
       hwloc_bitmap_or(nomembutcpucpuset, nomembutcpucpuset, node->cpuset);
     }
@@ -146,7 +146,7 @@ int main(void)
 
   /* convert first node (with CPU and memory) between cpuset/nodeset and libnuma */
   node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, NULL);
-  while (node && (!node->memory.local_memory || hwloc_bitmap_iszero(node->cpuset)))
+  while (node && (!node->attr->numanode.local_memory || hwloc_bitmap_iszero(node->cpuset)))
     /* skip nodes with no cpus or no memory to avoid strange libnuma behaviors */
     node = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_NUMANODE, node);
   if (node) {

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -85,10 +85,12 @@ hwloc_info_show_obj(hwloc_topology_t topology, hwloc_obj_t obj, const char *type
   printf("%s memory children = %u\n", prefix, obj->memory_arity);
   printf("%s i/o children = %u\n", prefix, obj->io_arity);
   printf("%s misc children = %u\n", prefix, obj->misc_arity);
-  if (obj->memory.local_memory)
-    printf("%s local memory = %llu\n", prefix, (unsigned long long) obj->memory.local_memory);
-  if (obj->memory.total_memory)
-    printf("%s total memory = %llu\n", prefix, (unsigned long long) obj->memory.total_memory);
+
+  if (obj->type == HWLOC_OBJ_NUMANODE) {
+    printf("%s local memory = %llu\n", prefix, (unsigned long long) obj->attr->numanode.local_memory);
+  }
+  if (obj->total_memory)
+    printf("%s total memory = %llu\n", prefix, (unsigned long long) obj->total_memory);
 
   if (obj->cpuset) {
     hwloc_bitmap_snprintf(s, sizeof(s), obj->cpuset);

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -622,11 +622,11 @@ lstopo_obj_snprintf(struct lstopo_output *loutput, char *text, size_t textlen, h
 
   if (loutput->show_attrs[obj->type]) {
     attrlen = hwloc_obj_attr_snprintf(attrstr, sizeof(attrstr), obj, " ", 0);
-    /* display the root total_memory if different from the local_memory (already shown) */
-    if (!obj->parent && obj->memory.total_memory > obj->memory.local_memory)
+    /* display the root total_memory (cannot be local_memory since root cannot be a NUMA node) */
+    if (!obj->parent && obj->total_memory)
       snprintf(totmemstr, sizeof(totmemstr), " (%lu%s total)",
-	       (unsigned long) hwloc_memory_size_printf_value(obj->memory.total_memory, 0),
-	       hwloc_memory_size_printf_unit(obj->memory.total_memory, 0));
+	       (unsigned long) hwloc_memory_size_printf_value(obj->total_memory, 0),
+	       hwloc_memory_size_printf_unit(obj->total_memory, 0));
   } else
     attrlen = 0;
 

--- a/utils/lstopo/lstopo-text.c
+++ b/utils/lstopo/lstopo-text.c
@@ -89,11 +89,11 @@ output_console_obj (struct lstopo_output *loutput, hwloc_obj_t l, int collapse)
     }
     free(attr);
     /* display the root total_memory if not verbose (already shown)
-     * and different from the local_memory (already shown) */
-    if (verbose_mode == 1 && !l->parent && l->memory.total_memory > l->memory.local_memory)
+     * (cannot be local_memory since root cannot be a NUMA node) */
+    if (verbose_mode == 1 && !l->parent && l->total_memory)
       fprintf(output, " (%lu%s total)",
-	      (unsigned long) hwloc_memory_size_printf_value(l->memory.total_memory, 0),
-	      hwloc_memory_size_printf_unit(l->memory.total_memory, 0));
+	      (unsigned long) hwloc_memory_size_printf_value(l->total_memory, 0),
+	      hwloc_memory_size_printf_unit(l->total_memory, 0));
     /* append the name */
     if (l->name && (l->type == HWLOC_OBJ_OS_DEVICE || verbose_mode >= 2)
 	&& l->type != HWLOC_OBJ_MISC && l->type != HWLOC_OBJ_GROUP)


### PR DESCRIPTION
Only NUMA nodes have memory, so it makes sense to change obj->memory into obj->attr->numanode
However obj->memory.total_memory is used for all objects (especially root), so that one becomes obj->total_memory.