### PR TITLE
topology.c: fix undefined behavior of passing null to qsort()

### DIFF
--- a/src/topology.c
+++ b/src/topology.c
@@ -1393,7 +1393,9 @@ propagate_total_memory(hwloc_obj_t obj)
   /* By the way, sort the page_type array.
    * Cannot do it on insert since some backends (e.g. XML) add page_types after inserting the object.
    */
-  qsort(obj->memory.page_types, obj->memory.page_types_len, sizeof(*obj->memory.page_types), hwloc_memory_page_type_compare);
+  if(obj->memory.page_types_len > 0)
+      qsort(obj->memory.page_types, obj->memory.page_types_len,
+            sizeof(*obj->memory.page_types), hwloc_memory_page_type_compare);
   /* Ignore 0-size page_types, they are at the end */
   for(i=obj->memory.page_types_len; i>=1; i--)
     if (obj->memory.page_types[i-1].size)


### PR DESCRIPTION
stdlib.h:828 defines qsort as:

/* Sort NMEMB elements of BASE, of SIZE bytes each,
   using COMPAR to perform the comparisons.  */
extern void qsort (void *__base, size_t __nmemb, size_t __size,
		   __compar_fn_t __compar) __nonnull ((1, 4));

Explicitly marking arg1 and arg4 as nonnull which is caught by
the undefined behavior sanitizer -fsanitize=undefined
and running any program with environment variable set
UBSAN_OPTIONS="print_stacktrace=1"

This error was reported by clang-9.

Fixes: #373 