### PR TITLE
Remove the "System" object type

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -72,6 +72,7 @@ Version 2.0.0
   + Remove the custom interface for assembling the topologies of different
     nodes as well as the hwloc-assembler tools.
   + Remove Kerrighed support from the Linux backend.
+  + Remove the now-unused "System" object type HWLOC_OBJ_SYSTEM.
   + Remove Tru64 (OSF/1) support.
     - Remove HWLOC_MEMBIND_REPLICATE which wasn't available anywhere else.
 * API

--- a/NEWS
+++ b/NEWS
@@ -72,7 +72,8 @@ Version 2.0.0
   + Remove the custom interface for assembling the topologies of different
     nodes as well as the hwloc-assembler tools.
   + Remove Kerrighed support from the Linux backend.
-  + Remove the now-unused "System" object type HWLOC_OBJ_SYSTEM.
+  + Remove the now-unused "System" object type HWLOC_OBJ_SYSTEM,
+    defined to MACHINE for backward compatibility.
   + Remove Tru64 (OSF/1) support.
     - Remove HWLOC_MEMBIND_REPLICATE which wasn't available anywhere else.
 * API

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -291,7 +291,6 @@ man3_object_types_DATA = \
         $(DOX_MAN_DIR)/man3/HWLOC_OBJ_PU.3 \
         $(DOX_MAN_DIR)/man3/HWLOC_OBJ_PCI_DEVICE.3 \
         $(DOX_MAN_DIR)/man3/HWLOC_OBJ_PACKAGE.3 \
-        $(DOX_MAN_DIR)/man3/HWLOC_OBJ_SYSTEM.3 \
         $(DOX_MAN_DIR)/man3/hwloc_obj_type_t.3 \
         $(DOX_MAN_DIR)/man3/HWLOC_OBJ_CACHE_UNIFIED.3 \
         $(DOX_MAN_DIR)/man3/HWLOC_OBJ_CACHE_DATA.3 \

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1844,7 +1844,7 @@ the number of such children under each object of the previous level.
 That is why the above topology contains 4 cores (2 cores times 2 nodes).
 
 These type names must be written as
-<tt>machine</tt>, <tt>numanode</tt>, <tt>package</tt>, <tt>core</tt>,
+<tt>numanode</tt>, <tt>package</tt>, <tt>core</tt>,
 <tt>l2u</tt>, <tt>l1i</tt>, <tt>pu</tt>, <tt>group</tt>
 (hwloc_obj_type_sscanf() is used for parsing the type names).
 They do not need to be written case-sensitively, nor entirely
@@ -1869,9 +1869,8 @@ These groups are merged back into the parent when possible
 (typically when a single NUMA node is requested below each parent).
 
 The root object does not appear in the synthetic description string.
-A Machine object is used by default, and a System object replaces it
-if a Machine level is specified in the string.
-Therefore the System type cannot be used in the description string as well.
+A Machine object is used by default.
+Therefore Machine and System types are disallowed in the description as well.
 
 A NUMA level (with a single NUMA node) is automatically added if needed.
 

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1870,7 +1870,7 @@ These groups are merged back into the parent when possible
 
 The root object does not appear in the synthetic description string.
 A Machine object is used by default.
-Therefore Machine and System types are disallowed in the description as well.
+Therefore the Machine type is disallowed in the description as well.
 
 A NUMA level (with a single NUMA node) is automatically added if needed.
 
@@ -2518,7 +2518,7 @@ HWLOC_SETUP_CORE <em>must</em> be invoked if using the m4 macros):
   hwloc's types and public symbols with "foo_"; meaning that function
   hwloc_init() becomes foo_hwloc_init().  Enum values are prefixed
   with an upper-case translation if the prefix supplied;
-  HWLOC_OBJ_SYSTEM becomes FOO_HWLOC_OBJ_SYSTEM.  This is recommended
+  HWLOC_OBJ_CORE becomes FOO_HWLOC_OBJ_CORE.  This is recommended
   behavior if you are including hwloc in middleware -- it is possible
   that your software will be combined with other software that links
   to another copy of hwloc.  If both uses of hwloc utilize different

--- a/hwloc/hwloc2.dtd
+++ b/hwloc/hwloc2.dtd
@@ -11,7 +11,7 @@
 <!ATTLIST topology version CDATA "">
 
 <!ELEMENT object (page_type*,info*,userdata*,object*)>
