### PR TITLE
Update HPE copyrights

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@ Copyright © 2009 CNRS
 Copyright © 2009-2020 Inria.  All rights reserved.
 Copyright © 2009-2013 Université Bordeaux
 Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
-Copyright © 2020 Hewlett-Packard Enterprise.  All rights reserved.
+Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
 
 $COPYRIGHT$
 

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -3,7 +3,7 @@
  * Copyright © 2009-2020 Inria.  All rights reserved.
  * Copyright © 2009-2013 Université Bordeaux
  * Copyright © 2009-2020 Cisco Systems, Inc.  All rights reserved.
- * Copyright © 2020 Hewlett-Packard Enterprise.  All rights reserved.
+ * Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
  * See COPYING in top-level directory.
  */
 

--- a/utils/lstopo/Makefile.am
+++ b/utils/lstopo/Makefile.am
@@ -1,7 +1,7 @@
 # Copyright © 2009-2019 Inria.  All rights reserved.
 # Copyright © 2009-2012, 2014 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
-# Copyright © 2020 Hewlett-Packard Enterprise.  All rights reserved.
+# Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
 #
 # See COPYING in top-level directory.
 

--- a/utils/lstopo/lstopo-no-graphics.1in
+++ b/utils/lstopo/lstopo-no-graphics.1in
@@ -2,7 +2,7 @@
 .\" Copyright © 2009-2020 Inria.  All rights reserved.
 .\" Copyright © 2009-2010 Université of Bordeaux
 .\" Copyright © 2009-2010 Cisco Systems, Inc.  All rights reserved.
-.\" Copyright © 2020 Hewlett-Packard Enterprise.  All rights reserved.
+.\" Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
 .\" See COPYING in top-level directory.
 .TH LSTOPO "1" "%HWLOC_DATE%" "%PACKAGE_VERSION%" "%PACKAGE_NAME%"
 .SH NAME

--- a/utils/lstopo/lstopo-tikz.c
+++ b/utils/lstopo/lstopo-tikz.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Hewlett-Packard Enterprise.  All rights reserved.
+ * Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
  * See COPYING in top-level directory.
  */
 

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -3,7 +3,7 @@
  * Copyright © 2009-2020 Inria.  All rights reserved.
  * Copyright © 2009-2012, 2015, 2017 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright © 2020 Hewlett-Packard Enterprise.  All rights reserved.
+ * Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
  * See COPYING in top-level directory.
  */
 

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -3,7 +3,7 @@
  * Copyright © 2009-2020 Inria.  All rights reserved.
  * Copyright © 2009-2010, 2012, 2015 Université Bordeaux
  * Copyright © 2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright © 2020 Hewlett-Packard Enterprise.  All rights reserved.
+ * Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
  * See COPYING in top-level directory.
  */
 

--- a/utils/lstopo/test-lstopo.sh.in
+++ b/utils/lstopo/test-lstopo.sh.in
@@ -5,7 +5,7 @@
 # Copyright © 2009 CNRS
 # Copyright © 2009-2020 Inria.  All rights reserved.
 # Copyright © 2009, 2011 Université Bordeaux
-# Copyright © 2020 Hewlett-Packard Enterprise.  All rights reserved.
+# Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
 # See COPYING in top-level directory.
 #
 


### PR DESCRIPTION
The previous HPE copyrights were not complying with the company's policy format. This PR fixes the issue.