### PR TITLE
Fix bash completion for zsh

### DIFF
--- a/contrib/completion/hwloc-completion.bash
+++ b/contrib/completion/hwloc-completion.bash
@@ -4,7 +4,7 @@
 #
 
 # bash < 4 doesn't support compopt
-test ${BASH_VERSINFO[0]} -lt 4 && return
+[[ -z "$ZSH_VERSION" ]] && [[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]] && return
 # TODO only disable the nospace completion of "--filter"
 
 


### PR DESCRIPTION
Currently the bash completion script breaks for zsh since `test ${BASH_VERSINFO[0]} -lt 4 && return` gives the error `/etc/bash_completion.d/hwloc-completion.bash:test:7: unknown condition: -lt` because `BASH_VERSINFO` is empty.

I'm not a shell wizard, so my fix is probably not idiomatic. I did make sure it works on Bash 3, 4, 5 and zsh.