### PR TITLE
Support for clang-cl on windows

### DIFF
--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -491,7 +491,7 @@ EOF])
     # Needed for Windows in private/misc.h
     AC_CHECK_TYPES([ssize_t])
     AC_CHECK_DECLS([snprintf], [], [], [AC_INCLUDES_DEFAULT])
-    AC_CHECK_DECLS([strcasecmp], [], [], [AC_INCLUDES_DEFAULT])
+    AC_CHECK_DECLS([strcasecmp], [], [], [[#include <strings.h>]])
     # strdup and putenv are declared in windows headers but marked deprecated
     AC_CHECK_DECLS([_strdup], [], [], [AC_INCLUDES_DEFAULT])
     AC_CHECK_DECLS([_putenv], [], [], [AC_INCLUDES_DEFAULT])

--- a/config/hwloc_internal.m4
+++ b/config/hwloc_internal.m4
@@ -339,6 +339,7 @@ EOF
 
     _HWLOC_CHECK_DIFF_U
     _HWLOC_CHECK_DIFF_W
+    _HWLOC_CHECK_DIFF_STRIP_TRAILING_CR
 
     AC_CHECK_HEADERS([time.h], [
       AC_CHECK_FUNCS([clock_gettime])
@@ -410,6 +411,7 @@ int foo(void) {
     AC_MSG_RESULT([$hwloc_have_cxx])
 
     _HWLOC_CHECK_DIFF_U
+    _HWLOC_CHECK_DIFF_STRIP_TRAILING_CR
 
     # Only generate these files if we're making the tests
     AC_CONFIG_FILES(
@@ -511,6 +513,20 @@ AC_DEFUN([_HWLOC_CHECK_DIFF_U], [
     HWLOC_DIFF_U=""
   fi
   AC_SUBST([HWLOC_DIFF_U])
+])
+
+AC_DEFUN([_HWLOC_CHECK_DIFF_STRIP_TRAILING_CR], [
+  AC_REQUIRE([_HWLOC_PROG_DIFF])
+  AC_MSG_CHECKING([whether diff accepts --strip-trailing-cr])
+  if $DIFF --strip-trailing-cr /dev/null /dev/null 2> /dev/null
+  then
+    AC_MSG_RESULT([yes])
+    HWLOC_DIFF_STRIP_TRAILING_CR="--strip-trailing-cr"
+  else
+    AC_MSG_RESULT([no])
+    HWLOC_DIFF_STRIP_TRAILING_CR=""
+  fi
+  AC_SUBST([HWLOC_DIFF_STRIP_TRAILING_CR])
 ])
 
 AC_DEFUN([_HWLOC_CHECK_DIFF_W], [

--- a/doc/examples/cpuset+bitmap+cpubind.c
+++ b/doc/examples/cpuset+bitmap+cpubind.c
@@ -11,7 +11,9 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 
 int main(void)
 {

--- a/doc/examples/nodeset+membind+policy.c
+++ b/doc/examples/nodeset+membind+policy.c
@@ -11,7 +11,9 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#endif
 #include <assert.h>
 
 int main(void)

--- a/doc/examples/sharedcaches.c
+++ b/doc/examples/sharedcaches.c
@@ -9,7 +9,11 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#else
+#define pid_t int
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/tests/hwloc/hwloc_backends.c
+++ b/tests/hwloc/hwloc_backends.c
@@ -22,7 +22,11 @@
 static inline int mkstemp(char *name)
 {
   mktemp(name);
+#ifdef _MSC_VER
+  return open(name, O_RDWR|O_CREAT, 00700);
+#else
   return open(name, O_RDWR|O_CREAT, S_IRWXU);
+#endif
 }
 #endif
 

--- a/tests/hwloc/linux/allowed/test-topology.sh.in
+++ b/tests/hwloc/linux/allowed/test-topology.sh.in
@@ -67,7 +67,7 @@ test_topology ()
     else
 	if [ "$HWLOC_UPDATE_TEST_TOPOLOGY_OUTPUT" != 1 ]
 	then
-	    @DIFF@ @HWLOC_DIFF_U@ -b "$expected_output" "$output"
+	    @DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ -b "$expected_output" "$output"
 	    result=$?
 	else
 	    if ! @DIFF@ "$expected_output" "$output" >/dev/null

--- a/tests/hwloc/linux/test-topology.sh.in
+++ b/tests/hwloc/linux/test-topology.sh.in
@@ -60,7 +60,7 @@ test_topology ()
     else
 	if [ "$HWLOC_UPDATE_TEST_TOPOLOGY_OUTPUT" != 1 ]
 	then
-	    @DIFF@ @HWLOC_DIFF_U@ -b "$expected_output" "$output"
+	    @DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ -b "$expected_output" "$output"
 	    result=$?
 	else
 	    if ! @DIFF@ "$expected_output" "$output" >/dev/null

--- a/tests/hwloc/x86/test-topology.sh.in
+++ b/tests/hwloc/x86/test-topology.sh.in
@@ -56,7 +56,7 @@ test_topology ()
     else
 	if [ "$HWLOC_UPDATE_TEST_TOPOLOGY_OUTPUT" != 1 ]
 	then
-	    @DIFF@ -b @HWLOC_DIFF_U@ "$expected_output" "$output"
+	    @DIFF@ -b @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ "$expected_output" "$output"
 	    result=$?
 	else
 	    if ! @DIFF@ "$expected_output" "$output" >/dev/null

--- a/tests/hwloc/xml/test-topology.sh.in
+++ b/tests/hwloc/xml/test-topology.sh.in
@@ -85,7 +85,7 @@ do_run()
 
   if [ "$HWLOC_UPDATE_TEST_TOPOLOGY_OUTPUT" != 1 ]
   then
-    @DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_W@ "$output" "$file"
+    @DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ @HWLOC_DIFF_W@ "$output" "$file"
   else
     if ! @DIFF@ "$output" "$file" >/dev/null
     then
@@ -110,7 +110,7 @@ do_run_with_output()
 
   if [ "$HWLOC_UPDATE_TEST_TOPOLOGY_OUTPUT" != 1 ]
   then
-    @DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_W@ "$output" "$file"
+    @DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ @HWLOC_DIFF_W@ "$output" "$file"
   else
     if ! @DIFF@ "$output" "$file" >/dev/null
     then

--- a/utils/hwloc/test-hwloc-annotate.sh.in
+++ b/utils/hwloc/test-hwloc-annotate.sh.in
@@ -68,5 +68,5 @@ pu:1
 EOF
 $annotate $file $file dummy distances $distances
 
-@DIFF@ @HWLOC_DIFF_U@ $srcdir/test-hwloc-annotate.output "$file"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ $srcdir/test-hwloc-annotate.output "$file"
 rm -rf "$tmp"

--- a/utils/hwloc/test-hwloc-calc.sh.in
+++ b/utils/hwloc/test-hwloc-calc.sh.in
@@ -107,5 +107,5 @@ node:0 node:3
 root
 EOF
 ) > "$file"
-@DIFF@ @HWLOC_DIFF_U@ $srcdir/test-hwloc-calc.output "$file"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ $srcdir/test-hwloc-calc.output "$file"
 rm -rf "$tmp"

--- a/utils/hwloc/test-hwloc-compress-dir.sh.in
+++ b/utils/hwloc/test-hwloc-compress-dir.sh.in
@@ -46,10 +46,10 @@ set -e
 
 $compress "$tmp/test-hwloc-compress-dir.input" "$tmp/test-hwloc-compress-dir.newoutput"
 
-@DIFF@ @HWLOC_DIFF_U@ -r "$tmp/test-hwloc-compress-dir.output" "$tmp/test-hwloc-compress-dir.newoutput"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ -r "$tmp/test-hwloc-compress-dir.output" "$tmp/test-hwloc-compress-dir.newoutput"
 
 $compress -R "$tmp/test-hwloc-compress-dir.newoutput" "$tmp/test-hwloc-compress-dir.newoutput2"
 
-@DIFF@ @HWLOC_DIFF_U@ -r "$tmp/test-hwloc-compress-dir.input" "$tmp/test-hwloc-compress-dir.newoutput2"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ -r "$tmp/test-hwloc-compress-dir.input" "$tmp/test-hwloc-compress-dir.newoutput2"
 
 rm -rf "$tmp"

--- a/utils/hwloc/test-hwloc-diffpatch.sh.in
+++ b/utils/hwloc/test-hwloc-diffpatch.sh.in
@@ -52,8 +52,8 @@ cp $srcdir/test-hwloc-diffpatch.input1 .
 cat $diffoutput | $patch refname - $output1
 $patch -R $srcdir/test-hwloc-diffpatch.input2 $diffoutput $output2
 
-diff -u $srcdir/test-hwloc-diffpatch.input1 "$output2"
-diff -u $srcdir/test-hwloc-diffpatch.input2 "$output1"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ $srcdir/test-hwloc-diffpatch.input1 "$output2"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ $srcdir/test-hwloc-diffpatch.input2 "$output1"
 
 cd ..
 rm -rf "$tmp"

--- a/utils/hwloc/test-hwloc-distrib.sh.in
+++ b/utils/hwloc/test-hwloc-distrib.sh.in
@@ -69,5 +69,5 @@ set -e
   $distrib --if synthetic --input "2 2 2 2" --to core 9
   echo
 ) > "$file"
-@DIFF@ @HWLOC_DIFF_U@ $srcdir/test-hwloc-distrib.output "$file"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ $srcdir/test-hwloc-distrib.output "$file"
 rm -rf "$tmp"

--- a/utils/hwloc/test-hwloc-dump-hwdata/test-hwloc-dump-hwdata.sh.in
+++ b/utils/hwloc/test-hwloc-dump-hwdata/test-hwloc-dump-hwdata.sh.in
@@ -33,6 +33,6 @@ export HWLOC_FSROOT
 
 $hdhd -o $tmp/output
 
-@DIFF@ @HWLOC_DIFF_U@ -r "$HWLOC_FSROOT/expected_output" "$tmp/output"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ -r "$HWLOC_FSROOT/expected_output" "$tmp/output"
 
 rm -rf "$tmp"

--- a/utils/hwloc/test-hwloc-info.sh.in
+++ b/utils/hwloc/test-hwloc-info.sh.in
@@ -60,5 +60,5 @@ set -e
   echo
   $info --if synthetic --input "node:2 core:2 l2:2 l1d:2 pu:2" --descendants l1d -s core:1-2
 ) > "$file"
-@DIFF@ @HWLOC_DIFF_U@ $srcdir/test-hwloc-info.output "$file"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ $srcdir/test-hwloc-info.output "$file"
 rm -rf "$tmp"

--- a/utils/lstopo/test-lstopo.sh.in
+++ b/utils/lstopo/test-lstopo.sh.in
@@ -100,5 +100,5 @@ echo "**** Import from synthetic so that we can check some exact outputs in $fil
   echo "** Export to XML..."
   $ls -i "$SI" -.xml
 ) > "$file"
-@DIFF@ @HWLOC_DIFF_U@ $srcdir/test-lstopo.output "$file"
+@DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_STRIP_TRAILING_CR@ $srcdir/test-lstopo.output "$file"
 rm -rf "$tmp"


### PR DESCRIPTION
I'm using a simple wrapper around clang-cl for making the configure script work.

There are few things that I need to change that I need help with,

1. Line https://github.com/open-mpi/hwloc/blob/f3ba1fea561c23c5afd1c3856818506fced4c96f/hwloc/Makefile.am#L170 needs to be changed as clang-cl doesn't understand `--output-def` and libtool creates it. It needs to be changed to `-Xlinker -def:.libs/libhwloc.def` depending on whether we are using clang-cl or gnu tools like mingw and cygwin.

2. strcasecmp check goes through with a warning of implicit declaration.
