### PR TITLE
Fix documentation on API version

### DIFF
--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -82,7 +82,7 @@ extern "C" {
 
 /** \brief Indicate at build time which hwloc API version is being used.
  *
- * This number is updated to (X>>16)+(Y>>8)+Z when a new release X.Y.Z
+ * This number is updated to (X<<16)+(Y<<8)+Z when a new release X.Y.Z
  * actually modifies the API.
  *
  * Users may check for available features at build time using this number


### PR DESCRIPTION
The documentation used a right-shift operator to construct HWLOC_API_VERSION from a release version. This made no sense and the left-shift operator should be used.

Signed-off-by: Hannes Weisbach hannes.weisbach@gmail.com