### PR TITLE
Define HWLOC_VERSION* in hwloc/autogen/config.h public header

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -5,7 +5,7 @@
 # major, minor, and release are generally combined in the form
 # <major>.<minor>.<release>.  If release is zero, then it is omitted.
 
-# Please update HWLOC_VERSION in contrib/windows/private_config.h too.
+# Please update HWLOC_VERSION* in contrib/windows/hwloc_config.h too.
 
 major=2
 minor=1

--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -85,12 +85,13 @@ EOF])
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
-    HWLOC_RELEASE_DATE="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --release-date`"
+    AC_MSG_RESULT([$HWLOC_VERSION])
     AC_SUBST(HWLOC_VERSION)
     AC_DEFINE_UNQUOTED([HWLOC_VERSION], ["$HWLOC_VERSION"],
                        [The library version, always available, even in embedded mode, contrary to VERSION])
+
+    HWLOC_RELEASE_DATE="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --release-date`"
     AC_SUBST(HWLOC_RELEASE_DATE)
-    AC_MSG_RESULT([$HWLOC_VERSION])
 
     # Debug mode?
     AC_MSG_CHECKING([if want hwloc maintainer support])

--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -90,6 +90,15 @@ EOF])
     AC_DEFINE_UNQUOTED([HWLOC_VERSION], ["$HWLOC_VERSION"],
                        [The library version, always available, even in embedded mode, contrary to VERSION])
 
+    HWLOC_VERSION_MAJOR="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --major`"
+    AC_DEFINE_UNQUOTED([HWLOC_VERSION_MAJOR], [$HWLOC_VERSION_MAJOR], [The library version major number])
+    HWLOC_VERSION_MINOR="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --minor`"
+    AC_DEFINE_UNQUOTED([HWLOC_VERSION_MINOR], [$HWLOC_VERSION_MINOR], [The library version minor number])
+    HWLOC_VERSION_RELEASE="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --release`"
+    AC_DEFINE_UNQUOTED([HWLOC_VERSION_RELEASE], [$HWLOC_VERSION_RELEASE], [The library version release number])
+    HWLOC_VERSION_GREEK="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --greek`"
+    AC_DEFINE_UNQUOTED([HWLOC_VERSION_GREEK], ["$HWLOC_VERSION_GREEK"], [The library version optional greek suffix string])
+
     HWLOC_RELEASE_DATE="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --release-date`"
     AC_SUBST(HWLOC_RELEASE_DATE)
 

--- a/config/hwloc_get_version.sh
+++ b/config/hwloc_get_version.sh
@@ -11,7 +11,7 @@
 # Copyright © 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright © 2008-2014 Cisco Systems, Inc.  All rights reserved.
-# Copyright © 2014 Inria.  All rights reserved.
+# Copyright © 2014-2018 Inria.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -70,6 +70,18 @@ case "$option" in
     --version)
 	echo $HWLOC_VERSION
 	;;
+    --major)
+        echo $HWLOC_MAJOR_VERSION
+        ;;
+    --minor)
+        echo $HWLOC_MINOR_VERSION
+        ;;
+    --release)
+        echo $HWLOC_RELEASE_VERSION
+        ;;
+    --greek)
+        echo $HWLOC_GREEK_VERSION
+        ;;
     --release-date)
         echo $HWLOC_RELEASE_DATE
         ;;
@@ -82,7 +94,11 @@ $0 <srcfile> <option>
 
 <srcfile> - Text version file
 <option>  - One of:
-    --version      - Show version number
+    --version      - Show full version number
+    --major        - Major version number
+    --minor        - Minor version number
+    --release      - Release version number
+    --greek        - Greek (alpha, beta, etc) version suffix
     --release-date - Show the release date
     --snapshot     - Show whether this is a snapshot release or not
     --help         - This message

--- a/contrib/windows/hwloc_config.h
+++ b/contrib/windows/hwloc_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2017 Inria.  All rights reserved.
+ * Copyright © 2009-2018 Inria.  All rights reserved.
  * Copyright © 2009-2012 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
@@ -10,6 +10,12 @@
 
 #ifndef HWLOC_CONFIG_H
 #define HWLOC_CONFIG_H
+
+#define HWLOC_VERSION "2.1.0"
+#define HWLOC_VERSION_MAJOR 2
+#define HWLOC_VERSION_MINOR 1
+#define HWLOC_VERSION_RELEASE 0
+#define HWLOC_VERSION_GREEK ""
 
 #define __hwloc_restrict
 #define __hwloc_inline __inline

--- a/contrib/windows/private_config.h
+++ b/contrib/windows/private_config.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009, 2011, 2012 CNRS.  All rights reserved.
- * Copyright © 2009-2016 Inria.  All rights reserved.
+ * Copyright © 2009-2018 Inria.  All rights reserved.
  * Copyright © 2009, 2011, 2012, 2015 Université Bordeaux.  All rights reserved.
  * Copyright © 2009 Cisco Systems, Inc.  All rights reserved.
  * $COPYRIGHT$
@@ -640,7 +640,6 @@
 
 
 /* Version number of package */
