### PR TITLE
Miscellaneous compiler warning fixes

### DIFF
--- a/hwloc/misc.c
+++ b/hwloc/misc.c
@@ -2,7 +2,7 @@
  * Copyright © 2009 CNRS
  * Copyright © 2009-2015 Inria.  All rights reserved.
  * Copyright © 2009-2010 Université Bordeaux
- * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2009-2018 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -128,18 +128,18 @@ char *
 hwloc_progname(struct hwloc_topology *topology __hwloc_attribute_unused)
 {
 #if HAVE_DECL_GETMODULEFILENAME
-  char name[256], *basename;
+  char name[256], *local_basename;
   unsigned res = GetModuleFileName(NULL, name, sizeof(name));
   if (res == sizeof(name) || !res)
     return NULL;
-  basename = strrchr(name, '\\');
-  if (!basename)
-    basename = name;
+  local_basename = strrchr(name, '\\');
+  if (!local_basename)
+    local_basename = name;
   else
-    basename++;
-  return strdup(basename);
+    local_basename++;
+  return strdup(local_basename);
 #else /* !HAVE_GETMODULEFILENAME */
-  const char *name, *basename;
+  const char *name, *local_basename;
 #if HAVE_DECL_GETPROGNAME
   name = getprogname(); /* FreeBSD, NetBSD, some Solaris */
 #elif HAVE_DECL_GETEXECNAME
@@ -156,11 +156,11 @@ hwloc_progname(struct hwloc_topology *topology __hwloc_attribute_unused)
 #endif
   if (!name)
     return NULL;
-  basename = strrchr(name, '/');
-  if (!basename)
-    basename = name;
+  local_basename = strrchr(name, '/');
+  if (!local_basename)
+    local_basename = name;
   else
-    basename++;
-  return strdup(basename);
+    local_basename++;
+  return strdup(local_basename);
 #endif /* !HAVE_GETMODULEFILENAME */
 }

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -2,7 +2,7 @@
  * Copyright © 2009 CNRS
  * Copyright © 2009-2018 Inria.  All rights reserved.
  * Copyright © 2009-2013, 2015 Université Bordeaux
- * Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2009-2018 Cisco Systems, Inc.  All rights reserved.
  * Copyright © 2015 Intel, Inc.  All rights reserved.
  * Copyright © 2010 IBM
  * See COPYING in top-level directory.
