### PR TITLE
Check for freed memory before using it

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -1777,20 +1777,22 @@ hwloc_convert_from_v1dist_floats(topology, nbobjs, v1dist->floats, values);
     fprintf(stderr, "%s: XML component discovery failed.\n",
 	    data->msgprefix);
  err:
-  hwloc_free_object_siblings_and_children(root->first_child);
-  root->first_child = NULL;
-  hwloc_free_object_siblings_and_children(root->memory_first_child);
-  root->memory_first_child = NULL;
-  hwloc_free_object_siblings_and_children(root->io_first_child);
-  root->io_first_child = NULL;
-  hwloc_free_object_siblings_and_children(root->misc_first_child);
-  root->misc_first_child = NULL;
+  if (NULL != root) {
+    hwloc_free_object_siblings_and_children(root->first_child);
+    root->first_child = NULL;
+    hwloc_free_object_siblings_and_children(root->memory_first_child);
+    root->memory_first_child = NULL;
+    hwloc_free_object_siblings_and_children(root->io_first_child);
+    root->io_first_child = NULL;
+    hwloc_free_object_siblings_and_children(root->misc_first_child);
+    root->misc_first_child = NULL;
 
-  /* make sure the core will abort */
-  if (root->cpuset)
-    hwloc_bitmap_zero(root->cpuset);
-  if (root->nodeset)
-    hwloc_bitmap_zero(root->nodeset);
+    /* make sure the core will abort */
+    if (root->cpuset)
+      hwloc_bitmap_zero(root->cpuset);
+    if (root->nodeset)
+      hwloc_bitmap_zero(root->nodeset);
+  }
 
   hwloc_localeswitch_fini();
   return -1;

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -469,6 +469,7 @@ hwloc_free_unlinked_object(hwloc_obj_t obj)
 {
   hwloc__free_object_contents(obj);
   free(obj);
+  obj = NULL;
 }
 
 /* Replace old with contents of new object, and make new freeable by the caller.


### PR DESCRIPTION
The error case of `hwloc_convert_from_v1dist_floats` cleans up memory
which might have previously been freed if the right set of error
branches occur. By explicitly setting the memory pointer to `NULL` after
freeing it, we can later check that value and make sure we don't
dereference an freed pointer.

See Coverity defects 185552, 185546, and 185542 in MPICH-CH4 project