-<!ATTLIST object type (System | Machine | Misc | Group | NUMANode | Package | L1Cache | L2Cache | L3Cache | L4Cache | L5Cache | L1iCache | L2iCache | L3iCache | Core | PU | Bridge | PCIDev | OSDev) #REQUIRED>
+<!ATTLIST object type (Machine | Misc | Group | NUMANode | Package | L1Cache | L2Cache | L3Cache | L4Cache | L5Cache | L1iCache | L2iCache | L3iCache | Core | PU | Bridge | PCIDev | OSDev) #REQUIRED>
 <!ATTLIST object subtype CDATA "" >
 <!ATTLIST object os_index CDATA "-1" >
 <!ATTLIST object gp_index CDATA "-1" >

--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -418,7 +418,7 @@ hwloc_backend_synthetic_init(struct hwloc_synthetic_backend_data_s *data,
 	errno = EINVAL;
 	goto error;
       }
-      if (type == HWLOC_OBJ_SYSTEM || type == HWLOC_OBJ_MACHINE || type == HWLOC_OBJ_MISC || type == HWLOC_OBJ_BRIDGE || type == HWLOC_OBJ_PCI_DEVICE || type == HWLOC_OBJ_OS_DEVICE) {
+      if (type == HWLOC_OBJ_MACHINE || type == HWLOC_OBJ_MISC || type == HWLOC_OBJ_BRIDGE || type == HWLOC_OBJ_PCI_DEVICE || type == HWLOC_OBJ_OS_DEVICE) {
 	if (verbose)
 	  fprintf(stderr, "Synthetic string with disallowed object type at '%s'\n", pos);
 	errno = EINVAL;
@@ -712,11 +712,11 @@ hwloc_synthetic__post_look_hooks(struct hwloc_synthetic_level_data_s *curlevel,
     break;
   case HWLOC_OBJ_PU:
     break;
-  case HWLOC_OBJ_SYSTEM:
   case HWLOC_OBJ_BRIDGE:
   case HWLOC_OBJ_PCI_DEVICE:
   case HWLOC_OBJ_OS_DEVICE:
   case HWLOC_OBJ_MISC:
+  case _HWLOC_OBJ_SYSTEM_OBSOLETE:
   case HWLOC_OBJ_TYPE_MAX:
     /* Should never happen */
     assert(0);
@@ -767,11 +767,11 @@ hwloc__look_synthetic(struct hwloc_topology *topology,
     case HWLOC_OBJ_PU:
       break;
     case HWLOC_OBJ_MACHINE:
-    case HWLOC_OBJ_SYSTEM:
     case HWLOC_OBJ_BRIDGE:
     case HWLOC_OBJ_PCI_DEVICE:
     case HWLOC_OBJ_OS_DEVICE:
     case HWLOC_OBJ_MISC:
+    case _HWLOC_OBJ_SYSTEM_OBSOLETE:
     case HWLOC_OBJ_TYPE_MAX:
       /* Should never happen */
       assert(0);

--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -778,6 +778,15 @@ hwloc__xml_import_object(hwloc_topology_t topology,
 	if (!strcasecmp(attrvalue, "Cache")) {
 	  obj->type = _HWLOC_OBJ_CACHE_OLD; /* will be fixed below */
 	  attribute_less_cache = 1;
+	} else if (!strcasecmp(attrvalue, "System")) {
+	  if (!parent)
+	    obj->type = HWLOC_OBJ_MACHINE;
+	  else {
+	    if (hwloc__xml_verbose())
+	      fprintf(stderr, "%s: obsolete System object only allowed at root\n",
+		      state->global->msgprefix);
+	    goto error_with_object;
+	  }
 	} else {
 	  if (hwloc__xml_verbose())
 	    fprintf(stderr, "%s: unrecognized object type string %s\n",
@@ -795,6 +804,11 @@ hwloc__xml_import_object(hwloc_topology_t topology,
       }
       hwloc__xml_import_object_attr(topology, data, obj, attrname, attrvalue, state);
     }
+  }
+
+  if (parent && obj->type == HWLOC_OBJ_MACHINE) {
+    /* replace non-root Machine with Groups */
+    obj->type = HWLOC_OBJ_GROUP;
   }
 
   if (parent && data->version_major >= 2) {

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -4285,6 +4285,12 @@ hwloc_topology_check(struct hwloc_topology *topology)
 
   assert(!topology->modified);
 
+  /* check that first level is Machine.
+   * Root object cannot be ignored. And Machine can only be merged into PU,
+   * but there must be a NUMA node below Machine, and it cannot be below PU.
+   */
+  assert(hwloc_get_depth_type(topology, 0) == HWLOC_OBJ_MACHINE);
+
   /* check that last level is PU and that it doesn't have memory */
   assert(hwloc_get_depth_type(topology, depth-1) == HWLOC_OBJ_PU);
   assert(hwloc_get_nbobjs_by_depth(topology, depth-1) > 0);
@@ -4294,9 +4300,11 @@ hwloc_topology_check(struct hwloc_topology *topology)
     assert(obj->type == HWLOC_OBJ_PU);
     assert(!obj->memory_first_child);
   }
-  /* check that other levels are not PU */
-  for(j=1; j<depth-1; j++)
+  /* check that other levels are not PU or Machine */
+  for(j=1; j<depth-1; j++) {
     assert(hwloc_get_depth_type(topology, j) != HWLOC_OBJ_PU);
+    assert(hwloc_get_depth_type(topology, j) != HWLOC_OBJ_MACHINE);
+  }
 
   /* check that we have a NUMA level */
   assert(hwloc_get_type_depth(topology, HWLOC_OBJ_NUMANODE) == HWLOC_TYPE_DEPTH_NUMANODE);

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -973,30 +973,29 @@ hwloc_topology_dup(hwloc_topology_t *newp,
    */
 /***** Make sure you update obj_type_priority[] below as well. *****/
 static const unsigned obj_type_order[] = {
-    /* first entry is HWLOC_OBJ_SYSTEM */  0,
-    /* next entry is HWLOC_OBJ_MACHINE */  1,
-    /* next entry is HWLOC_OBJ_NUMANODE */ 3,
-    /* next entry is HWLOC_OBJ_PACKAGE */  4,
-    /* next entry is HWLOC_OBJ_CORE */     13,
-    /* next entry is HWLOC_OBJ_PU */       17,
-    /* next entry is HWLOC_OBJ_L1CACHE */  11,
-    /* next entry is HWLOC_OBJ_L2CACHE */  9,
-    /* next entry is HWLOC_OBJ_L3CACHE */  7,
-    /* next entry is HWLOC_OBJ_L4CACHE */  6,
-    /* next entry is HWLOC_OBJ_L5CACHE */  5,
-    /* next entry is HWLOC_OBJ_L1ICACHE */ 12,
-    /* next entry is HWLOC_OBJ_L2ICACHE */ 10,
-    /* next entry is HWLOC_OBJ_L3ICACHE */ 8,
-    /* next entry is HWLOC_OBJ_GROUP */    2,
-    /* next entry is HWLOC_OBJ_MISC */     18,
-    /* next entry is HWLOC_OBJ_BRIDGE */   14,
-    /* next entry is HWLOC_OBJ_PCI_DEVICE */  15,
-    /* next entry is HWLOC_OBJ_OS_DEVICE */   16
+    /* FIXME remove _HWLOC_OBJ_SYSTEM_OBSOLETE */ 18,
+    /* first entry is HWLOC_OBJ_MACHINE */  0,
+    /* next entry is HWLOC_OBJ_NUMANODE */ 2,
+    /* next entry is HWLOC_OBJ_PACKAGE */  3,
+    /* next entry is HWLOC_OBJ_CORE */     12,
+    /* next entry is HWLOC_OBJ_PU */       16,
+    /* next entry is HWLOC_OBJ_L1CACHE */  10,
+    /* next entry is HWLOC_OBJ_L2CACHE */  8,
+    /* next entry is HWLOC_OBJ_L3CACHE */  6,
+    /* next entry is HWLOC_OBJ_L4CACHE */  5,
+    /* next entry is HWLOC_OBJ_L5CACHE */  4,
+    /* next entry is HWLOC_OBJ_L1ICACHE */ 11,
+    /* next entry is HWLOC_OBJ_L2ICACHE */ 9,
+    /* next entry is HWLOC_OBJ_L3ICACHE */ 7,
+    /* next entry is HWLOC_OBJ_GROUP */    1,
+    /* next entry is HWLOC_OBJ_MISC */     17,
+    /* next entry is HWLOC_OBJ_BRIDGE */   13,
+    /* next entry is HWLOC_OBJ_PCI_DEVICE */  14,
+    /* next entry is HWLOC_OBJ_OS_DEVICE */   15
 };
 
 #ifndef NDEBUG /* only used in debug check assert if !NDEBUG */
 static const hwloc_obj_type_t obj_order_type[] = {
-  HWLOC_OBJ_SYSTEM,
   HWLOC_OBJ_MACHINE,
   HWLOC_OBJ_GROUP,
   HWLOC_OBJ_NUMANODE,
@@ -1015,6 +1014,7 @@ static const hwloc_obj_type_t obj_order_type[] = {
   HWLOC_OBJ_OS_DEVICE,
   HWLOC_OBJ_PU,
   HWLOC_OBJ_MISC, /* Misc is always a leaf */
+  _HWLOC_OBJ_SYSTEM_OBSOLETE, /* FIXME remove */
 };
 #endif
 /***** Make sure you update obj_type_priority[] below as well. *****/
@@ -1023,7 +1023,6 @@ static const hwloc_obj_type_t obj_order_type[] = {
  * (in merge_useless_child), keep the highest priority one.
  *
  * Always keep Machine/NUMANode/PU/PCIDev/OSDev
- * then System
  * then Core
  * then Package
  * then Cache,
@@ -1034,8 +1033,8 @@ static const hwloc_obj_type_t obj_order_type[] = {
  */
 /***** Make sure you update this array when changing the list of types. *****/
 static const int obj_type_priority[] = {
-  /* first entry is HWLOC_OBJ_SYSTEM */     80,
-  /* next entry is HWLOC_OBJ_MACHINE */     90,
+  /* FIXME remove _HWLOC_OBJ_SYSTEM_OBSOLETE */ 0,
+  /* first entry is HWLOC_OBJ_MACHINE */     90,
   /* next entry is HWLOC_OBJ_NUMANODE */    100,
   /* next entry is HWLOC_OBJ_PACKAGE */     40,
   /* next entry is HWLOC_OBJ_CORE */        60,
@@ -1060,12 +1059,12 @@ int hwloc_compare_types (hwloc_obj_type_t type1, hwloc_obj_type_t type2)
   unsigned order1 = obj_type_order[type1];
   unsigned order2 = obj_type_order[type2];
 
-  /* only normal objects are comparable. others are only comparable with machine/system */
+  /* only normal objects are comparable. others are only comparable with machine */
   if (!hwloc_obj_type_is_normal(type1)
-      && hwloc_obj_type_is_normal(type2) && type2 != HWLOC_OBJ_SYSTEM && type2 != HWLOC_OBJ_MACHINE)
+      && hwloc_obj_type_is_normal(type2) && type2 != HWLOC_OBJ_MACHINE)
     return HWLOC_TYPE_UNORDERED;
   if (!hwloc_obj_type_is_normal(type2)
-      && hwloc_obj_type_is_normal(type1) && type1 != HWLOC_OBJ_SYSTEM && type1 != HWLOC_OBJ_MACHINE)
+      && hwloc_obj_type_is_normal(type1) && type1 != HWLOC_OBJ_MACHINE)
     return HWLOC_TYPE_UNORDERED;
 
   return order1 - order2;
@@ -4063,6 +4062,7 @@ hwloc__check_object(hwloc_topology_t topology, hwloc_bitmap_t gp_indexes, hwloc_
   hwloc_bitmap_set(gp_indexes, obj->gp_index);
 
   HWLOC_BUILD_ASSERT(HWLOC_OBJ_TYPE_MIN == 0);
+  assert(obj->type != _HWLOC_OBJ_SYSTEM_OBSOLETE);
   assert((unsigned) obj->type < HWLOC_OBJ_TYPE_MAX);
 
   /* check that sets and depth */

--- a/hwloc/traversal.c
+++ b/hwloc/traversal.c
@@ -173,7 +173,6 @@ hwloc_type_name (hwloc_obj_type_t obj)
 {
   switch (obj)
     {
-    case HWLOC_OBJ_SYSTEM: return "System";
     case HWLOC_OBJ_MACHINE: return "Machine";
     case HWLOC_OBJ_MISC: return "Misc";
     case HWLOC_OBJ_GROUP: return "Group";
@@ -212,9 +211,7 @@ hwloc_type_sscanf(const char *string, hwloc_obj_type_t *typep,
    */
 
   /* types without a custom depth */
-  if (!hwloc_strncasecmp(string, "system", 2)) {
-    type = HWLOC_OBJ_SYSTEM;
-  } else if (!hwloc_strncasecmp(string, "machine", 2)) {
+  if (!hwloc_strncasecmp(string, "machine", 2)) {
     type = HWLOC_OBJ_MACHINE;
   } else if (!hwloc_strncasecmp(string, "node", 2)
 	     || !hwloc_strncasecmp(string, "numa", 2)) { /* matches node and numanode */
@@ -359,7 +356,6 @@ hwloc_obj_type_snprintf(char * __hwloc_restrict string, size_t size, hwloc_obj_t
   hwloc_obj_type_t type = obj->type;
   switch (type) {
   case HWLOC_OBJ_MISC:
-  case HWLOC_OBJ_SYSTEM:
   case HWLOC_OBJ_MACHINE:
   case HWLOC_OBJ_NUMANODE:
   case HWLOC_OBJ_PACKAGE:

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -318,7 +318,9 @@ typedef enum hwloc_obj_osdev_type_e {
  * contain packages which contain caches, which contain cores, which contain
  * processors).
  *
- * \note ::HWLOC_OBJ_PU will always be the deepest.
+ * \note ::HWLOC_OBJ_PU will always be the deepest,
+ * while ::HWLOC_OBJ_MACHINE is always the highest.
+ *
  * \note This does not mean that the actual topology will respect that order:
  * e.g. as of today cores may also contain caches, and packages may also contain
  * nodes. This is thus just to be seen as a fallback comparison method.

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -169,15 +169,11 @@ typedef hwloc_const_bitmap_t hwloc_const_nodeset_t;
  * hwloc_compare_types() instead.
  */
 typedef enum {
-  HWLOC_OBJ_SYSTEM,	/**< \brief Whole system (may be a cluster of machines).
-  			  * The whole system that is accessible to hwloc.
-			  * That may comprise several machines in SSI systems.
-			  * This object type is currently unused in native backends.
-			  */
-  HWLOC_OBJ_TYPE_MIN =  HWLOC_OBJ_SYSTEM,   /**< \private Sentinel value */
+  _HWLOC_OBJ_SYSTEM_OBSOLETE,  /* FIXME drop and reorder */
+  HWLOC_OBJ_TYPE_MIN = _HWLOC_OBJ_SYSTEM_OBSOLETE,   /**< \private Sentinel value */
 
   HWLOC_OBJ_MACHINE,	/**< \brief Machine.
-			  * The typical root object type.
+			  * The root object type.
 			  * A set of processors and memory with cache
 			  * coherency.
 			  */

--- a/include/hwloc/deprecated.h
+++ b/include/hwloc/deprecated.h
@@ -21,6 +21,8 @@
 extern "C" {
 #endif
 
+/* backward compat with v1.11 before System removal */
+#define HWLOC_OBJ_SYSTEM HWLOC_OBJ_MACHINE
 /* backward compat with v1.10 before Socket->Package renaming */
 #define HWLOC_OBJ_SOCKET HWLOC_OBJ_PACKAGE
 /* backward compat with v1.10 before Node->NUMANode clarification */

--- a/include/hwloc/inlines.h
+++ b/include/hwloc/inlines.h
@@ -38,7 +38,7 @@ hwloc_get_type_or_below_depth (hwloc_topology_t topology, hwloc_obj_type_t type)
     if (hwloc_compare_types(hwloc_get_depth_type(topology, depth), type) < 0)
       return depth+1;
 
-  /* Shouldn't ever happen, as there is always a SYSTEM level with lower order and known depth.  */
+  /* Shouldn't ever happen, as there is always a Machine level with lower order and known depth.  */
   /* abort(); */
 }
 

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -47,7 +47,6 @@ extern "C" {
 #define hwloc_nodeset_t HWLOC_NAME(nodeset_t)
 #define hwloc_const_nodeset_t HWLOC_NAME(const_nodeset_t)
 
-#define HWLOC_OBJ_SYSTEM HWLOC_NAME_CAPS(OBJ_SYSTEM)
 #define HWLOC_OBJ_MACHINE HWLOC_NAME_CAPS(OBJ_MACHINE)
 #define HWLOC_OBJ_NUMANODE HWLOC_NAME_CAPS(OBJ_NUMANODE)
 #define HWLOC_OBJ_PACKAGE HWLOC_NAME_CAPS(OBJ_PACKAGE)

--- a/tests/hwloc/hwloc_backends.c
+++ b/tests/hwloc/hwloc_backends.c
@@ -98,7 +98,7 @@ int main(void)
     assert(!hwloc_topology_set_xmlbuffer(topology2, xmlbuf, xmlbuflen));
   }
   printf("switching to synthetic...\n");
-  hwloc_topology_set_synthetic(topology2, "machine:2 node:3 l1:2 pu:4");
+  hwloc_topology_set_synthetic(topology2, "pack:2 node:3 l1:2 pu:4");
   hwloc_topology_destroy(topology2);
 
   /* init+xml+load+destroy */
@@ -130,7 +130,7 @@ int main(void)
   /* init+synthetic+load+destroy */
   printf("switching to synthetic and loading...\n");
   hwloc_topology_init(&topology2);
-  hwloc_topology_set_synthetic(topology2, "machine:2 node:3 l3i:2 pu:4");
+  hwloc_topology_set_synthetic(topology2, "pack:2 node:3 l3i:2 pu:4");
   hwloc_topology_load(topology2);
   assert_backend_name(topology2, "Synthetic");
   assert_foo_bar(topology2, 0);

--- a/tests/hwloc/hwloc_get_obj_inside_cpuset.c
+++ b/tests/hwloc/hwloc_get_obj_inside_cpuset.c
@@ -34,21 +34,14 @@ main (void)
   if (err)
     return EXIT_FAILURE;
 
-  /* there is no second system object */
-  root = hwloc_get_root_obj (topology);
-  obj = hwloc_get_obj_inside_cpuset_by_type(topology, root->cpuset, HWLOC_OBJ_SYSTEM, 1);
-  assert(!obj);
-
   /* first system object is the top-level object of the topology */
+  root = hwloc_get_root_obj (topology);
   obj = hwloc_get_obj_inside_cpuset_by_type(topology, root->cpuset, HWLOC_OBJ_MACHINE, 0);
   assert(obj == hwloc_get_root_obj(topology));
 
   /* first next-object object is the top-level object of the topology */
   obj = hwloc_get_next_obj_inside_cpuset_by_type(topology, root->cpuset, HWLOC_OBJ_MACHINE, NULL);
   assert(obj == hwloc_get_root_obj(topology));
-  /* there is no next object after the system object */
-  obj = hwloc_get_next_obj_inside_cpuset_by_type(topology, root->cpuset, HWLOC_OBJ_SYSTEM, obj);
-  assert(!obj);
 
   /* check last PU */
   obj = hwloc_get_obj_inside_cpuset_by_type(topology, root->cpuset, HWLOC_OBJ_PU, 2*3*4*5*6-1);

--- a/tests/hwloc/hwloc_groups.c
+++ b/tests/hwloc/hwloc_groups.c
@@ -31,6 +31,7 @@ int main(void)
   hwloc_topology_load(topology);
   /* 3 group at depth 1 */
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_GROUP);
+printf("depth %d\n", depth);
   assert(depth == 1);
   width = hwloc_get_nbobjs_by_depth(topology, 1);
   assert(width == 3);

--- a/tests/hwloc/hwloc_type_depth.c
+++ b/tests/hwloc/hwloc_type_depth.c
@@ -16,7 +16,7 @@
  * and hwloc_get_depth_type()
  */
 
-#define SYNTHETIC_TOPOLOGY_DESCRIPTION "machine:3 group:2 group:2 core:3 l3:2 l1:2 2"
+#define SYNTHETIC_TOPOLOGY_DESCRIPTION "group:2 group:2 core:3 l3:2 l1:2 2"
 
 int main(void)
 {
@@ -26,28 +26,27 @@ int main(void)
   hwloc_topology_set_synthetic(topology, SYNTHETIC_TOPOLOGY_DESCRIPTION);
   hwloc_topology_load(topology);
 
-  assert(hwloc_topology_get_depth(topology) == 8);
+  assert(hwloc_topology_get_depth(topology) == 7);
 
-  assert(hwloc_get_depth_type(topology, 0) == HWLOC_OBJ_SYSTEM);
-  assert(hwloc_get_depth_type(topology, 1) == HWLOC_OBJ_MACHINE);
+  assert(hwloc_get_depth_type(topology, 0) == HWLOC_OBJ_MACHINE);
+  assert(hwloc_get_depth_type(topology, 1) == HWLOC_OBJ_GROUP);
   assert(hwloc_get_depth_type(topology, 2) == HWLOC_OBJ_GROUP);
-  assert(hwloc_get_depth_type(topology, 3) == HWLOC_OBJ_GROUP);
-  assert(hwloc_get_depth_type(topology, 4) == HWLOC_OBJ_CORE);
-  assert(hwloc_get_depth_type(topology, 5) == HWLOC_OBJ_L3CACHE);
-  assert(hwloc_get_depth_type(topology, 6) == HWLOC_OBJ_L1CACHE);
-  assert(hwloc_get_depth_type(topology, 7) == HWLOC_OBJ_PU);
+  assert(hwloc_get_depth_type(topology, 3) == HWLOC_OBJ_CORE);
+  assert(hwloc_get_depth_type(topology, 4) == HWLOC_OBJ_L3CACHE);
+  assert(hwloc_get_depth_type(topology, 5) == HWLOC_OBJ_L1CACHE);
+  assert(hwloc_get_depth_type(topology, 6) == HWLOC_OBJ_PU);
 
-  assert(hwloc_get_type_depth(topology, HWLOC_OBJ_MACHINE) == 1);
-  assert(hwloc_get_type_depth(topology, HWLOC_OBJ_CORE) == 4);
-  assert(hwloc_get_type_depth(topology, HWLOC_OBJ_PU) == 7);
+  assert(hwloc_get_type_depth(topology, HWLOC_OBJ_MACHINE) == 0);
+  assert(hwloc_get_type_depth(topology, HWLOC_OBJ_CORE) == 3);
+  assert(hwloc_get_type_depth(topology, HWLOC_OBJ_PU) == 6);
 
   assert(hwloc_get_type_depth(topology, HWLOC_OBJ_PACKAGE) == HWLOC_TYPE_DEPTH_UNKNOWN);
-  assert(hwloc_get_type_or_above_depth(topology, HWLOC_OBJ_PACKAGE) == 3);
-  assert(hwloc_get_type_or_below_depth(topology, HWLOC_OBJ_PACKAGE) == 4);
+  assert(hwloc_get_type_or_above_depth(topology, HWLOC_OBJ_PACKAGE) == 2);
+  assert(hwloc_get_type_or_below_depth(topology, HWLOC_OBJ_PACKAGE) == 3);
   assert(hwloc_get_type_depth(topology, HWLOC_OBJ_GROUP) == HWLOC_TYPE_DEPTH_MULTIPLE);
   assert(hwloc_get_type_or_above_depth(topology, HWLOC_OBJ_GROUP) == HWLOC_TYPE_DEPTH_MULTIPLE);
   assert(hwloc_get_type_or_below_depth(topology, HWLOC_OBJ_GROUP) == HWLOC_TYPE_DEPTH_MULTIPLE);
-  assert(hwloc_get_type_depth(topology, HWLOC_OBJ_L3CACHE) == 5);
+  assert(hwloc_get_type_depth(topology, HWLOC_OBJ_L3CACHE) == 4);
 
   assert(hwloc_get_type_depth(topology, HWLOC_OBJ_BRIDGE) == HWLOC_TYPE_DEPTH_BRIDGE);
   assert(hwloc_get_type_depth(topology, HWLOC_OBJ_PCI_DEVICE) == HWLOC_TYPE_DEPTH_PCI_DEVICE);

--- a/utils/hwloc/hwloc.7in
+++ b/utils/hwloc/hwloc.7in
@@ -226,11 +226,6 @@ The smallest physical execution unit that hwloc recognizes.  For
 example, there may be multiple PUs on a core (e.g.,
 hardware threads).
 .PP
-The additional
-.B system
-type can be used when several machines form an overall single system image
-(SSI).
-.PP
 \fBosdev\fR, \fBpcidev\fR, \fBbridge\fR, and \fBmisc\fR may also be used
 to specify special devices although some of them have dedicated identification
 ways as explained in \fBLocation Specification\fR.

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -375,11 +375,8 @@ place_children(struct lstopo_output *loutput, hwloc_obj_t parent,
   else
     plud->above_children.kinds = 0;
 
-  /* system containing machines is drawn as network */
-  /* FIXME: we only use the network code for drawing systems of machines.
-   * Systems of groups (of groups ...) of machines still use boxes.
-   */
-  plud->network = network = (parent->type == HWLOC_OBJ_SYSTEM && parent->arity > 1 && parent->children[0]->type == HWLOC_OBJ_MACHINE);
+  // FIXME
+  plud->network = network = 0;
   /* must be initialized before returning below so that draw_children() works */
 
   /* bridge children always vertical */
@@ -706,13 +703,13 @@ lstopo_set_object_color(struct lstopo_output *loutput,
   switch (obj->type) {
 
   case HWLOC_OBJ_MACHINE:
+    // FIXME
     if (obj->depth) {
       s->bg = MACHINE_COLOR;
       break;
     }
     /* Machine root printed as a System */
     /* FALLTHRU */
-  case HWLOC_OBJ_SYSTEM:
     s->bg = SYSTEM_COLOR;
     break;
 
@@ -1285,7 +1282,6 @@ static foo_draw
 get_type_fun(hwloc_obj_type_t type)
 {
   switch (type) {
-    case HWLOC_OBJ_SYSTEM:
     case HWLOC_OBJ_MACHINE:
     case HWLOC_OBJ_NUMANODE:
     case HWLOC_OBJ_PACKAGE:

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -43,7 +43,6 @@ const struct lstopo_color RUNNING_COLOR = { 0, 0xff, 0 };
 const struct lstopo_color FORBIDDEN_COLOR = { 0xff, 0, 0 };
 const struct lstopo_color CACHE_COLOR = { 0xff, 0xff, 0xff };
 const struct lstopo_color MACHINE_COLOR = { EPOXY_R_COLOR, EPOXY_G_COLOR, EPOXY_B_COLOR };
-const struct lstopo_color SYSTEM_COLOR = { 0xff, 0xff, 0xff };
 const struct lstopo_color GROUP_IN_PACKAGE_COLOR = { EPOXY_R_COLOR, EPOXY_G_COLOR, EPOXY_B_COLOR };
 const struct lstopo_color MISC_COLOR = { 0xff, 0xff, 0xff };
 const struct lstopo_color PCI_DEVICE_COLOR = { DARK_EPOXY_R_COLOR, DARK_EPOXY_G_COLOR, DARK_EPOXY_B_COLOR };
@@ -703,14 +702,7 @@ lstopo_set_object_color(struct lstopo_output *loutput,
   switch (obj->type) {
 
   case HWLOC_OBJ_MACHINE:
-    // FIXME
-    if (obj->depth) {
-      s->bg = MACHINE_COLOR;
-      break;
-    }
-    /* Machine root printed as a System */
-    /* FALLTHRU */
-    s->bg = SYSTEM_COLOR;
+    s->bg = MACHINE_COLOR;
     break;
 
   case HWLOC_OBJ_GROUP: {
@@ -1322,7 +1314,6 @@ declare_colors(struct lstopo_output *output)
   methods->declare_color(output, &FORBIDDEN_COLOR);
   methods->declare_color(output, &CACHE_COLOR);
   methods->declare_color(output, &MACHINE_COLOR);
-  methods->declare_color(output, &SYSTEM_COLOR);
   methods->declare_color(output, &GROUP_IN_PACKAGE_COLOR);
   methods->declare_color(output, &MISC_COLOR);
   methods->declare_color(output, &PCI_DEVICE_COLOR);

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -126,8 +126,6 @@ struct lstopo_obj_userdata {
   unsigned xrel;
   unsigned yrel;
 
-  /* children connected by network? */
-  int network;
   /* children orientation */
   enum lstopo_orient_e orient;
 

--- a/utils/lstopo/test-lstopo.sh.in
+++ b/utils/lstopo/test-lstopo.sh.in
@@ -55,7 +55,7 @@ $ls
   $ls -f $tmp/test.xml
   HWLOC_LIBXML_EXPORT=0 $ls -f $tmp/test.xml
   $ls --export-xml-flags 1 -f $tmp/test.v1.xml
-  $ls --input "ma:1 no:2 so:1 l2:2 2" $tmp/test.synthetic
+  $ls --input "pa:1 no:2 co:1 l2:2 2" $tmp/test.synthetic
 ) > "$file"
 diff @HWLOC_DIFF_U@ $srcdir/test-lstopo.output "$file"
 rm -rf "$tmp"


### PR DESCRIPTION
We don't support topologies made of multiple machines anymore (kerrighed is dead, we removed its support, and custom assembly of topologies has been removed too). Therefore, the only way to get a topology with a System object above Machine is synthetic.

I don't think we will ever again support a single topology made of different/independent operating system instances, at least because binding isn't possible there. But we still support assembly of multiple machines managed by a single OS (SGI NumaLink, ScaleMP vSMP, etc). So maybe Machine isn't the right name, but I am not sure it's worth changing it.

Anyway, once we remove System, we can now clarify that root is always Machine. This means the "network drawing" code isn't needed in lstopo anymore.
