### PR TITLE
lstopo/tikz: Update auto-completion with tikz output format

### DIFF
--- a/contrib/completion/hwloc-completion.bash
+++ b/contrib/completion/hwloc-completion.bash
@@ -12,7 +12,7 @@
 
 _lstopo() {
     local INPUT_FORMAT=(xml synthetic fsroot cpuid)
-    local OUTPUT_FORMAT=(console ascii fig pdf ps png svg xml synthetic)
+    local OUTPUT_FORMAT=(console ascii tikz fig pdf ps png svg xml synthetic)
     local TYPES=("Machine" "Misc" "Group" "NUMANode" "MemCache" "Package" "Die" "L1" "L2" "L3" "L4" "L5" "L1i" "L2i" "L3i" "Core" "Bridge" "PCIDev" "OSDev" "PU")
     local FILTERKINDS=("none" "all" "structure" "important")
     local OPTIONS=(-l --logical


### PR DESCRIPTION
The PR from July 23, was lacking the update of the auto-completion of the output format. This commit fixes it. As the man page states both tikz and tex, should `tex` be added as well?