### PR TITLE
Execute hwloc_get_version.sh with sh

### DIFF
--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -81,7 +81,7 @@ EOF])
 
     # Get the version of hwloc that we are installing
     AC_MSG_CHECKING([for hwloc version])
-    HWLOC_VERSION="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION`"
+    HWLOC_VERSION="`sh $HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION`"
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
     fi
@@ -90,16 +90,16 @@ EOF])
     AC_DEFINE_UNQUOTED([HWLOC_VERSION], ["$HWLOC_VERSION"],
                        [The library version, always available, even in embedded mode, contrary to VERSION])
 
-    HWLOC_VERSION_MAJOR="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --major`"
+    HWLOC_VERSION_MAJOR="`sh $HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --major`"
     AC_DEFINE_UNQUOTED([HWLOC_VERSION_MAJOR], [$HWLOC_VERSION_MAJOR], [The library version major number])
-    HWLOC_VERSION_MINOR="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --minor`"
+    HWLOC_VERSION_MINOR="`sh $HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --minor`"
     AC_DEFINE_UNQUOTED([HWLOC_VERSION_MINOR], [$HWLOC_VERSION_MINOR], [The library version minor number])
-    HWLOC_VERSION_RELEASE="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --release`"
+    HWLOC_VERSION_RELEASE="`sh $HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --release`"
     AC_DEFINE_UNQUOTED([HWLOC_VERSION_RELEASE], [$HWLOC_VERSION_RELEASE], [The library version release number])
-    HWLOC_VERSION_GREEK="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --greek`"
+    HWLOC_VERSION_GREEK="`sh $HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --greek`"
     AC_DEFINE_UNQUOTED([HWLOC_VERSION_GREEK], ["$HWLOC_VERSION_GREEK"], [The library version optional greek suffix string])
 
-    HWLOC_RELEASE_DATE="`$HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --release-date`"
+    HWLOC_RELEASE_DATE="`sh $HWLOC_top_srcdir/config/hwloc_get_version.sh $HWLOC_top_srcdir/VERSION --release-date`"
     AC_SUBST(HWLOC_RELEASE_DATE)
 
     # Debug mode?

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@
 ####################################################################
 
 AC_INIT([hwloc],
-        [m4_normalize(esyscmd([config/hwloc_get_version.sh VERSION --version]))],
+        [m4_normalize(esyscmd([sh config/hwloc_get_version.sh VERSION --version]))],
         [http://github.com/open-mpi/hwloc/issues], [hwloc])
 AC_PREREQ(2.63)
 AC_CONFIG_AUX_DIR(./config)

--- a/contrib/dist/publish_doc
+++ b/contrib/dist/publish_doc
@@ -36,7 +36,7 @@ if ! test -f VERSION; then
   exit 1
 fi
 
-VERSION=$(./config/hwloc_get_version.sh ./VERSION)
+VERSION=$(sh config/hwloc_get_version.sh ./VERSION)
 if test x$VERSION = x; then
   echo "ERROR: Failed to extract VERSION number from VERSION file."
   exit 1


### PR DESCRIPTION
Long story short - I'm using **hwloc** on a system, on which I lose executable permissions, and since I have no control over this, I came to this solution, which, I thought, might be beneficial to someone else using **hwloc**.