### PR TITLE
Look for tinfo too

### DIFF
--- a/config/hwloc_internal.m4
+++ b/config/hwloc_internal.m4
@@ -321,7 +321,7 @@ EOF
     chosen_curses=""
     for curses in ncurses curses
     do
-      for lib in "" -ltermcap -l${curses}w -l$curses
+      for lib in "" -ltermcap -l${curses}w -l$curses -ltinfo
       do
         AC_MSG_CHECKING(termcap support using $curses and $lib)
         LIBS="$hwloc_old_LIBS $lib"


### PR DESCRIPTION
On my system hwloc never detects ncurses, because `tparm` lives in `libtinfo.so`