### PR TITLE
Consistent naming of Intel(R) Xeon Phi(TM) processors in messages and documentation

### DIFF
--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -38,8 +38,7 @@ hwloc supports the following operating systems:
 <ul>
 <li>Linux (including old kernels not having sysfs topology
 information, with knowledge of cpusets, ScaleMP vSMP support, etc.)
-on all supported hardware, including Intel Xeon Phi
-(KNL and KNC, either standalone or as a coprocessor)
+on all supported hardware, including Intel(R) Xeon Phi(TM) processors and coprocessors,
 and NumaScale NumaConnect.</li>
 <li>Solaris (with support for processor sets and logical domains)</li>
 <li>AIX</li>
@@ -1091,7 +1090,7 @@ following environment variables.
   uses /proc/cpuinfo instead of sysfs.
   may be useful in the doc for debugging?
  HWLOC_KNL_NUMA_QUIRK
-  disables the KNL NUMA Cluster quirk in the linux backend
+  disables the Intel(R) Xeon Phi(TM) processor NUMA Cluster quirk in the linux backend
  HWLOC_DEBUG_CHECK
   runs sanity checks during discovery, as if \--enable-debug was passed but
   without debug messages
@@ -1870,8 +1869,8 @@ These groups are merged back into the parent when possible
 (typically when a single NUMA node is requested below each parent).
 
 It is also possible the explicitly attach NUMA nodes to specific levels.
-For instance, a KNL-like topology with 2 NUMA nodes per 16-core group
-may be created with:
+For instance, an Intel(R) Xeon Phi(TM) processor topology with 2 NUMA nodes
+per 16-core group may be created with:
 \verbatim
 $ lstopo -i "package:1 group:4 [numa] [numa] core:16 pu:4"
 \endverbatim
@@ -3265,7 +3264,7 @@ Starting with version 2.0, hwloc properly exposes this memory
 configuration.
 DDR and MCDRAM are attached as two memory children of the same parent,
 DDR first, and MCDRAM second if any.
-Depending on the KNL configuration, that parent may be a Package,
+Depending on the Intel(R) Xeon Phi(TM) processor configuration, that parent may be a Package,
 a Cache, or a Group object of type <tt>Cluster</tt>.
 
 Hence cores may have one or two local NUMA nodes, listed by the core nodeset.
@@ -3316,7 +3315,7 @@ https://github.com/TresysTechnology/refpolicy-contrib
 
 hwloc-dump-hwdata requires <tt>dmi-sysfs</tt> kernel module loaded.
 
-The utility is currently unneeded on non-KNL platforms.
+The utility is currently unneeded on platforms without Intel(R) Xeon Phi(TM) processors.
 
 See <tt>HWLOC_DUMPED_HWDATA_DIR</tt> in \ref envvar for details
 about the location of dumped files.

--- a/utils/hwloc/hwloc-dump-hwdata-knl.c
+++ b/utils/hwloc/hwloc-dump-hwdata-knl.c
@@ -18,7 +18,7 @@
 
 #define KERNEL_SMBIOS_SYSFS "/sys/firmware/dmi/entries"
 
-#define KNL_SMBIOS_GROUP_STRING "Group: Knights Landing Information"
+#define KNL_SMBIOS_GROUP_STRING "Group: Intel(R) Xeon Phi(TM) Processor Information"
 
 /* Header is common part of all SMBIOS entries */
 struct smbios_header
@@ -209,7 +209,7 @@ static int process_smbios_group(const char *input_fsroot, char *dir_name, struct
     h = (struct smbios_header*)file_buf;
     end = file_buf+size;
     if (!is_knl_group(h, end)) {
-        fprintf(stderr, "SMBIOS table does not contain KNL entries\n");
+        fprintf(stderr, "SMBIOS table does not contain Intel(R) Xeon Phi(TM) processor entries\n");
         return -1;
     }
 
@@ -225,7 +225,7 @@ static int process_smbios_group(const char *input_fsroot, char *dir_name, struct
     for (; p < end; i++, p+=3) {
         struct smbios_group_entry *e = (struct smbios_group_entry*)p;
         data->knl_types[i] = e->type;
-        printf("  Found KNL type = %d\n", e->type);
+        printf("  Found Intel(R) Xeon Phi(TM) processor type = %d\n", e->type);
     }
 
     data->type_count = i;
@@ -254,7 +254,7 @@ static int process_knl_entry(const char *input_fsroot, char *dir_name, struct pa
     if (h->member_id & KNL_MEMBER_ID_GENERAL) {
         struct knl_general_info *info =
             (struct knl_general_info*) (file_buf+SMBIOS_KNL_HEADER_SIZE);
-        printf("  Getting general KNL info\n");
+        printf("  Getting general Intel(R) Xeon Phi(TM) processor info\n");
         data->cluster_mode = info->cluster_mode;
         data->memory_mode = info->memory_mode;
         data->cache_info = info->cache_info;
@@ -271,11 +271,11 @@ static int process_knl_entry(const char *input_fsroot, char *dir_name, struct pa
                 printf("  MCDRAM info size is set to 0, falling back to known size\n");
                 struct_size = sizeof(*mi);
             }
-            printf("  Getting MCDRAM KNL info. Count=%d struct size=%d\n",
+            printf("  Getting Intel(R) Xeon Phi(TM) processor MCDRAM info. Count=%d struct size=%d\n",
                    (int)info->mcdram_info_count, struct_size);
             for ( ; i < info->mcdram_info_count; i++) {
                 if ((char*)mi >= end) {
-                    fprintf(stderr, "SMBIOS KNL entry is too small\n");
+                    fprintf(stderr, "Intel(R) Xeon Phi(TM) processor SMBIOS entry is too small\n");
                     return -1;
                 }
                 printf("  MCDRAM controller %d\n", mi->controller);
@@ -449,7 +449,7 @@ int hwloc_dump_hwdata_knl_smbios(const char *input_fsroot, const char *outfile)
     char path[PATH_SIZE];
     int err;
 
-    printf("Dumping KNL SMBIOS Memory-Side Cache information:\n");
+    printf("Dumping Intel(R) Xeon Phi(TM) processor SMBIOS Memory-Side Cache information:\n");
 
     snprintf(path, PATH_SIZE-1, "%s/" KERNEL_SMBIOS_SYSFS, input_fsroot);
     path[PATH_SIZE-1] = 0;
@@ -475,7 +475,7 @@ int hwloc_dump_hwdata_knl_smbios(const char *input_fsroot, const char *outfile)
     }
 
     if (!data.type_count) {
-      fprintf (stderr, "  Couldn't find any KNL information.\n");
+      fprintf (stderr, "  Couldn't find any Intel(R) Xeon Phi(TM) processor information.\n");
       closedir(d);
       return -1;
     }


### PR DESCRIPTION
For both Knights Landing (KNL) and Knights Mill (KNM) processors mostly
the same code and documentation is used. Therefore text regarding these
processors has to be consistent and appropriate for both KNL and KNM.

Signed-off-by: Dawid Łukwiński <dawid.lukwinski@intel.com>