### PR TITLE
contrib/ci.inria.fr: keep the full branch name for the snapshot version

### DIFF
--- a/contrib/ci.inria.fr/job-0-tarball.sh
+++ b/contrib/ci.inria.fr/job-0-tarball.sh
@@ -20,10 +20,10 @@ test -f $HOME/.ciprofile && . $HOME/.ciprofile
 
 # keep branch-name before the first - (e.g. v2.0-beta becomes v2.0)
 # and look for the corresponding autotools
-branch=$( echo $branch | sed -r -e 's@^.*/([^/]+)$@\1@' -e 's/-.*//' )
-if test -d $HOME/local/hwloc-$branch ; then
-  export PATH=$HOME/local/hwloc-${branch}/bin:$PATH
-  echo using specific $HOME/local/hwloc-$branch
+basebranch=$( echo $branch | sed -r -e 's@^.*/([^/]+)$@\1@' -e 's/-.*//' )
+if test -d $HOME/local/hwloc-$basebranch ; then
+  export PATH=$HOME/local/hwloc-${basebranch}/bin:$PATH
+  echo using specific $HOME/local/hwloc-$basebranch
 else
   export PATH=$HOME/local/hwloc-master/bin:$PATH
   echo using generic $HOME/local/hwloc-master


### PR DESCRIPTION
There's no reason to remove it.
At least now we'll keep "PR-xyz" instead of "PR" in the name.

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>

Also use that PR to debug failures to configure on openindiana when building the version branch as a PR and not as a normal branch.