@@ -3441,7 +3441,7 @@ look_sysfscpu(struct hwloc_topology *topology,
       sprintf(str, "%s/cpu%d/topology/thread_siblings", path, i);
       coreset = hwloc__alloc_read_path_as_cpumask(str, data->root_fd);
       if (coreset) {
-        unsigned mycoreid;
+        unsigned mycoreid = (unsigned) -1;
 	int gotcoreid = 0; /* to avoid reading the coreid twice */
 	hwloc_bitmap_and(coreset, coreset, cpuset);
 	if (hwloc_bitmap_weight(coreset) > 1 && threadwithcoreid == -1) {

--- a/hwloc/topology-pci.c
+++ b/hwloc/topology-pci.c
@@ -2,7 +2,7 @@
  * Copyright © 2009 CNRS
  * Copyright © 2009-2018 Inria.  All rights reserved.
  * Copyright © 2009-2011, 2013 Université Bordeaux
- * Copyright © 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2014-2018 Cisco Systems, Inc.  All rights reserved.
  * Copyright © 2015      Research Organization for Information Science
  *                       and Technology (RIST). All rights reserved.
  * See COPYING in top-level directory.
@@ -204,15 +204,15 @@ hwloc_look_pci(struct hwloc_backend *backend)
       char path[64];
       char value[16];
       FILE *file;
-      size_t read;
+      size_t bytes_read;
 
       snprintf(path, sizeof(path), "/sys/bus/pci/devices/%04x:%02x:%02x.%01x/vendor",
 	       domain, pcidev->bus, pcidev->dev, pcidev->func);
       file = fopen(path, "r");
       if (file) {
-	read = fread(value, 1, sizeof(value), file);
+	bytes_read = fread(value, 1, sizeof(value), file);
 	fclose(file);
-	if (read)
+	if (bytes_read)
 	  /* fixup the pciaccess struct so that pci_device_get_vendor_name() is correct later. */
           pcidev->vendor_id = strtoul(value, NULL, 16);
       }
@@ -221,9 +221,9 @@ hwloc_look_pci(struct hwloc_backend *backend)
 	       domain, pcidev->bus, pcidev->dev, pcidev->func);
       file = fopen(path, "r");
       if (file) {
-	read = fread(value, 1, sizeof(value), file);
+	bytes_read = fread(value, 1, sizeof(value), file);
 	fclose(file);
-	if (read)
+	if (bytes_read)
 	  /* fixup the pciaccess struct so that pci_device_get_device_name() is correct later. */
           pcidev->device_id = strtoul(value, NULL, 16);
       }
@@ -251,25 +251,25 @@ hwloc_look_pci(struct hwloc_backend *backend)
       char path[64];
       char value[16];
       FILE *file;
-      size_t read;
+      size_t bytes_read;
       float speed = 0.f;
       unsigned width = 0;
       snprintf(path, sizeof(path), "/sys/bus/pci/devices/%04x:%02x:%02x.%01x/current_link_speed",
 	       domain, pcidev->bus, pcidev->dev, pcidev->func);
       file = fopen(path, "r");
       if (file) {
-	read = fread(value, 1, sizeof(value), file);
+	bytes_read = fread(value, 1, sizeof(value), file);
 	fclose(file);
-	if (read)
+	if (bytes_read)
 	  speed = hwloc_linux_pci_link_speed_from_string(value);
       }
       snprintf(path, sizeof(path), "/sys/bus/pci/devices/%04x:%02x:%02x.%01x/current_link_width",
 	       domain, pcidev->bus, pcidev->dev, pcidev->func);
       file = fopen(path, "r");
       if (file) {
-	read = fread(value, 1, sizeof(value), file);
+	bytes_read = fread(value, 1, sizeof(value), file);
 	fclose(file);
-	if (read)
+	if (bytes_read)
 	  width = atoi(value);
       }
       obj->attr->pcidev.linkspeed = speed*width/8;

--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -2,7 +2,7 @@
  * Copyright © 2009 CNRS
  * Copyright © 2009-2018 Inria.  All rights reserved.
  * Copyright © 2009-2011 Université Bordeaux
- * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2009-2018 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -1804,18 +1804,18 @@ hwloc_topology_diff_load_xml(const char *xmlpath,
   struct hwloc__xml_import_state_s state;
   struct hwloc_xml_backend_data_s fakedata; /* only for storing global info during parsing */
   hwloc_localeswitch_declare;
-  const char *basename;
+  const char *local_basename;
   int force_nolibxml;
   int ret;
 
   state.global = &fakedata;
 
-  basename = strrchr(xmlpath, '/');
-  if (basename)
-    basename++;
+  local_basename = strrchr(xmlpath, '/');
+  if (local_basename)
+    local_basename++;
   else
-    basename = xmlpath;
-  fakedata.msgprefix = strdup(basename);
+    local_basename = xmlpath;
+  fakedata.msgprefix = strdup(local_basename);
 
   hwloc_components_init();
   assert(hwloc_nolibxml_callbacks);
@@ -2732,7 +2732,7 @@ hwloc_xml_component_instantiate(struct hwloc_disc_component *component,
   const char * xmlpath = (const char *) _data1;
   const char * xmlbuffer = (const char *) _data2;
   int xmlbuflen = (int)(uintptr_t) _data3;
-  const char *basename;
+  const char *local_basename;
   int err;
 
   assert(hwloc_nolibxml_callbacks); /* the core called components_init() for the component's topology */
@@ -2764,15 +2764,15 @@ hwloc_xml_component_instantiate(struct hwloc_disc_component *component,
   backend->is_thissystem = 0;
 
   if (xmlpath) {
-    basename = strrchr(xmlpath, '/');
-    if (basename)
-      basename++;
+    local_basename = strrchr(xmlpath, '/');
+    if (local_basename)
+      local_basename++;
     else
-      basename = xmlpath;
+      local_basename = xmlpath;
   } else {
-    basename = "xmlbuffer";
+    local_basename = "xmlbuffer";
   }
-  data->msgprefix = strdup(basename);
+  data->msgprefix = strdup(local_basename);
 
   force_nolibxml = hwloc_nolibxml_import();
 retry:

--- a/utils/hwloc/hwloc-bind.c
+++ b/utils/hwloc/hwloc-bind.c
@@ -2,7 +2,7 @@
  * Copyright © 2009 CNRS
  * Copyright © 2009-2018 Inria.  All rights reserved.
  * Copyright © 2009-2010, 2012 Université Bordeaux
- * Copyright © 2009 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2009-2018 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
 {
   hwloc_topology_t topology;
   int loaded = 0;
-  int depth;
+  int depth = -1;
   hwloc_bitmap_t cpubind_set, membind_set;
   int got_cpubind = 0, got_membind = 0;
   int working_on_cpubind = 1; /* membind if 0 */


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Fix 2 kinds of compiler warnings:

1. Uninitialized variables
1. Local symbols shadowing global symbols