### PR TITLE
configure.ac: remove "tar-ustar"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ EOF
 AC_CANONICAL_TARGET
 
 # Init automake
-AM_INIT_AUTOMAKE([1.11 dist-bzip2 subdir-objects foreign tar-ustar parallel-tests -Wall -Werror])
+AM_INIT_AUTOMAKE([1.11 dist-bzip2 subdir-objects foreign parallel-tests -Wall -Werror])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_LANG([C])


### PR DESCRIPTION
Commit ba3ba61e88122d8aada992371eb12d23a0c06d34 introduced "tar-ustar" into the AM_INIT_AUTOMAKE line, citing the need for filenames longer than 99 characters in the dist tarball.

On MacOS 10.15.x (Catalina), the default "tar" option seems to allow for filenames longer than 99 characters (e.g., `hwloc-2.3.0a1/doc/doxygen-doc/man/man3/hwloc_topology_diff_obj_attr_u_hwloc_topology_diff_obj_attr_generic_s.3`, which is 111 characters long).  Hence, the need for `tar-ustar` does not seem to exist any longer.

Indeed, we have actually run into a developer who has run into a documented problem with the ustar format: it doesn't support UIDs greater than 21 bits in length, causing `make dist` to fail (and his UID is greater than 21 bits).  This developer was working in another Open MPI project (not hwloc), but we thought we'd bring this learned knowledge over to hwloc as well.

After some testing, it looks like not specifying a `tar-*` option to `AM_INIT_AUTOMAKE` causes Automake to not pass the `--format` option to `tar`, which -- at least with GNU `tar` -- defaults to `--format=gnu`.  This format has wide portability -- e.g., it works on old versions of NetBSD where tarballs created with the `tar-pax` Automake option do not work.

See https://github.com/openpmix/prrte/pull/579#issuecomment-632849426 for a little more detail.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>