-#define HWLOC_VERSION "2.1.0"
 #define VERSION HWLOC_VERSION
 
 /* Define to 1 if the X Window System is missing or not being used. */

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -3436,6 +3436,11 @@ and <tt>hwloc_get_api_version()</tt> came only in 1.1.1.
 Also do not use the old cpuset API since it was deprecated and superseded
 by the bitmap API in 1.1, and later removed in 1.5.
 
+If you ever need to look at the library version instead of the API version,
+you may want to use HWLOC_VERSION instead.
+Two stable releases of the same series usually have the same ::HWLOC_API_VERSION
+even if their HWLOC_VERSION are different.
+
 
 
 \htmlonly

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -87,6 +87,10 @@ extern "C" {
  *
  * Users may check for available features at build time using this number
  * (see \ref faq_upgrade).
+ *
+ * \note This should not be confused with HWLOC_VERSION, the library version.
+ * Two stable releases of the same series usually have the same ::HWLOC_API_VERSION
+ * even if their HWLOC_VERSION are different.
  */
 #define HWLOC_API_VERSION 0x00020100
 

--- a/include/hwloc/autogen/config.h.in
+++ b/include/hwloc/autogen/config.h.in
@@ -1,6 +1,6 @@
 /* -*- c -*-
  * Copyright © 2009 CNRS
- * Copyright © 2009-2017 Inria.  All rights reserved.
+ * Copyright © 2009-2018 Inria.  All rights reserved.
  * Copyright © 2009-2012 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
@@ -10,6 +10,12 @@
 
 #ifndef HWLOC_CONFIG_H
 #define HWLOC_CONFIG_H
+
+#undef HWLOC_VERSION
+#undef HWLOC_VERSION_MAJOR
+#undef HWLOC_VERSION_MINOR
+#undef HWLOC_VERSION_RELEASE
+#undef HWLOC_VERSION_GREEK
 
 #if (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 95))
 # define __hwloc_restrict __restrict

--- a/tests/hwloc/linux/allowed/test-topology.sh.in
+++ b/tests/hwloc/linux/allowed/test-topology.sh.in
@@ -12,7 +12,6 @@
 # Check the conformance of `lstopo' for all the Linux sysfs
 # hierarchies available here.  Return true on success.
 
-HWLOC_VERSION="@HWLOC_VERSION@"
 HWLOC_top_srcdir="@HWLOC_top_srcdir@"
 HWLOC_top_builddir="@HWLOC_top_builddir@"
 lstopo="$HWLOC_top_builddir/utils/lstopo/lstopo-no-graphics"

--- a/tests/hwloc/linux/test-topology.sh.in
+++ b/tests/hwloc/linux/test-topology.sh.in
@@ -12,7 +12,6 @@
 # Check the conformance of `lstopo' for all the Linux sysfs
 # hierarchies available here.  Return true on success.
 
-HWLOC_VERSION="@HWLOC_VERSION@"
 HWLOC_top_srcdir="@HWLOC_top_srcdir@"
 HWLOC_top_builddir="@HWLOC_top_builddir@"
 lstopo="$HWLOC_top_builddir/utils/lstopo/lstopo-no-graphics"

--- a/tests/hwloc/x86/test-topology.sh.in
+++ b/tests/hwloc/x86/test-topology.sh.in
@@ -6,7 +6,6 @@
 # See COPYING in top-level directory.
 #
 
-HWLOC_VERSION="@HWLOC_VERSION@"
 HWLOC_top_srcdir="@HWLOC_top_srcdir@"
 HWLOC_top_builddir="@HWLOC_top_builddir@"
 lstopo="$HWLOC_top_builddir/utils/lstopo/lstopo-no-graphics"

--- a/utils/hwloc/test-hwloc-info.sh.in
+++ b/utils/hwloc/test-hwloc-info.sh.in
@@ -9,7 +9,6 @@
 # See COPYING in top-level directory.
 #
 
-HWLOC_VERSION="@HWLOC_VERSION@"
 HWLOC_top_srcdir="@HWLOC_top_srcdir@"
 HWLOC_top_builddir="@HWLOC_top_builddir@"
 srcdir="$HWLOC_top_srcdir/utils/hwloc"

--- a/utils/lstopo/test-lstopo.sh.in
+++ b/utils/lstopo/test-lstopo.sh.in
@@ -8,7 +8,6 @@
 # See COPYING in top-level directory.
 #
 
-HWLOC_VERSION="@HWLOC_VERSION@"
 HWLOC_top_srcdir="@HWLOC_top_srcdir@"
 HWLOC_top_builddir="@HWLOC_top_builddir@"
 srcdir="$HWLOC_top_srcdir/utils/lstopo"


### PR DESCRIPTION
OMPI would like a way to check the hwloc library version (not API version) from external configure scripts (open-mpi/ompi#5395). We currently have HWLOC_VERSION defined in private/autogen/config.h
It's only there because it wasn't prefixed with HWLOC_ in the past. Now that it's properly prefixed, there's no reason to keep it private.
Also add HWLOC_VERSION_{MAJOR,MINOR,RELEASE,GREEK} to avoid external parsing.
