### PR TITLE
bsd: Make hwloc_get_sysctl able to return 64bit values

### DIFF
--- a/include/private/private.h
+++ b/include/private/private.h
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2009      CNRS
  * Copyright © 2009-2019 Inria.  All rights reserved.
- * Copyright © 2009-2012 Université Bordeaux
+ * Copyright © 2009-2012, 2020 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
  *
  * See COPYING in top-level directory.
@@ -224,7 +224,7 @@ struct hwloc_topology {
 extern void hwloc_alloc_root_sets(hwloc_obj_t root);
 extern void hwloc_setup_pu_level(struct hwloc_topology *topology, unsigned nb_pus);
 extern int hwloc_get_sysctlbyname(const char *name, int64_t *n);
-extern int hwloc_get_sysctl(int name[], unsigned namelen, int *n);
+extern int hwloc_get_sysctl(int name[], unsigned namelen, int64_t *n);
 
 /* returns the number of CPU from the OS (only valid if thissystem) */
 #define HWLOC_FALLBACK_NBPROCESSORS_INCLUDE_OFFLINE 1 /* by default we try to get only the online CPUs */


### PR DESCRIPTION
Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>