### PR TITLE
API: change level depth to signed int

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -74,6 +74,7 @@ Version 2.0.0
 * API
   + Objects now have a "subtype" field that supersedes former "Type" and
     "CoProcType" info attributes.
+  + Object depths are now signed ints.
   + Objects do not have allowed_cpuset and allowed_nodeset anymore.
     They are only available for the entire topology using
     hwloc_topology_get_allowed_cpuset() and hwloc_topology_get_allowed_nodeset().

--- a/hwloc/distances.c
+++ b/hwloc/distances.c
@@ -151,7 +151,7 @@ int hwloc_distances_remove(hwloc_topology_t topology)
   return 0;
 }
 
-int hwloc_distances_remove_by_depth(hwloc_topology_t topology, unsigned depth)
+int hwloc_distances_remove_by_depth(hwloc_topology_t topology, int depth)
 {
   struct hwloc_internal_distances_s *dist, *next;
   hwloc_obj_type_t type;
@@ -634,7 +634,7 @@ hwloc_distances_get(hwloc_topology_t topology,
 }
 
 int
-hwloc_distances_get_by_depth(hwloc_topology_t topology, unsigned depth,
+hwloc_distances_get_by_depth(hwloc_topology_t topology, int depth,
 			     unsigned *nrp, struct hwloc_distances_s **distancesp,
 			     unsigned long kind, unsigned long flags)
 {

--- a/hwloc/topology-cuda.c
+++ b/hwloc/topology-cuda.c
@@ -78,7 +78,7 @@ hwloc_cuda_discover(struct hwloc_backend *backend)
     cuda_device = hwloc_alloc_setup_object(topology, HWLOC_OBJ_OS_DEVICE, HWLOC_UNKNOWN_INDEX);
     snprintf(cuda_name, sizeof(cuda_name), "cuda%d", i);
     cuda_device->name = strdup(cuda_name);
-    cuda_device->depth = (unsigned) HWLOC_TYPE_DEPTH_UNKNOWN;
+    cuda_device->depth = HWLOC_TYPE_DEPTH_UNKNOWN;
     cuda_device->attr->osdev.type = HWLOC_OBJ_OSDEV_COPROC;
 
     cuda_device->subtype = strdup("CUDA");

--- a/hwloc/topology-nvml.c
+++ b/hwloc/topology-nvml.c
@@ -46,7 +46,7 @@ hwloc_nvml_discover(struct hwloc_backend *backend)
     osdev = hwloc_alloc_setup_object(topology, HWLOC_OBJ_OS_DEVICE, HWLOC_UNKNOWN_INDEX);
     snprintf(buffer, sizeof(buffer), "nvml%u", i);
     osdev->name = strdup(buffer);
-    osdev->depth = (unsigned) HWLOC_TYPE_DEPTH_UNKNOWN;
+    osdev->depth = HWLOC_TYPE_DEPTH_UNKNOWN;
     osdev->attr->osdev.type = HWLOC_OBJ_OSDEV_GPU;
 
     hwloc_obj_add_info(osdev, "Backend", "NVML");

--- a/hwloc/topology-opencl.c
+++ b/hwloc/topology-opencl.c
@@ -79,7 +79,7 @@ hwloc_opencl_discover(struct hwloc_backend *backend)
       osdev = hwloc_alloc_setup_object(topology, HWLOC_OBJ_OS_DEVICE, HWLOC_UNKNOWN_INDEX);
       snprintf(buffer, sizeof(buffer), "opencl%ud%u", j, i);
       osdev->name = strdup(buffer);
-      osdev->depth = (unsigned) HWLOC_TYPE_DEPTH_UNKNOWN;
+      osdev->depth = HWLOC_TYPE_DEPTH_UNKNOWN;
       osdev->attr->osdev.type = HWLOC_OBJ_OSDEV_COPROC;
 
       osdev->subtype = strdup("OpenCL");

--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -956,7 +956,7 @@ static int hwloc_topology_export_synthetic_indexes(struct hwloc_topology * topol
 						   hwloc_obj_t obj,
 						   char *buffer, size_t buflen)
 {
-  unsigned depth = obj->depth;
+  int depth = obj->depth;
   unsigned total;
   hwloc_obj_t *level;
   unsigned step = 1;
@@ -968,8 +968,8 @@ static int hwloc_topology_export_synthetic_indexes(struct hwloc_topology * topol
   char *tmp = buffer;
   int res, ret = 0;
 
-  if ((int)depth < 0) {
-    assert((int)depth == HWLOC_TYPE_DEPTH_NUMANODE);
+  if (depth < 0) {
+    assert(depth == HWLOC_TYPE_DEPTH_NUMANODE);
     total = topology->slevels[HWLOC_SLEVEL_NUMANODE].nbobjs;
     level = topology->slevels[HWLOC_SLEVEL_NUMANODE].objs;
   } else {

--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -2037,7 +2037,7 @@ hwloc__xml_export_object (hwloc__xml_export_state_t parentstate, hwloc_topology_
 	  hwloc_obj_t parent = dist->objs[i]->parent;
 	  while (hwloc_obj_type_is_memory(parent->type))
 	    parent = parent->parent;
-	  if ((int)parent->depth+1 > depth)
+	  if (parent->depth+1 > depth)
 	    depth = parent->depth+1;
 	}
       } else {
@@ -2191,7 +2191,7 @@ hwloc__xml_export_diff(hwloc__xml_export_state_t parentstate, hwloc_topology_dif
 
     switch (diff->generic.type) {
     case HWLOC_TOPOLOGY_DIFF_OBJ_ATTR:
-      sprintf(tmp, "%d", (int) diff->obj_attr.obj_depth);
+      sprintf(tmp, "%d", diff->obj_attr.obj_depth);
       state.new_prop(&state, "obj_depth", tmp);
       sprintf(tmp, "%u", diff->obj_attr.obj_index);
       state.new_prop(&state, "obj_index", tmp);

--- a/hwloc/traversal.c
+++ b/hwloc/traversal.c
@@ -25,9 +25,9 @@ hwloc_get_type_depth (struct hwloc_topology *topology, hwloc_obj_type_t type)
 }
 
 hwloc_obj_type_t
-hwloc_get_depth_type (hwloc_topology_t topology, unsigned depth)
+hwloc_get_depth_type (hwloc_topology_t topology, int depth)
 {
-  if (depth >= topology->nb_levels)
+  if ((unsigned)depth >= topology->nb_levels)
     switch (depth) {
     case HWLOC_TYPE_DEPTH_NUMANODE:
       return HWLOC_OBJ_NUMANODE;
@@ -46,9 +46,9 @@ hwloc_get_depth_type (hwloc_topology_t topology, unsigned depth)
 }
 
 unsigned
-hwloc_get_nbobjs_by_depth (struct hwloc_topology *topology, unsigned depth)
+hwloc_get_nbobjs_by_depth (struct hwloc_topology *topology, int depth)
 {
-  if (depth >= topology->nb_levels) {
+  if ((unsigned)depth >= topology->nb_levels) {
     unsigned l = HWLOC_SLEVEL_FROM_DEPTH(depth);
     if (l < HWLOC_NR_SLEVELS)
       return topology->slevels[l].nbobjs;
@@ -59,9 +59,9 @@ hwloc_get_nbobjs_by_depth (struct hwloc_topology *topology, unsigned depth)
 }
 
 struct hwloc_obj *
-hwloc_get_obj_by_depth (struct hwloc_topology *topology, unsigned depth, unsigned idx)
+hwloc_get_obj_by_depth (struct hwloc_topology *topology, int depth, unsigned idx)
 {
-  if (depth >= topology->nb_levels) {
+  if ((unsigned)depth >= topology->nb_levels) {
     unsigned l = HWLOC_SLEVEL_FROM_DEPTH(depth);
     if (l < HWLOC_NR_SLEVELS)
       return idx < topology->slevels[l].nbobjs ? topology->slevels[l].objs[idx] : NULL;
@@ -330,7 +330,7 @@ hwloc_type_sscanf_as_depth(const char *string, hwloc_obj_type_t *typep,
     for(l=0; l<topology->nb_levels; l++) {
       if (topology->levels[l][0]->type == HWLOC_OBJ_GROUP
 	  && topology->levels[l][0]->attr->group.depth == attr.group.depth) {
-	depth = l;
+	depth = (int)l;
 	break;
       }
     }
@@ -338,7 +338,7 @@ hwloc_type_sscanf_as_depth(const char *string, hwloc_obj_type_t *typep,
 
   if (typep)
     *typep = type;
-  *depthp = (unsigned) depth;
+  *depthp = depth;
   return 0;
 }
 

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -386,7 +386,7 @@ struct hwloc_obj {
 					 * may be \c NULL if no attribute value was found */
 
   /* global position */
-  unsigned depth;			/**< \brief Vertical index in the hierarchy.
+  int depth;				/**< \brief Vertical index in the hierarchy.
 					 *
 					 * For normal objects, this is the depth of the horizontal level
 					 * that contains this object and its cousins of the same type.
@@ -707,7 +707,7 @@ HWLOC_DECLSPEC void hwloc_topology_check(hwloc_topology_t topology);
  * \note NUMA nodes, I/O and Misc objects are ignored when computing
  * the depth of the tree (they are placed on special levels).
  */
-HWLOC_DECLSPEC unsigned hwloc_topology_get_depth(hwloc_topology_t __hwloc_restrict topology) __hwloc_attribute_pure;
+HWLOC_DECLSPEC int hwloc_topology_get_depth(hwloc_topology_t __hwloc_restrict topology) __hwloc_attribute_pure;
 
 /** \brief Returns the depth of objects of type \p type.
  *
@@ -773,11 +773,11 @@ hwloc_get_type_or_above_depth (hwloc_topology_t topology, hwloc_obj_type_t type)
  *
  * \return (hwloc_obj_type_t)-1 if depth \p depth does not exist.
  */
-HWLOC_DECLSPEC hwloc_obj_type_t hwloc_get_depth_type (hwloc_topology_t topology, unsigned depth) __hwloc_attribute_pure;
+HWLOC_DECLSPEC hwloc_obj_type_t hwloc_get_depth_type (hwloc_topology_t topology, int depth) __hwloc_attribute_pure;
 
 /** \brief Returns the width of level at depth \p depth.
  */
-HWLOC_DECLSPEC unsigned hwloc_get_nbobjs_by_depth (hwloc_topology_t topology, unsigned depth) __hwloc_attribute_pure;
+HWLOC_DECLSPEC unsigned hwloc_get_nbobjs_by_depth (hwloc_topology_t topology, int depth) __hwloc_attribute_pure;
 
 /** \brief Returns the width of level type \p type
  *
@@ -796,7 +796,7 @@ static __hwloc_inline hwloc_obj_t
 hwloc_get_root_obj (hwloc_topology_t topology) __hwloc_attribute_pure;
 
 /** \brief Returns the topology object at logical index \p idx from depth \p depth */
-HWLOC_DECLSPEC hwloc_obj_t hwloc_get_obj_by_depth (hwloc_topology_t topology, unsigned depth, unsigned idx) __hwloc_attribute_pure;
+HWLOC_DECLSPEC hwloc_obj_t hwloc_get_obj_by_depth (hwloc_topology_t topology, int depth, unsigned idx) __hwloc_attribute_pure;
 
 /** \brief Returns the topology object at logical index \p idx with type \p type
  *
@@ -812,7 +812,7 @@ hwloc_get_obj_by_type (hwloc_topology_t topology, hwloc_obj_type_t type, unsigne
  * If \p prev is \c NULL, return the first object at depth \p depth.
  */
 static __hwloc_inline hwloc_obj_t
-hwloc_get_next_obj_by_depth (hwloc_topology_t topology, unsigned depth, hwloc_obj_t prev);
+hwloc_get_next_obj_by_depth (hwloc_topology_t topology, int depth, hwloc_obj_t prev);
 
 /** \brief Returns the next object of type \p type.
  *

--- a/include/hwloc/diff.h
+++ b/include/hwloc/diff.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013-2016 Inria.  All rights reserved.
+ * Copyright © 2013-2017 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -136,7 +136,7 @@ typedef union hwloc_topology_diff_u {
     hwloc_topology_diff_type_t type; /* must be ::HWLOC_TOPOLOGY_DIFF_OBJ_ATTR */
     union hwloc_topology_diff_u * next;
     /* List of attribute differences for a single object */
-    unsigned obj_depth;
+    int obj_depth;
     unsigned obj_index;
     union hwloc_topology_diff_obj_attr_u diff;
   } obj_attr;
@@ -146,7 +146,7 @@ typedef union hwloc_topology_diff_u {
     hwloc_topology_diff_type_t type; /* must be ::HWLOC_TOPOLOGY_DIFF_TOO_COMPLEX */
     union hwloc_topology_diff_u * next;
     /* Where we had to stop computing the diff in the first topology */
-    unsigned obj_depth;
+    int obj_depth;
     unsigned obj_index;
   } too_complex;
 } * hwloc_topology_diff_t;

--- a/include/hwloc/distances.h
+++ b/include/hwloc/distances.h
@@ -122,7 +122,7 @@ hwloc_distances_get(hwloc_topology_t topology,
  * Identical to hwloc_distances_get() with the additional \p depth filter.
  */
 HWLOC_DECLSPEC int
-hwloc_distances_get_by_depth(hwloc_topology_t topology, unsigned depth,
+hwloc_distances_get_by_depth(hwloc_topology_t topology, int depth,
 			     unsigned *nr, struct hwloc_distances_s **distances,
 			     unsigned long kind, unsigned long flags);
 
@@ -244,7 +244,7 @@ HWLOC_DECLSPEC int hwloc_distances_remove(hwloc_topology_t topology);
  *
  * Identical to hwloc_distances_remove() but only applies to one level of the topology.
  */
-HWLOC_DECLSPEC int hwloc_distances_remove_by_depth(hwloc_topology_t topology, unsigned depth);
+HWLOC_DECLSPEC int hwloc_distances_remove_by_depth(hwloc_topology_t topology, int depth);
 
 /** \brief Remove distance matrices for objects of a specific type in the topology.
  *

--- a/include/hwloc/helper.h
+++ b/include/hwloc/helper.h
@@ -83,7 +83,7 @@ HWLOC_DECLSPEC int hwloc_get_largest_objs_inside_cpuset (hwloc_topology_t topolo
  */
 static __hwloc_inline hwloc_obj_t
 hwloc_get_next_obj_inside_cpuset_by_depth (hwloc_topology_t topology, hwloc_const_cpuset_t set,
-					   unsigned depth, hwloc_obj_t prev)
+					   int depth, hwloc_obj_t prev)
 {
   hwloc_obj_t next = hwloc_get_next_obj_by_depth(topology, depth, prev);
   if (!next)
@@ -125,10 +125,10 @@ hwloc_get_next_obj_inside_cpuset_by_type (hwloc_topology_t topology, hwloc_const
  */
 static __hwloc_inline hwloc_obj_t
 hwloc_get_obj_inside_cpuset_by_depth (hwloc_topology_t topology, hwloc_const_cpuset_t set,
-				      unsigned depth, unsigned idx) __hwloc_attribute_pure;
+				      int depth, unsigned idx) __hwloc_attribute_pure;
 static __hwloc_inline hwloc_obj_t
 hwloc_get_obj_inside_cpuset_by_depth (hwloc_topology_t topology, hwloc_const_cpuset_t set,
-				      unsigned depth, unsigned idx)
+				      int depth, unsigned idx)
 {
   hwloc_obj_t obj = hwloc_get_obj_by_depth (topology, depth, 0);
   unsigned count = 0;
@@ -180,10 +180,10 @@ hwloc_get_obj_inside_cpuset_by_type (hwloc_topology_t topology, hwloc_const_cpus
  */
 static __hwloc_inline unsigned
 hwloc_get_nbobjs_inside_cpuset_by_depth (hwloc_topology_t topology, hwloc_const_cpuset_t set,
-					 unsigned depth) __hwloc_attribute_pure;
+					 int depth) __hwloc_attribute_pure;
 static __hwloc_inline unsigned
 hwloc_get_nbobjs_inside_cpuset_by_depth (hwloc_topology_t topology, hwloc_const_cpuset_t set,
-					 unsigned depth)
+					 int depth)
 {
   hwloc_obj_t obj = hwloc_get_obj_by_depth (topology, depth, 0);
   unsigned count = 0;
@@ -319,7 +319,7 @@ hwloc_get_obj_covering_cpuset (hwloc_topology_t topology, hwloc_const_cpuset_t s
  */
 static __hwloc_inline hwloc_obj_t
 hwloc_get_next_obj_covering_cpuset_by_depth(hwloc_topology_t topology, hwloc_const_cpuset_t set,
-					    unsigned depth, hwloc_obj_t prev)
+					    int depth, hwloc_obj_t prev)
 {
   hwloc_obj_t next = hwloc_get_next_obj_by_depth(topology, depth, prev);
   if (!next)
@@ -369,9 +369,9 @@ hwloc_get_next_obj_covering_cpuset_by_type(hwloc_topology_t topology, hwloc_cons
 
 /** \brief Returns the ancestor object of \p obj at depth \p depth. */
 static __hwloc_inline hwloc_obj_t
-hwloc_get_ancestor_obj_by_depth (hwloc_topology_t topology __hwloc_attribute_unused, unsigned depth, hwloc_obj_t obj) __hwloc_attribute_pure;
+hwloc_get_ancestor_obj_by_depth (hwloc_topology_t topology __hwloc_attribute_unused, int depth, hwloc_obj_t obj) __hwloc_attribute_pure;
 static __hwloc_inline hwloc_obj_t
-hwloc_get_ancestor_obj_by_depth (hwloc_topology_t topology __hwloc_attribute_unused, unsigned depth, hwloc_obj_t obj)
+hwloc_get_ancestor_obj_by_depth (hwloc_topology_t topology __hwloc_attribute_unused, int depth, hwloc_obj_t obj)
 {
   hwloc_obj_t ancestor = obj;
   if (obj->depth < depth)
@@ -765,7 +765,7 @@ hwloc_distrib(hwloc_topology_t topology,
 	      hwloc_obj_t *roots, unsigned n_roots,
 	      hwloc_cpuset_t *set,
 	      unsigned n,
-	      unsigned until, unsigned long flags)
+	      int until, unsigned long flags)
 {
   unsigned i;
   unsigned tot_weight;

--- a/include/hwloc/inlines.h
+++ b/include/hwloc/inlines.h
@@ -82,7 +82,7 @@ hwloc_get_obj_by_type (hwloc_topology_t topology, hwloc_obj_type_t type, unsigne
 }
 
 static __hwloc_inline hwloc_obj_t
-hwloc_get_next_obj_by_depth (hwloc_topology_t topology, unsigned depth, hwloc_obj_t prev)
+hwloc_get_next_obj_by_depth (hwloc_topology_t topology, int depth, hwloc_obj_t prev)
 {
   if (!prev)
     return hwloc_get_obj_by_depth (topology, depth, 0);

--- a/tests/hwloc/glibc-sched.c
+++ b/tests/hwloc/glibc-sched.c
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2015 Inria.  All rights reserved.
+ * Copyright © 2009-2017 Inria.  All rights reserved.
  * Copyright © 2009 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
@@ -19,7 +19,7 @@ int main(void)
 {
   hwloc_topology_t topology;
 #ifdef HWLOC_HAVE_CPU_SET
-  unsigned depth;
+  int depth;
   hwloc_bitmap_t hwlocset;
   cpu_set_t schedset;
   hwloc_obj_t obj;

--- a/tests/hwloc/hwloc_bitmap_string.c
+++ b/tests/hwloc/hwloc_bitmap_string.c
@@ -1,7 +1,7 @@
 
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2015 Inria.  All rights reserved.
+ * Copyright © 2009-2017 Inria.  All rights reserved.
  * Copyright © 2009 Université Bordeaux
  * Copyright © 2011 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
@@ -57,7 +57,7 @@ static void check_cpuset(hwloc_bitmap_t set, const char *expected1, const char *
 int main(void)
 {
   hwloc_topology_t topology;
-  unsigned depth;
+  int depth;
   char *string = NULL;
   int stringlen, len;
   hwloc_obj_t obj;

--- a/tests/hwloc/hwloc_distances.c
+++ b/tests/hwloc/hwloc_distances.c
@@ -36,7 +36,7 @@ static void print_distances(const struct hwloc_distances_s *distances)
   }
 }
 
-static void check_distances(hwloc_topology_t topology, unsigned depth, unsigned expected)
+static void check_distances(hwloc_topology_t topology, int depth, unsigned expected)
 {
   struct hwloc_distances_s *distances[2];
  unsigned nr = 0;
@@ -44,13 +44,13 @@ static void check_distances(hwloc_topology_t topology, unsigned depth, unsigned 
   assert(!err);
   assert(nr == expected);
   if (!nr) {
-    printf("No distance at depth %u\n", depth);
+    printf("No distance at depth %d\n", depth);
     return;
   }
   nr = 2;
   err = hwloc_distances_get_by_depth(topology, depth, &nr, distances, 0, 0);
   assert(!err);
-  printf("distance matrix for depth %u:\n", depth);
+  printf("distance matrix for depth %d:\n", depth);
   print_distances(distances[0]);
   hwloc_distances_release(topology, distances[0]);
   if (nr > 1) {
@@ -65,7 +65,7 @@ int main(void)
   struct hwloc_distances_s *distances[2];
   hwloc_obj_t objs[16];
   uint64_t values[16*16], value1, value2;
-  unsigned topodepth;
+  int topodepth;
   unsigned i, j, k, nr;
   int err;
 

--- a/tests/hwloc/hwloc_get_closest_objs.c
+++ b/tests/hwloc/hwloc_get_closest_objs.c
@@ -26,7 +26,7 @@ int
 main (void)
 {
   hwloc_topology_t topology;
-  unsigned depth;
+  int depth;
   hwloc_obj_t last;
   hwloc_obj_t *closest;
   unsigned found;
@@ -71,7 +71,7 @@ main (void)
   assert(hwloc_obj_is_in_subtree(topology, last, ancestor));
   assert(hwloc_obj_is_in_subtree(topology, closest[found-1], ancestor));
   assert(ancestor == hwloc_get_root_obj(topology));
-  printf("ancestor type %d (%s) depth %u number %u is the root object\n",
+  printf("ancestor type %d (%s) depth %d number %u is the root object\n",
 	 (int) ancestor->type, hwloc_type_name(ancestor->type), ancestor->depth, ancestor->logical_index);
 
   free(closest);

--- a/tests/hwloc/hwloc_groups.c
+++ b/tests/hwloc/hwloc_groups.c
@@ -17,7 +17,7 @@ int main(void)
   hwloc_obj_t obj;
   hwloc_obj_t objs[32];
   uint64_t values[32*32];
-  unsigned depth;
+  int depth;
   unsigned width;
   unsigned i, j;
   int err;
@@ -44,7 +44,7 @@ int main(void)
   assert(width == 1);
   /* 3 nodes */
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_NUMANODE);
-  assert((int)depth == HWLOC_TYPE_DEPTH_NUMANODE);
+  assert(depth == HWLOC_TYPE_DEPTH_NUMANODE);
   width = hwloc_get_nbobjs_by_depth(topology, depth);
   assert(width == 3);
   /* find the root obj */
@@ -78,7 +78,7 @@ int main(void)
   assert(!err);
   /* 1 node */
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_NUMANODE);
-  assert((int)depth == HWLOC_TYPE_DEPTH_NUMANODE);
+  assert(depth == HWLOC_TYPE_DEPTH_NUMANODE);
   width = hwloc_get_nbobjs_by_depth(topology, depth);
   assert(width == 1);
   /* 2 groups at depth 1 */

--- a/tests/hwloc/hwloc_object_userdata.c
+++ b/tests/hwloc/hwloc_object_userdata.c
@@ -22,8 +22,8 @@ static char *randomstring;
 
 static void check(hwloc_topology_t topology)
 {
-  unsigned depth;
-  unsigned i,j;
+  int depth, i;
+  unsigned j;
 
   depth = hwloc_topology_get_depth(topology);
   for(i=0; i<depth; i++) {

--- a/tests/hwloc/hwloc_topology_diff.c
+++ b/tests/hwloc/hwloc_topology_diff.c
@@ -74,7 +74,7 @@ int main(void)
   assert(!err);
   tmpdiff = tmpdiff->generic.next;
   assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR);
-  assert(tmpdiff->obj_attr.obj_depth == (unsigned) hwloc_get_type_depth(topo1, HWLOC_OBJ_NUMANODE));
+  assert(tmpdiff->obj_attr.obj_depth == hwloc_get_type_depth(topo1, HWLOC_OBJ_NUMANODE));
   assert(tmpdiff->obj_attr.obj_index == 0);
   assert(tmpdiff->obj_attr.diff.generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR_SIZE);
   assert(tmpdiff->obj_attr.diff.uint64.newvalue - tmpdiff->obj_attr.diff.uint64.oldvalue == 32*4096);
@@ -139,7 +139,7 @@ int main(void)
   assert(!err);
   tmpdiff = tmpdiff->generic.next;
   assert(tmpdiff->generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR);
-  assert(tmpdiff->obj_attr.obj_depth == (unsigned) hwloc_get_type_depth(topo1, HWLOC_OBJ_NUMANODE));
+  assert(tmpdiff->obj_attr.obj_depth == hwloc_get_type_depth(topo1, HWLOC_OBJ_NUMANODE));
   assert(tmpdiff->obj_attr.obj_index == 0);
   assert(tmpdiff->obj_attr.diff.generic.type == HWLOC_TOPOLOGY_DIFF_OBJ_ATTR_SIZE);
   assert(tmpdiff->obj_attr.diff.uint64.newvalue - tmpdiff->obj_attr.diff.uint64.oldvalue == 32*4096);

--- a/tests/hwloc/hwloc_topology_restrict.c
+++ b/tests/hwloc/hwloc_topology_restrict.c
@@ -36,9 +36,9 @@ static void print_distances(const struct hwloc_distances_s *distances)
   }
 }
 
-static void check(unsigned has_groups, unsigned nbnodes, unsigned nbcores, unsigned nbpus)
+static void check(int has_groups, unsigned nbnodes, unsigned nbcores, unsigned nbpus)
 {
-  unsigned depth;
+  int depth;
   unsigned nb;
   unsigned long long total_memory;
 
@@ -46,9 +46,9 @@ static void check(unsigned has_groups, unsigned nbnodes, unsigned nbcores, unsig
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 3 + has_groups);
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_NUMANODE);
-  assert((int) depth == HWLOC_TYPE_DEPTH_NUMANODE);
+  assert(depth == HWLOC_TYPE_DEPTH_NUMANODE);
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_GROUP);
-  assert((int) depth == (has_groups ? 1 : HWLOC_TYPE_DEPTH_UNKNOWN));
+  assert(depth == (has_groups ? 1 : HWLOC_TYPE_DEPTH_UNKNOWN));
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_CORE);
   assert(depth == 1 + has_groups);
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_PU);

--- a/utils/hwloc/hwloc-annotate.c
+++ b/utils/hwloc/hwloc-annotate.c
@@ -113,7 +113,7 @@ hwloc_calc_get_obj_cb(struct hwloc_calc_location_context_s *lcontext __hwloc_att
 }
 
 static void
-add_distances(hwloc_topology_t topology, unsigned topodepth)
+add_distances(hwloc_topology_t topology, int topodepth)
 {
 	unsigned long kind = 0;
 	unsigned nbobjs = 0;
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
 {
 	hwloc_topology_t topology;
 	char *callname, *input, *output, *location;
-	unsigned topodepth;
+	int topodepth;
 	int err;
 
 	callname = argv[0];

--- a/utils/hwloc/hwloc-bind.c
+++ b/utils/hwloc/hwloc-bind.c
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 {
   hwloc_topology_t topology;
   int loaded = 0;
-  unsigned depth;
+  int depth;
   hwloc_bitmap_t cpubind_set, membind_set;
   int got_cpubind = 0, got_membind = 0;
   int working_on_cpubind = 1; /* membind if 0 */

--- a/utils/hwloc/hwloc-calc.c
+++ b/utils/hwloc/hwloc-calc.c
@@ -194,7 +194,7 @@ int main(int argc, char *argv[])
   unsigned long flags = 0;
   char *input = NULL;
   enum hwloc_utils_input_format input_format = HWLOC_UTILS_INPUT_DEFAULT;
-  unsigned depth = 0;
+  int depth = 0;
   hwloc_bitmap_t set;
   int cmdline_args = 0;
   const char * numberoftype = NULL;

--- a/utils/hwloc/hwloc-calc.h
+++ b/utils/hwloc/hwloc-calc.h
@@ -23,7 +23,7 @@
 
 struct hwloc_calc_location_context_s {
   hwloc_topology_t topology;
-  unsigned topodepth;
+  int topodepth;
   int only_hbm; /* -1 for everything, 0 for only non-HBM, 1 for only HBM numa nodes */
   int logical;
   int verbose;
@@ -79,7 +79,7 @@ hwloc_calc_append_set(hwloc_bitmap_t set, hwloc_const_bitmap_t newset,
 static __hwloc_inline unsigned
 hwloc_calc_get_nbobjs_inside_sets_by_depth(struct hwloc_calc_location_context_s *lcontext,
 					   hwloc_const_bitmap_t cpuset, hwloc_const_bitmap_t nodeset,
-					   unsigned depth)
+					   int depth)
 {
   hwloc_topology_t topology = lcontext->topology;
   int only_hbm = lcontext->only_hbm;
@@ -107,7 +107,7 @@ hwloc_calc_get_nbobjs_inside_sets_by_depth(struct hwloc_calc_location_context_s 
 static __hwloc_inline hwloc_obj_t
 hwloc_calc_get_obj_inside_sets_by_depth(struct hwloc_calc_location_context_s *lcontext,
 					hwloc_const_bitmap_t cpuset, hwloc_const_bitmap_t nodeset,
-					unsigned depth, unsigned ind)
+					int depth, unsigned ind)
 {
   hwloc_topology_t topology = lcontext->topology;
   int only_hbm = lcontext->only_hbm;
@@ -146,7 +146,7 @@ hwloc_calc_parse_depth_prefix(struct hwloc_calc_location_context_s *lcontext,
 			      hwloc_obj_type_t *typep)
 {
   hwloc_topology_t topology = lcontext->topology;
-  unsigned topodepth = lcontext->topodepth;
+  int topodepth = lcontext->topodepth;
   int verbose = lcontext->verbose;
   char typestring[20+1]; /* large enough to store all type names, even with a depth attribute */
   hwloc_obj_type_t type;
@@ -183,7 +183,7 @@ hwloc_calc_parse_depth_prefix(struct hwloc_calc_location_context_s *lcontext,
       fprintf(stderr, "invalid type name %s\n", string);
     return -1;
   }
-  if ((unsigned) depth >= topodepth) {
+  if (depth >= topodepth) {
     if (verbose >= 0)
       fprintf(stderr, "ignoring invalid depth %d\n", depth);
     return -1;

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -79,7 +79,7 @@ hwloc_info_show_obj(hwloc_topology_t topology, hwloc_obj_t obj, const char *type
   printf("%s gp index = %llu\n", prefix, (unsigned long long) obj->gp_index);
   if (obj->name)
     printf("%s name = %s\n", prefix, obj->name);
-  printf("%s depth = %d\n", prefix, (int) obj->depth); /* special levels have negative values */
+  printf("%s depth = %d\n", prefix, obj->depth);
   printf("%s sibling rank = %u\n", prefix, obj->sibling_rank);
   printf("%s children = %u\n", prefix, obj->arity);
   printf("%s memory children = %u\n", prefix, obj->memory_arity);
@@ -238,7 +238,7 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
     char parents[128];
     hwloc_obj_t parent = obj;
     while (parent) {
-      if (parent->depth == (unsigned) show_ancestor_depth) {
+      if (parent->depth == show_ancestor_depth) {
 	hwloc_obj_type_snprintf(parents, sizeof(parents), parent, 1);
 	if (verbose < 0)
 	  printf("%s%s:%u\n", prefix, parents, parent->logical_index);
@@ -333,7 +333,7 @@ main (int argc, char *argv[])
 {
   int err;
   hwloc_topology_t topology;
-  unsigned topodepth;
+  int topodepth;
   unsigned long flags = 0;
   char * callname;
   char * input = NULL;
@@ -538,7 +538,7 @@ main (int argc, char *argv[])
       usage(callname, stderr);
       return EXIT_FAILURE;
     }
-    if (show_ancestor_depth == (int) HWLOC_TYPE_DEPTH_UNKNOWN) {
+    if (show_ancestor_depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
       fprintf(stderr, "unavailable --ancestor type %s\n", show_ancestor_type);
       return EXIT_FAILURE;
     }
@@ -554,7 +554,7 @@ main (int argc, char *argv[])
       usage(callname, stderr);
       return EXIT_FAILURE;
     }
-    if (show_descendants_depth == (int) HWLOC_TYPE_DEPTH_UNKNOWN) {
+    if (show_descendants_depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
       fprintf(stderr, "unavailable --descendants type %s\n", show_descendants_type);
       return EXIT_FAILURE;
     }

--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -373,8 +373,8 @@ hwloc_lstopo_show_summary_depth(FILE *output, size_t prefixmaxlen, hwloc_topolog
 static __hwloc_inline void
 hwloc_lstopo_show_summary(FILE *output, hwloc_topology_t topology)
 {
-  unsigned topodepth = hwloc_topology_get_depth(topology);
-  unsigned depth;
+  int topodepth = hwloc_topology_get_depth(topology);
+  int depth;
   size_t prefixmaxlen, sdepthmaxlen;
 
   prefixmaxlen = topodepth-1 + strlen("depth xyz:  ");

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -1148,7 +1148,7 @@ output_compute_pu_min_textwidth(struct lstopo_output *output)
   }
 
   if (output->logical) {
-    unsigned depth = hwloc_get_type_depth(topology, HWLOC_OBJ_PU);
+    int depth = hwloc_get_type_depth(topology, HWLOC_OBJ_PU);
     lastpu = hwloc_get_obj_by_depth(topology, depth, hwloc_get_nbobjs_by_depth(topology, depth)-1);
   } else {
     unsigned lastidx = hwloc_bitmap_last(hwloc_topology_get_topology_cpuset(topology));

--- a/utils/lstopo/lstopo-text.c
+++ b/utils/lstopo/lstopo-text.c
@@ -218,7 +218,7 @@ static void output_distances(struct lstopo_output *loutput)
 	      kindmeans, dist[j]->kind,
 	      dist[j]->nbobjs,
 	      hwloc_type_name(dist[j]->objs[0]->type),
-	      (int) dist[j]->objs[0]->depth,
+	      dist[j]->objs[0]->depth,
 	      logical ? "logical" : "physical");
       hwloc_utils_print_distance_matrix(output, dist[j]->nbobjs, dist[j]->objs, dist[j]->values, logical);
       hwloc_distances_release(topology, dist[j]);


### PR DESCRIPTION
Change obj->depth to signed int, and all relevant function manipulating
object depths.

We have negative depth for special levels so we cast in lots of places.
This is becoming even more common with the NUMAnode special level.

Also change hwloc_topology_get_depth() to signed to avoid signedness
comparison warnings when iterating over depths.
That one is less obvious since it's always >0 and even an unsigned internally.

Cache/Bridge/Group specific depth attr are still unsigned,
those are never negative.
It's not clear whether mixing signed depth for object and unsigned
for attribute could cause confusion.

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>