### PR TITLE
Memory attributes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,8 @@ Version 2.3.0
       table exposed by Linux kernel 5.2+.
     - Attributes may also be customized to expose user-defined performance
       information.
+  + Add hwloc_get_local_numanode_objs() for listing NUMA nodes that are
+    local to some locality.
   + The new topology flag HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT causes
     support arrays to be loaded from XML exported with hwloc 2.3+.
     - hwloc_topology_get_support() now returns an additional "misc"

--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,10 @@ bug fixes (and other actions) for each version of hwloc since version
 Version 2.3.0
 -------------
 * API
+  + Add hwloc/memattrs.h for exposing latency/bandwidth information between
+    initiators (CPU sets for now) and target NUMA nodes.
+    - Attributes may also be customized to expose user-defined performance
+      information.
   + The new topology flag HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT causes
     support arrays to be loaded from XML exported with hwloc 2.3+.
     - hwloc_topology_get_support() now returns an additional "misc"

--- a/NEWS
+++ b/NEWS
@@ -42,6 +42,8 @@ Version 2.3.0
 * Tools
   + Command-line options for specifying flags now understand comma-separated
     lists of flag names (substrings).
+  + hwloc-info has new --local-memory --local-memoty-flags and --best-memattr
+    options for reporting local memory nodes and filtering by memory attributes.
   + Tools that have a --restrict option may now receive a nodeset or
     some custom flags for restricting the topology.
   + Fix lstopo drawing when autoresizing on Windows 10.

--- a/NEWS
+++ b/NEWS
@@ -44,6 +44,8 @@ Version 2.3.0
     lists of flag names (substrings).
   + hwloc-info has new --local-memory --local-memoty-flags and --best-memattr
     options for reporting local memory nodes and filtering by memory attributes.
+  + hwloc-bind has a new --best-memattr option for filtering by memory attributes
+    among the memory binding set.
   + Tools that have a --restrict option may now receive a nodeset or
     some custom flags for restricting the topology.
   + Fix lstopo drawing when autoresizing on Windows 10.

--- a/NEWS
+++ b/NEWS
@@ -42,8 +42,9 @@ Version 2.3.0
 * Tools
   + Command-line options for specifying flags now understand comma-separated
     lists of flag names (substrings).
-  + hwloc-info has new --local-memory --local-memoty-flags and --best-memattr
-    options for reporting local memory nodes and filtering by memory attributes.
+  + hwloc-info and hwloc-calc have new --local-memory --local-memory-flags
+    and --best-memattr options for reporting local memory nodes and filtering
+    by memory attributes.
   + hwloc-bind has a new --best-memattr option for filtering by memory attributes
     among the memory binding set.
   + Tools that have a --restrict option may now receive a nodeset or

--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,8 @@ Version 2.3.0
 * API
   + Add hwloc/memattrs.h for exposing latency/bandwidth information between
     initiators (CPU sets for now) and target NUMA nodes.
+    - When available, bandwidths and latencies are read from the ACPI HMAT
+      table exposed by Linux kernel 5.2+.
     - Attributes may also be customized to expose user-defined performance
       information.
   + The new topology flag HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT causes

--- a/contrib/completion/bash/hwloc
+++ b/contrib/completion/bash/hwloc
@@ -23,6 +23,7 @@ _lstopo() {
 		   -v --verbose
 		   -s --silent
 		   --distances
+		   --memattrs
 		   -c --cpuset
 		   -C --cpuset-only
 		   --taskset

--- a/contrib/completion/bash/hwloc
+++ b/contrib/completion/bash/hwloc
@@ -271,6 +271,9 @@ _hwloc_calc(){
 		   -I --intersect
 		   -H --hierarchical
 		   --largest
+		   --local-memory
+		   --local-memory-flags
+		   --best-memattr
 		   -l --logical
 		   -p --physical
 		   --li --logical-input
@@ -317,6 +320,12 @@ _hwloc_calc(){
 		;;
 	    --restrict)
 		COMPREPLY=( "<bitmask>" "" )
+		;;
+	    --local-memory-flags)
+		COMPREPLY=( "<flags>" "" )
+		;;
+	    --best-memattr)
+		COMPREPLY=( "<memattr>" "" )
 		;;
 	esac
     fi

--- a/contrib/completion/bash/hwloc
+++ b/contrib/completion/bash/hwloc
@@ -215,6 +215,7 @@ _hwloc_bind(){
     local OPTIONS=(--cpubind
 		   --membind
 		   --mempolicy
+		   --best-memattr
 		   --logical -l
 		   --physical -p
 		   --single
@@ -254,6 +255,9 @@ _hwloc_bind(){
 		;;
 	    --restrict)
 		COMPREPLY=( "<bitmask>" "" )
+		;;
+	    --best-memattr)
+		COMPREPLY=( "<memattr>" "" )
 		;;
 	esac
     fi

--- a/contrib/completion/bash/hwloc
+++ b/contrib/completion/bash/hwloc
@@ -150,6 +150,9 @@ _hwloc_info(){
 		   --ancestor
 		   --children
 		   --descendants
+		   --local-memory
+		   --local-memory-flags
+		   --best-memattr
 		   -n
 		   --restrict
 		   --filter
@@ -195,6 +198,12 @@ _hwloc_info(){
 		;;
 	    --ancestor | --descendants)
 		COMPREPLY=( `compgen -W "${TYPES[*]}" -- "$cur"` )
+		;;
+	    --local-memory-flags)
+		COMPREPLY=( "<flags>" "" )
+		;;
+	    --best-memattr)
+		COMPREPLY=( "<memattr>" "" )
 		;;
 	esac
     fi

--- a/contrib/windows/libhwloc.vcxproj
+++ b/contrib/windows/libhwloc.vcxproj
@@ -202,6 +202,7 @@
     <ClCompile Include="..\..\hwloc\components.c" />
     <ClCompile Include="..\..\hwloc\diff.c" />
     <ClCompile Include="..\..\hwloc\distances.c" />
+    <ClCompile Include="..\..\hwloc\memattrs.c" />
     <ClCompile Include="..\..\hwloc\misc.c" />
     <ClCompile Include="..\..\hwloc\pci-common.c" />
     <ClCompile Include="..\..\hwloc\shmem.c" />
@@ -226,6 +227,7 @@
     <ClInclude Include="..\..\include\hwloc\export.h" />
     <ClInclude Include="..\..\include\hwloc\helper.h" />
     <ClInclude Include="..\..\include\hwloc\inlines.h" />
+    <ClInclude Include="..\..\include\hwloc\memattrs.h" />
     <ClInclude Include="..\..\include\hwloc\plugins.h" />
     <ClInclude Include="..\..\include\hwloc\shmem.h" />
     <ClInclude Include="..\..\include\hwloc\rename.h" />

--- a/contrib/windows/libhwloc.vcxproj.filters
+++ b/contrib/windows/libhwloc.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="..\..\hwloc\distances.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\hwloc\memattrs.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\hwloc\misc.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -96,6 +99,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\hwloc\inlines.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\hwloc\memattrs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\hwloc\plugins.h">

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -686,6 +686,11 @@ man3_memattrs_DATA = \
         $(DOX_MAN_DIR)/man3/hwloc_location_type_e.3 \
         $(DOX_MAN_DIR)/man3/HWLOC_LOCATION_TYPE_OBJECT.3 \
         $(DOX_MAN_DIR)/man3/HWLOC_LOCATION_TYPE_CPUSET.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_local_numanode_flag_e.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_LOCAL_NUMANODE_FLAG_ALL.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_get_local_numanode_objs.3 \
         $(DOX_MAN_DIR)/man3/hwloc_memattr_get_value.3 \
         $(DOX_MAN_DIR)/man3/hwloc_memattr_get_best_target.3 \
         $(DOX_MAN_DIR)/man3/hwloc_memattr_get_best_initiator.3 \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -69,6 +69,7 @@ dox_inputs = $(DOX_CONFIG) \
        $(hwloc_include_dir)/hwloc/bitmap.h \
        $(hwloc_include_dir)/hwloc/export.h \
        $(hwloc_include_dir)/hwloc/distances.h \
+       $(hwloc_include_dir)/hwloc/memattrs.h \
        $(hwloc_include_dir)/hwloc/diff.h \
        $(hwloc_include_dir)/hwloc/shmem.h \
        $(hwloc_include_dir)/hwloc/plugins.h \
@@ -671,6 +672,35 @@ man3_distances_DATA = \
         $(DOX_MAN_DIR)/man3/hwloc_distances_remove_by_type.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_release_remove.3
 
+man3_memattrsdir = $(man3dir)
+man3_memattrs_DATA = \
+        $(DOX_MAN_DIR)/man3/hwlocality_memattrs.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_id_e.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_MEMATTR_ID_CAPACITY.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_MEMATTR_ID_LOCALITY.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_MEMATTR_ID_BANDWIDTH.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_MEMATTR_ID_LATENCY.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_id_t.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_get_by_name.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_location.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_location_type_e.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_LOCATION_TYPE_OBJECT.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_LOCATION_TYPE_CPUSET.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_get_value.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_get_best_target.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_get_best_initiator.3 \
+        $(DOX_MAN_DIR)/man3/hwlocality_memattrs_manage.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_get_name.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_get_flags.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_flag_e.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_MEMATTR_FLAG_HIGHER_FIRST.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_MEMATTR_FLAG_LOWER_FIRST.3 \
+        $(DOX_MAN_DIR)/man3/HWLOC_MEMATTR_FLAG_NEED_INITIATOR.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_register.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_set_value.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_get_targets.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_memattr_get_initiators.3
+
 man3_diffdir = $(man3dir)
 man3_diff_DATA = \
         $(DOX_MAN_DIR)/man3/hwlocality_diff.3 \
@@ -803,6 +833,7 @@ $(man3_helper_topology_sets_DATA): $(DOX_TAG)
 $(man3_helper_nodeset_convert_DATA): $(DOX_TAG)
 $(man3_helper_advanced_io_DATA): $(DOX_TAG)
 $(man3_distances_DATA): $(DOX_TAG)
+$(man3_memattrs_DATA): $(DOX_TAG)
 $(man3_diff_DATA): $(DOX_TAG)
 $(man3_cuda_DATA): $(DOX_TAG)
 $(man3_glibc_sched_DATA): $(DOX_TAG)

--- a/doc/doxygen-config.cfg.in
+++ b/doc/doxygen-config.cfg.in
@@ -15,6 +15,7 @@ INPUT          = \
 		@top_srcdir@/include/hwloc/bitmap.h \
 		@top_srcdir@/include/hwloc/export.h \
 		@top_srcdir@/include/hwloc/distances.h \
+		@top_srcdir@/include/hwloc/memattrs.h \
 		@top_srcdir@/include/hwloc/linux.h \
 		@top_srcdir@/include/hwloc/linux-libnuma.h \
 		@top_srcdir@/include/hwloc/glibc-sched.h \

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -2415,6 +2415,10 @@ For reference, ::hwloc_topology_t modification operations include
   (see \ref hwlocality_distances_add) modify the list of distance structures
   in the topology, and the former may even insert new Group objects.
 
+  <tt>hwloc_memattr_register()</tt> and <tt>hwloc_memattr_set_value()</tt>
+  (see \ref hwlocality_memattrs_manage) modify the memory attributes
+  of the topology.
+
   <tt>hwloc_topology_restrict()</tt> modifies the topology even more
   dramatically by removing some objects.
 
@@ -2435,6 +2439,21 @@ For reference, ::hwloc_topology_t modification operations include
 
   Once this refresh has been performed, multiple <tt>hwloc_distances_get()</tt>
   may then be performed concurrently by multiple threads.
+  </dd>
+
+<dt>Consulting memory attributes</dt>
+  <dd>
+  Functions consulting memory attributes in hwloc/memattrs.h
+  are thread-safe except if the topology was recently modified
+  (because memory attributes may involve objects that were removed).
+
+  Whenever the topology is modified (see above), one dummy (but valid) call to
+  <tt>hwloc_memattr_get_value()</tt> or <tt>hwloc_memattr_get_targets()</tt>
+  should be performed in the same thread-safe context to force the refresh
+  of internal structures for a given attribute.
+
+  Once this refresh has been performed, multiple functions consulting
+  memory attributes may then be performed concurrently by multiple threads.
   </dd>
 
 <dt>Locating topologies</dt>

--- a/hwloc/Makefile.am
+++ b/hwloc/Makefile.am
@@ -31,6 +31,7 @@ sources = \
         topology.c \
         traversal.c \
         distances.c \
+        memattrs.c \
         components.c \
         bind.c \
         bitmap.c \

--- a/hwloc/diff.c
+++ b/hwloc/diff.c
@@ -380,15 +380,9 @@ int hwloc_topology_diff_build(hwloc_topology_t topo1,
               continue;
             for(j=0; j<imattr1->nr_targets; j++) {
               struct hwloc_internal_memattr_target_s *imtg1 = &imattr1->targets[j], *imtg2 = &imattr2->targets[j];
-              hwloc_obj_t obj1, obj2;
               if (imtg1->type != imtg2->type)
                 goto roottoocomplex;
-              /* gp_index isn't enforced above. so compare logical_index instead, which is enforced. requires memattrs refresh() above */
-              obj1 = hwloc_get_obj_by_type_and_gp_index(topo1, imtg1->type, imtg1->gp_index);
-              assert(obj1);
-              obj2 = hwloc_get_obj_by_type_and_gp_index(topo2, imtg2->type, imtg2->gp_index);
-              assert(obj2);
-              if (obj1->logical_index != obj2->logical_index)
+              if (imtg1->obj->logical_index != imtg2->obj->logical_index)
                 goto roottoocomplex;
               if (imattr1->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR) {
                 unsigned k;
@@ -403,11 +397,7 @@ int hwloc_topology_diff_build(hwloc_topology_t topo1,
                   } else if (imi1->initiator.type == HWLOC_LOCATION_TYPE_OBJECT) {
                     if (imi1->initiator.location.object.type != imi2->initiator.location.object.type)
                       goto roottoocomplex;
-                    obj1 = hwloc_get_obj_by_type_and_gp_index(topo1, imi1->initiator.location.object.type, imi1->initiator.location.object.gp_index);
-                    assert(obj1);
-                    obj2 = hwloc_get_obj_by_type_and_gp_index(topo2, imi2->initiator.location.object.type, imi2->initiator.location.object.gp_index);
-                    assert(obj2);
-                    if (obj1->logical_index != obj2->logical_index)
+                    if (imi1->initiator.location.object.obj->logical_index != imi2->initiator.location.object.obj->logical_index)
                       goto roottoocomplex;
                   } else {
                     assert(0);

--- a/hwloc/distances.c
+++ b/hwloc/distances.c
@@ -526,36 +526,6 @@ int hwloc_distances_add(hwloc_topology_t topology,
  * Refresh objects in distances
  */
 
-static hwloc_obj_t hwloc_find_obj_by_depth_and_gp_index(hwloc_topology_t topology, unsigned depth, uint64_t gp_index)
-{
-  hwloc_obj_t obj = hwloc_get_obj_by_depth(topology, depth, 0);
-  while (obj) {
-    if (obj->gp_index == gp_index)
-      return obj;
-    obj = obj->next_cousin;
-  }
-  return NULL;
-}
-
-static hwloc_obj_t hwloc_find_obj_by_type_and_gp_index(hwloc_topology_t topology, hwloc_obj_type_t type, uint64_t gp_index)
-{
-  int depth = hwloc_get_type_depth(topology, type);
-  if (depth == HWLOC_TYPE_DEPTH_UNKNOWN)
-    return NULL;
-  if (depth == HWLOC_TYPE_DEPTH_MULTIPLE) {
-    int topodepth = hwloc_topology_get_depth(topology);
-    for(depth=0; depth<topodepth; depth++) {
-      if (hwloc_get_depth_type(topology, depth) == type) {
-	hwloc_obj_t obj = hwloc_find_obj_by_depth_and_gp_index(topology, depth, gp_index);
-	if (obj)
-	  return obj;
-      }
-    }
-    return NULL;
-  }
-  return hwloc_find_obj_by_depth_and_gp_index(topology, depth, gp_index);
-}
-
 static void
 hwloc_internal_distances_restrict(hwloc_obj_t *objs,
 				  uint64_t *indexes,
@@ -612,7 +582,7 @@ hwloc_internal_distances_refresh_one(hwloc_topology_t topology,
       else
 	abort();
     } else {
-      obj = hwloc_find_obj_by_type_and_gp_index(topology, different_types ? different_types[i] : unique_type, indexes[i]);
+      obj = hwloc_get_obj_by_type_and_gp_index(topology, different_types ? different_types[i] : unique_type, indexes[i]);
     }
     objs[i] = obj;
     if (!obj)

--- a/hwloc/hwloc2.dtd
+++ b/hwloc/hwloc2.dtd
@@ -7,7 +7,7 @@
   This is the DTD for hwloc v2.x XMLs.
  -->
 
-<!ELEMENT topology (object+,distances2*,distances2hetero*,support*)>
+<!ELEMENT topology (object+,distances2*,distances2hetero*,support*,memattr*)>
 <!ATTLIST topology version CDATA "">
 
 <!ELEMENT object (page_type*,info*,userdata*,object*)>
@@ -56,6 +56,18 @@
 <!ELEMENT distances2hetero (indexes+,u64values+)>
 <!ATTLIST distances2hetero nbobjs CDATA #REQUIRED>
 <!ATTLIST distances2hetero kind CDATA #REQUIRED>
+
+<!ELEMENT memattr (memattr_value*)>
+<!ATTLIST memattr name CDATA #REQUIRED>
+<!ATTLIST memattr flags CDATA #REQUIRED>
+
+<!ELEMENT memattr_value EMPTY>
+<!ATTLIST memattr_value target_obj_gp_index CDATA "">
+<!ATTLIST memattr_value target_obj_type CDATA #REQUIRED>
+<!ATTLIST memattr_value value CDATA #REQUIRED>
+<!ATTLIST memattr_value initiator_cpuset CDATA "">
+<!ATTLIST memattr_value initiator_obj_gp_index CDATA "">
+<!ATTLIST memattr_value initiator_obj_type CDATA "">
 
 <!ELEMENT indexes (#PCDATA)>
 <!ATTLIST indexes length CDATA #REQUIRED>

--- a/hwloc/memattrs.c
+++ b/hwloc/memattrs.c
@@ -1,0 +1,1106 @@
+/*
+ * Copyright © 2020 Inria.  All rights reserved.
+ * See COPYING in top-level directory.
+ */
+
+#include "private/autogen/config.h"
+#include "hwloc.h"
+#include "private/private.h"
+
+
+/*****************************
+ * Attributes
+ */
+
+static __hwloc_inline
+hwloc_uint64_t hwloc__memattr_get_convenience_value(hwloc_memattr_id_t id,
+                                                    hwloc_obj_t node)
+{
+  if (id == HWLOC_MEMATTR_ID_CAPACITY)
+    return node->attr->numanode.local_memory;
+  else if (id == HWLOC_MEMATTR_ID_LOCALITY)
+    return hwloc_bitmap_weight(node->cpuset);
+  else
+    assert(0);
+}
+
+void
+hwloc_internal_memattrs_init(struct hwloc_topology *topology)
+{
+  topology->nr_memattrs = 0;
+  topology->memattrs = NULL;
+}
+
+static void
+hwloc__setup_memattr(struct hwloc_internal_memattr_s *imattr,
+                     char *name,
+                     unsigned long flags,
+                     unsigned long iflags)
+{
+  imattr->name = name;
+  imattr->flags = flags;
+  imattr->iflags = iflags;
+
+  imattr->nr_targets = 0;
+  imattr->targets = NULL;
+}
+
+void
+hwloc_internal_memattrs_prepare(struct hwloc_topology *topology)
+{
+#define NR_DEFAULT_MEMATTRS 4
+  topology->memattrs = malloc(NR_DEFAULT_MEMATTRS * sizeof(*topology->memattrs));
+  if (!topology->memattrs)
+    return;
+
+  assert(HWLOC_MEMATTR_ID_CAPACITY < NR_DEFAULT_MEMATTRS);
+  hwloc__setup_memattr(&topology->memattrs[HWLOC_MEMATTR_ID_CAPACITY],
+                       (char *) "Capacity",
+                       HWLOC_MEMATTR_FLAG_HIGHER_FIRST,
+                       HWLOC_IMATTR_FLAG_STATIC_NAME|HWLOC_IMATTR_FLAG_CONVENIENCE);
+
+  assert(HWLOC_MEMATTR_ID_LOCALITY < NR_DEFAULT_MEMATTRS);
+  hwloc__setup_memattr(&topology->memattrs[HWLOC_MEMATTR_ID_LOCALITY],
+                       (char *) "Locality",
+                       HWLOC_MEMATTR_FLAG_LOWER_FIRST,
+                       HWLOC_IMATTR_FLAG_STATIC_NAME|HWLOC_IMATTR_FLAG_CONVENIENCE);
+
+  assert(HWLOC_MEMATTR_ID_BANDWIDTH < NR_DEFAULT_MEMATTRS);
+  hwloc__setup_memattr(&topology->memattrs[HWLOC_MEMATTR_ID_BANDWIDTH],
+                       (char *) "Bandwidth",
+                       HWLOC_MEMATTR_FLAG_HIGHER_FIRST|HWLOC_MEMATTR_FLAG_NEED_INITIATOR,
+                       HWLOC_IMATTR_FLAG_STATIC_NAME);
+
+  assert(HWLOC_MEMATTR_ID_LATENCY < NR_DEFAULT_MEMATTRS);
+  hwloc__setup_memattr(&topology->memattrs[HWLOC_MEMATTR_ID_LATENCY],
+                       (char *) "Latency",
+                       HWLOC_MEMATTR_FLAG_LOWER_FIRST|HWLOC_MEMATTR_FLAG_NEED_INITIATOR,
+                       HWLOC_IMATTR_FLAG_STATIC_NAME);
+
+  topology->nr_memattrs = NR_DEFAULT_MEMATTRS;
+}
+
+static void
+hwloc__imi_destroy(struct hwloc_internal_memattr_initiator_s *imi)
+{
+  if (imi->initiator.type == HWLOC_LOCATION_TYPE_CPUSET)
+    hwloc_bitmap_free(imi->initiator.location.cpuset);
+}
+
+static void
+hwloc__imtg_destroy(struct hwloc_internal_memattr_s *imattr,
+                    struct hwloc_internal_memattr_target_s *imtg)
+{
+  if (imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR) {
+    /* only attributes with initiators may have something to free() in the array */
+    unsigned k;
+    for(k=0; k<imtg->nr_initiators; k++)
+      hwloc__imi_destroy(&imtg->initiators[k]);
+  }
+  free(imtg->initiators);
+}
+
+void
+hwloc_internal_memattrs_destroy(struct hwloc_topology *topology)
+{
+  unsigned id;
+  for(id=0; id<topology->nr_memattrs; id++) {
+    struct hwloc_internal_memattr_s *imattr = &topology->memattrs[id];
+    unsigned j;
+    for(j=0; j<imattr->nr_targets; j++)
+      hwloc__imtg_destroy(imattr, &imattr->targets[j]);
+    free(imattr->targets);
+    if (!(imattr->iflags & HWLOC_IMATTR_FLAG_STATIC_NAME))
+      free(imattr->name);
+  }
+  free(topology->memattrs);
+
+  topology->memattrs = NULL;
+  topology->nr_memattrs = 0;
+}
+
+int
+hwloc_internal_memattrs_dup(struct hwloc_topology *new, struct hwloc_topology *old)
+{
+  struct hwloc_tma *tma = new->tma;
+  struct hwloc_internal_memattr_s *imattrs;
+  hwloc_memattr_id_t id;
+
+  imattrs = hwloc_tma_malloc(tma, old->nr_memattrs * sizeof(*imattrs));
+  if (!imattrs)
+    return -1;
+  new->memattrs = imattrs;
+  new->nr_memattrs = old->nr_memattrs;
+  memcpy(imattrs, old->memattrs, old->nr_memattrs * sizeof(*imattrs));
+
+  for(id=0; id<old->nr_memattrs; id++) {
+    struct hwloc_internal_memattr_s *oimattr = &old->memattrs[id];
+    struct hwloc_internal_memattr_s *nimattr = &imattrs[id];
+    unsigned j;
+
+    assert(oimattr->name);
+    nimattr->name = hwloc_tma_strdup(tma, oimattr->name);
+    if (!nimattr->name) {
+      assert(!tma || !tma->dontfree); /* this tma cannot fail to allocate */
+      new->nr_memattrs = id;
+      goto failed;
+    }
+    nimattr->iflags &= ~HWLOC_IMATTR_FLAG_STATIC_NAME;
+
+    if (!oimattr->nr_targets)
+      continue;
+
+    nimattr->targets = hwloc_tma_malloc(tma, oimattr->nr_targets * sizeof(*nimattr->targets));
+    if (!nimattr->targets) {
+      free(nimattr->name);
+      new->nr_memattrs = id;
+      goto failed;
+    }
+    memcpy(nimattr->targets, oimattr->targets, oimattr->nr_targets * sizeof(*nimattr->targets));
+
+    for(j=0; j<oimattr->nr_targets; j++) {
+      struct hwloc_internal_memattr_target_s *oimtg = &oimattr->targets[j];
+      struct hwloc_internal_memattr_target_s *nimtg = &nimattr->targets[j];
+      unsigned k;
+
+      if (!oimtg->nr_initiators)
+        continue;
+
+      nimtg->initiators = hwloc_tma_malloc(tma, oimtg->nr_initiators * sizeof(*nimtg->initiators));
+      if (!nimtg->initiators) {
+        nimattr->nr_targets = j;
+        new->nr_memattrs = id+1;
+        goto failed;
+      }
+      memcpy(nimtg->initiators, oimtg->initiators, oimtg->nr_initiators * sizeof(*nimtg->initiators));
+
+      for(k=0; k<oimtg->nr_initiators; k++) {
+        struct hwloc_internal_memattr_initiator_s *oimi = &oimtg->initiators[k];
+        struct hwloc_internal_memattr_initiator_s *nimi = &nimtg->initiators[k];
+        if (oimi->initiator.type == HWLOC_LOCATION_TYPE_CPUSET) {
+          nimi->initiator.location.cpuset = hwloc_bitmap_tma_dup(tma, oimi->initiator.location.cpuset);
+          if (!nimi->initiator.location.cpuset) {
+            nimtg->nr_initiators = k;
+            nimattr->nr_targets = j+1;
+            new->nr_memattrs = id+1;
+            goto failed;
+          }
+        }
+      }
+    }
+  }
+  return 0;
+
+ failed:
+  hwloc_internal_memattrs_destroy(new);
+  return -1;
+}
+
+int
+hwloc_memattr_get_by_name(hwloc_topology_t topology,
+                          const char *name,
+                          hwloc_memattr_id_t *idp)
+{
+  unsigned id;
+  for(id=0; id<topology->nr_memattrs; id++) {
+    if (!strcmp(topology->memattrs[id].name, name)) {
+      *idp = id;
+      return 0;
+    }
+  }
+  errno = EINVAL;
+  return -1;
+}
+
+int
+hwloc_memattr_get_name(hwloc_topology_t topology,
+                       hwloc_memattr_id_t id,
+                       const char **namep)
+{
+  if (id >= topology->nr_memattrs) {
+    errno = EINVAL;
+    return -1;
+  }
+  *namep = topology->memattrs[id].name;
+  return 0;
+}
+
+int
+hwloc_memattr_get_flags(hwloc_topology_t topology,
+                        hwloc_memattr_id_t id,
+                        unsigned long *flagsp)
+{
+  if (id >= topology->nr_memattrs) {
+    errno = EINVAL;
+    return -1;
+  }
+  *flagsp = topology->memattrs[id].flags;
+  return 0;
+}
+
+int
+hwloc_memattr_register(hwloc_topology_t topology,
+                       const char *_name,
+                       unsigned long flags,
+                       hwloc_memattr_id_t *id)
+{
+  struct hwloc_internal_memattr_s *newattrs;
+  char *name;
+  unsigned i;
+
+  /* check flags */
+  if (flags & ~(HWLOC_MEMATTR_FLAG_NEED_INITIATOR|HWLOC_MEMATTR_FLAG_LOWER_FIRST|HWLOC_MEMATTR_FLAG_HIGHER_FIRST)) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (!(flags & (HWLOC_MEMATTR_FLAG_LOWER_FIRST|HWLOC_MEMATTR_FLAG_HIGHER_FIRST))) {
+    errno = EINVAL;
+    return -1;
+  }
+  if ((flags & (HWLOC_MEMATTR_FLAG_LOWER_FIRST|HWLOC_MEMATTR_FLAG_HIGHER_FIRST))
+      == (HWLOC_MEMATTR_FLAG_LOWER_FIRST|HWLOC_MEMATTR_FLAG_HIGHER_FIRST)) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (!_name) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  /* check name isn't already used */
+  for(i=0; i<topology->nr_memattrs; i++) {
+    if (!strcmp(_name, topology->memattrs[i].name)) {
+      errno = EBUSY;
+      return -1;
+    }
+  }
+
+  name = strdup(_name);
+  if (!name)
+    return -1;
+
+  newattrs = realloc(topology->memattrs, (topology->nr_memattrs + 1) * sizeof(*topology->memattrs));
+  if (!newattrs) {
+    free(name);
+    return -1;
+  }
+
+  hwloc__setup_memattr(&newattrs[topology->nr_memattrs],
+                       name, flags, 0);
+
+  /* memattr valid when just created */
+  newattrs[topology->nr_memattrs].iflags |= HWLOC_IMATTR_FLAG_CACHE_VALID;
+
+  *id = topology->nr_memattrs;
+  topology->nr_memattrs++;
+  topology->memattrs = newattrs;
+  return 0;
+}
+
+
+/***************************
+ * Internal Locations
+ */
+
+/* return 1 if cpuset/obj matchs the existing initiator location,
+ * for instance if the cpuset of query is included in the cpuset of existing
+ */
+static int
+match_internal_location(struct hwloc_internal_location_s *iloc,
+                        struct hwloc_internal_memattr_initiator_s *imi)
+{
+  if (iloc->type != imi->initiator.type)
+    return 0;
+  switch (iloc->type) {
+  case HWLOC_LOCATION_TYPE_CPUSET:
+    return hwloc_bitmap_isincluded(iloc->location.cpuset, imi->initiator.location.cpuset);
+  case HWLOC_LOCATION_TYPE_OBJECT:
+    return iloc->location.object.type == imi->initiator.location.object.type
+      && iloc->location.object.gp_index == imi->initiator.location.object.gp_index;
+  default:
+    return 0;
+  }
+}
+
+static int
+to_internal_location(struct hwloc_internal_location_s *iloc,
+                     struct hwloc_location *location)
+{
+  iloc->type = location->type;
+
+  switch (location->type) {
+  case HWLOC_LOCATION_TYPE_CPUSET:
+    if (!location->location.cpuset || hwloc_bitmap_iszero(location->location.cpuset)) {
+      errno = EINVAL;
+      return -1;
+    }
+    iloc->location.cpuset = location->location.cpuset;
+    return 0;
+  case HWLOC_LOCATION_TYPE_OBJECT:
+    if (!location->location.object) {
+      errno = EINVAL;
+      return -1;
+    }
+    iloc->location.object.gp_index = location->location.object->gp_index;
+    iloc->location.object.type = location->location.object->type;
+    return 0;
+  default:
+    errno = EINVAL;
+    return -1;
+  }
+}
+
+static int
+from_internal_location(hwloc_topology_t topology,
+                       struct hwloc_internal_location_s *iloc,
+                       struct hwloc_location *location)
+{
+  location->type = iloc->type;
+
+  switch (iloc->type) {
+  case HWLOC_LOCATION_TYPE_CPUSET:
+    location->location.cpuset = iloc->location.cpuset;
+    return 0;
+  case HWLOC_LOCATION_TYPE_OBJECT:
+    location->location.object = hwloc_get_obj_by_type_and_gp_index(topology,
+                                                                   iloc->location.object.type,
+                                                                   iloc->location.object.gp_index);
+    if (!location->location.object)
+      return -1;
+    return 0;
+  default:
+    errno = EINVAL;
+    return -1;
+  }
+}
+
+
+/************************
+ * Refreshing
+ */
+
+static int
+hwloc__imi_refresh(struct hwloc_topology *topology,
+                   struct hwloc_internal_memattr_initiator_s *imi)
+{
+  switch (imi->initiator.type) {
+  case HWLOC_LOCATION_TYPE_CPUSET: {
+    hwloc_bitmap_and(imi->initiator.location.cpuset, imi->initiator.location.cpuset, topology->levels[0][0]->cpuset);
+    if (hwloc_bitmap_iszero(imi->initiator.location.cpuset)) {
+      hwloc__imi_destroy(imi);
+      return -1;
+    }
+    return 0;
+  }
+  case HWLOC_LOCATION_TYPE_OBJECT: {
+    hwloc_obj_t obj = hwloc_get_obj_by_type_and_gp_index(topology,
+                                                         imi->initiator.location.object.type,
+                                                         imi->initiator.location.object.gp_index);
+    if (!obj) {
+      hwloc__imi_destroy(imi);
+      return -1;
+    }
+    return 0;
+  }
+  default:
+    assert(0);
+  }
+  return -1;
+}
+
+static int
+hwloc__imtg_refresh(struct hwloc_topology *topology,
+                    struct hwloc_internal_memattr_s *imattr,
+                    struct hwloc_internal_memattr_target_s *imtg)
+{
+  hwloc_obj_t node;
+
+  /* no need to refresh convenience memattrs */
+  assert(!(imattr->iflags & HWLOC_IMATTR_FLAG_CONVENIENCE));
+
+  /* check the target object */
+  if (imtg->gp_index == (hwloc_uint64_t) -1) {
+    /* only NUMA and PU may work with os_index, and only NUMA is currently used internally */
+    if (imtg->type == HWLOC_OBJ_NUMANODE)
+      node = hwloc_get_numanode_obj_by_os_index(topology, imtg->os_index);
+    else if (imtg->type == HWLOC_OBJ_PU)
+      node = hwloc_get_pu_obj_by_os_index(topology, imtg->os_index);
+    else
+      node = NULL;
+  } else {
+    node = hwloc_get_obj_by_type_and_gp_index(topology, imtg->type, imtg->gp_index);
+  }
+  if (!node) {
+    hwloc__imtg_destroy(imattr, imtg);
+    return -1;
+  }
+
+  /* save the gp_index in case it wasn't initialized yet */
+  imtg->gp_index = node->gp_index;
+
+  if (imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR) {
+    /* check the initiators */
+    unsigned k, l;
+    for(k=0, l=0; k<imtg->nr_initiators; k++) {
+      int err = hwloc__imi_refresh(topology, &imtg->initiators[k]);
+      if (err < 0)
+        continue;
+      if (k != l)
+        memcpy(&imtg->initiators[l], &imtg->initiators[k], sizeof(*imtg->initiators));
+      l++;
+    }
+    imtg->nr_initiators = l;
+    if (!imtg->nr_initiators) {
+      hwloc__imtg_destroy(imattr, imtg);
+      return -1;
+    }
+  }
+  return 0;
+}
+
+static void
+hwloc__imattr_refresh(struct hwloc_topology *topology,
+                      struct hwloc_internal_memattr_s *imattr)
+{
+  unsigned j, k;
+  for(j=0, k=0; j<imattr->nr_targets; j++) {
+    int ret = hwloc__imtg_refresh(topology, imattr, &imattr->targets[j]);
+    if (!ret) {
+      /* target still valid, move it if some former targets were removed */
+      if (j != k)
+        memcpy(&imattr->targets[k], &imattr->targets[j], sizeof(*imattr->targets));
+      k++;
+    }
+  }
+  imattr->nr_targets = k;
+  imattr->iflags |= HWLOC_IMATTR_FLAG_CACHE_VALID;
+}
+
+void
+hwloc_internal_memattrs_refresh(struct hwloc_topology *topology)
+{
+  unsigned id;
+  for(id=0; id<topology->nr_memattrs; id++) {
+    struct hwloc_internal_memattr_s *imattr = &topology->memattrs[id];
+    if (imattr->iflags & HWLOC_IMATTR_FLAG_CACHE_VALID)
+      /* nothing to refresh */
+      continue;
+    hwloc__imattr_refresh(topology, imattr);
+  }
+}
+
+void
+hwloc_internal_memattrs_need_refresh(struct hwloc_topology *topology)
+{
+  unsigned id;
+  for(id=0; id<topology->nr_memattrs; id++) {
+    struct hwloc_internal_memattr_s *imattr = &topology->memattrs[id];
+    if (imattr->iflags & HWLOC_IMATTR_FLAG_CONVENIENCE)
+      /* no need to refresh convenience memattrs */
+      continue;
+    imattr->iflags &= ~HWLOC_IMATTR_FLAG_CACHE_VALID;
+  }
+}
+
+
+/********************************
+ * Targets
+ */
+
+static struct hwloc_internal_memattr_target_s *
+hwloc__memattr_get_target(struct hwloc_internal_memattr_s *imattr,
+                          hwloc_obj_type_t target_type,
+                          hwloc_uint64_t target_gp_index,
+                          unsigned target_os_index,
+                          int create)
+{
+  struct hwloc_internal_memattr_target_s *news, *new;
+  unsigned j;
+
+  for(j=0; j<imattr->nr_targets; j++) {
+    if (target_type == imattr->targets[j].type)
+      if ((target_gp_index != (hwloc_uint64_t)-1 && target_gp_index == imattr->targets[j].gp_index)
+          || (target_os_index != (unsigned)-1 && target_os_index == imattr->targets[j].os_index))
+        return &imattr->targets[j];
+  }
+  if (!create)
+    return NULL;
+
+  news = realloc(imattr->targets, (imattr->nr_targets+1)*sizeof(*imattr->targets));
+  if (!news)
+    return NULL;
+  imattr->targets = news;
+
+  /* FIXME sort targets? by logical index at the end of load? */
+
+  new = &news[imattr->nr_targets];
+  new->type = target_type;
+  new->gp_index = target_gp_index;
+  new->os_index = target_os_index;
+  new->nr_initiators = 0;
+  new->initiators = NULL;
+  new->noinitiator_value = 0;
+  imattr->nr_targets++;
+  return new;
+}
+
+static struct hwloc_internal_memattr_initiator_s *
+hwloc__memattr_get_initiator_from_location(struct hwloc_internal_memattr_s *imattr,
+                                           struct hwloc_internal_memattr_target_s *imtg,
+                                           struct hwloc_location *location);
+
+int
+hwloc_memattr_get_targets(hwloc_topology_t topology,
+                          hwloc_memattr_id_t id,
+                          struct hwloc_location *initiator,
+                          unsigned long flags,
+                          unsigned *nrp, hwloc_obj_t *targets, hwloc_uint64_t *values)
+{
+  struct hwloc_internal_memattr_s *imattr;
+  unsigned i, found = 0, max;
+
+  if (flags) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (!nrp || (*nrp && !targets)) {
+    errno = EINVAL;
+    return -1;
+  }
+  max = *nrp;
+
+  if (id >= topology->nr_memattrs) {
+    errno = EINVAL;
+    return -1;
+  }
+  imattr = &topology->memattrs[id];
+
+  if (imattr->iflags & HWLOC_IMATTR_FLAG_CONVENIENCE) {
+    /* convenience attributes */
+    for(i=0; ; i++) {
+      hwloc_obj_t node = hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, i);
+      if (!node)
+        break;
+      if (found<max) {
+        targets[found] = node;
+        if (values)
+          values[found] = hwloc__memattr_get_convenience_value(id, node);
+      }
+      found++;
+    }
+    goto done;
+  }
+
+  /* normal attributes */
+
+  if (!(imattr->iflags & HWLOC_IMATTR_FLAG_CACHE_VALID))
+    hwloc__imattr_refresh(topology, imattr);
+
+  for(i=0; i<imattr->nr_targets; i++) {
+    struct hwloc_internal_memattr_target_s *imtg = &imattr->targets[i];
+    hwloc_uint64_t value = 0;
+
+    if (imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR) {
+      if (initiator) {
+        /* find a matching initiator */
+        struct hwloc_internal_memattr_initiator_s *imi = hwloc__memattr_get_initiator_from_location(imattr, imtg, initiator);
+        if (!imi)
+          continue;
+        value = imi->value;
+      }
+    } else {
+      value = imtg->noinitiator_value;
+    }
+
+    if (found<max) {
+      targets[found] = hwloc_get_obj_by_type_and_gp_index(topology, imtg->type, imtg->gp_index);
+      if (values)
+        values[found] = value;
+    }
+    found++;
+  }
+
+ done:
+  *nrp = found;
+  return 0;
+}
+
+
+/************************
+ * Initiators
+ */
+
+static struct hwloc_internal_memattr_initiator_s *
+hwloc__memattr_target_get_initiator(struct hwloc_internal_memattr_target_s *imtg,
+                                    struct hwloc_internal_location_s *iloc,
+                                    int create)
+{
+  struct hwloc_internal_memattr_initiator_s *news, *new;
+  unsigned k;
+
+  for(k=0; k<imtg->nr_initiators; k++) {
+    struct hwloc_internal_memattr_initiator_s *imi = &imtg->initiators[k];
+    if (match_internal_location(iloc, imi)) {
+      return imi;
+    }
+  }
+
+  if (!create)
+    return NULL;
+
+  news = realloc(imtg->initiators, (imtg->nr_initiators+1)*sizeof(*imtg->initiators));
+  if (!news)
+    return NULL;
+  new = &news[imtg->nr_initiators];
+
+  new->initiator = *iloc;
+  if (iloc->type == HWLOC_LOCATION_TYPE_CPUSET) {
+    new->initiator.location.cpuset = hwloc_bitmap_dup(iloc->location.cpuset);
+    if (!new->initiator.location.cpuset)
+      goto out_with_realloc;
+  }
+
+  imtg->nr_initiators++;
+  imtg->initiators = news;
+  return new;
+
+ out_with_realloc:
+  imtg->initiators = news;
+  return NULL;
+}
+
+static struct hwloc_internal_memattr_initiator_s *
+hwloc__memattr_get_initiator_from_location(struct hwloc_internal_memattr_s *imattr,
+                                           struct hwloc_internal_memattr_target_s *imtg,
+                                           struct hwloc_location *location)
+{
+  struct hwloc_internal_memattr_initiator_s *imi;
+  struct hwloc_internal_location_s iloc;
+
+  assert(imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR);
+
+  /* use the initiator value */
+  if (!location) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  if (to_internal_location(&iloc, location) < 0) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  imi = hwloc__memattr_target_get_initiator(imtg, &iloc, 0);
+  if (!imi) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  return imi;
+}
+
+int
+hwloc_memattr_get_initiators(hwloc_topology_t topology,
+                             hwloc_memattr_id_t id,
+                             hwloc_obj_t target_node,
+                             unsigned long flags,
+                             unsigned *nrp, struct hwloc_location *initiators, hwloc_uint64_t *values)
+{
+  struct hwloc_internal_memattr_s *imattr;
+  struct hwloc_internal_memattr_target_s *imtg;
+  unsigned i, max;
+
+  if (flags) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (!nrp || (*nrp && !initiators)) {
+    errno = EINVAL;
+    return -1;
+  }
+  max = *nrp;
+
+  if (id >= topology->nr_memattrs) {
+    errno = EINVAL;
+    return -1;
+  }
+  imattr = &topology->memattrs[id];
+  if (!(imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR)) {
+    *nrp = 0;
+    return 0;
+  }
+
+  /* all convenience attributes have no initiators */
+  assert(!(imattr->iflags & HWLOC_IMATTR_FLAG_CONVENIENCE));
+
+  if (!(imattr->iflags & HWLOC_IMATTR_FLAG_CACHE_VALID))
+    hwloc__imattr_refresh(topology, imattr);
+
+  imtg = hwloc__memattr_get_target(imattr, target_node->type, target_node->gp_index, target_node->os_index, 0);
+  if (!imtg) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  for(i=0; i<imtg->nr_initiators && i<max; i++) {
+    struct hwloc_internal_memattr_initiator_s *imi = &imtg->initiators[i];
+    int err = from_internal_location(topology, &imi->initiator, &initiators[i]);
+    assert(!err);
+    if (values)
+      /* no need to handle capacity/locality special cases here, those are initiator-less attributes */
+      values[i] = imi->value;
+  }
+
+  *nrp = imtg->nr_initiators;
+  return 0;
+}
+
+
+/**************************
+ * Values
+ */
+
+int
+hwloc_memattr_get_value(hwloc_topology_t topology,
+                        hwloc_memattr_id_t id,
+                        hwloc_obj_t target_node,
+                        struct hwloc_location *initiator,
+                        unsigned long flags,
+                        hwloc_uint64_t *valuep)
+{
+  struct hwloc_internal_memattr_s *imattr;
+  struct hwloc_internal_memattr_target_s *imtg;
+
+  if (flags) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (id >= topology->nr_memattrs) {
+    errno = EINVAL;
+    return -1;
+  }
+  imattr = &topology->memattrs[id];
+
+  if (imattr->iflags & HWLOC_IMATTR_FLAG_CONVENIENCE) {
+    /* convenience attributes */
+    *valuep = hwloc__memattr_get_convenience_value(id, target_node);
+    return 0;
+  }
+
+  /* normal attributes */
+
+  if (!(imattr->iflags & HWLOC_IMATTR_FLAG_CACHE_VALID))
+    hwloc__imattr_refresh(topology, imattr);
+
+  imtg = hwloc__memattr_get_target(imattr, target_node->type, target_node->gp_index, target_node->os_index, 0);
+  if (!imtg) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR) {
+    /* find the initiator and set its value */
+    struct hwloc_internal_memattr_initiator_s *imi = hwloc__memattr_get_initiator_from_location(imattr, imtg, initiator);
+    if (!imi)
+      return -1;
+    *valuep = imi->value;
+  } else {
+    /* get the no-initiator value */
+    *valuep = imtg->noinitiator_value;
+  }
+  return 0;
+}
+
+static int
+hwloc__internal_memattr_set_value(hwloc_topology_t topology,
+                                  hwloc_memattr_id_t id,
+                                  hwloc_obj_type_t target_type,
+                                  hwloc_uint64_t target_gp_index,
+                                  unsigned target_os_index,
+                                  struct hwloc_internal_location_s *initiator,
+                                  hwloc_uint64_t value)
+{
+  struct hwloc_internal_memattr_s *imattr;
+  struct hwloc_internal_memattr_target_s *imtg;
+
+  if (id >= topology->nr_memattrs) {
+    /* something bad happened during init */
+    errno = EINVAL;
+    return -1;
+  }
+  imattr = &topology->memattrs[id];
+
+  if (imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR) {
+    /* check given initiator */
+    if (!initiator) {
+      errno = EINVAL;
+      return -1;
+    }
+  }
+
+  if (imattr->iflags & HWLOC_IMATTR_FLAG_CONVENIENCE) {
+    /* convenience attributes are read-only */
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (topology->is_loaded && !(imattr->iflags & HWLOC_IMATTR_FLAG_CACHE_VALID))
+    /* don't refresh when adding values during load (some nodes might not be ready yet),
+     * we'll refresh later
+     */
+    hwloc__imattr_refresh(topology, imattr);
+
+  imtg = hwloc__memattr_get_target(imattr, target_type, target_gp_index, target_os_index, 1);
+  if (!imtg)
+    return -1;
+
+  if (imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR) {
+    /* find/add the initiator and set its value */
+    // FIXME what if cpuset is larger than an existing one ?
+    struct hwloc_internal_memattr_initiator_s *imi = hwloc__memattr_target_get_initiator(imtg, initiator, 1);
+    if (!imi)
+      return -1;
+    imi->value = value;
+
+  } else {
+    /* set the no-initiator value */
+    imtg->noinitiator_value = value;
+  }
+
+  return 0;
+
+}
+
+int
+hwloc_internal_memattr_set_value(hwloc_topology_t topology,
+                                 hwloc_memattr_id_t id,
+                                 hwloc_obj_type_t target_type,
+                                 hwloc_uint64_t target_gp_index,
+                                 unsigned target_os_index,
+                                 struct hwloc_internal_location_s *initiator,
+                                 hwloc_uint64_t value)
+{
+  assert(id != HWLOC_MEMATTR_ID_CAPACITY);
+  assert(id != HWLOC_MEMATTR_ID_LOCALITY);
+
+  return hwloc__internal_memattr_set_value(topology, id, target_type, target_gp_index, target_os_index, initiator, value);
+}
+
+int
+hwloc_memattr_set_value(hwloc_topology_t topology,
+                        hwloc_memattr_id_t id,
+                        hwloc_obj_t target_node,
+                        struct hwloc_location *initiator,
+                        unsigned long flags,
+                        hwloc_uint64_t value)
+{
+  struct hwloc_internal_location_s iloc, *ilocp;
+
+  if (flags) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (initiator) {
+    if (to_internal_location(&iloc, initiator) < 0) {
+      errno = EINVAL;
+      return -1;
+    }
+    ilocp = &iloc;
+  } else {
+    ilocp = NULL;
+  }
+
+  return hwloc__internal_memattr_set_value(topology, id, target_node->type, target_node->gp_index, target_node->os_index, ilocp, value);
+}
+
+
+/**********************
+ * Best target
+ */
+
+static void
+hwloc__update_best_target(hwloc_uint64_t *best_gp_index, hwloc_obj_type_t *best_type, hwloc_uint64_t *best_value, int *found,
+                          hwloc_uint64_t new_gp_index, hwloc_obj_type_t new_type, hwloc_uint64_t new_value,
+                          int keep_highest)
+{
+  if (*found) {
+    if (keep_highest) {
+      if (new_value <= *best_value)
+        return;
+    } else {
+      if (new_value >= *best_value)
+        return;
+    }
+  }
+
+  *best_gp_index = new_gp_index;
+  *best_type = new_type;
+  *best_value = new_value;
+  *found = 1;
+}
+
+int
+hwloc_memattr_get_best_target(hwloc_topology_t topology,
+                              hwloc_memattr_id_t id,
+                              struct hwloc_location *initiator,
+                              unsigned long flags,
+                              hwloc_obj_t *bestp, hwloc_uint64_t *valuep)
+{
+  struct hwloc_internal_memattr_s *imattr;
+  hwloc_obj_type_t best_type = HWLOC_OBJ_TYPE_NONE;
+  hwloc_uint64_t best_value = 0; /* shutup the compiler */
+  hwloc_uint64_t best_gp_index = (hwloc_uint64_t) -1;
+  hwloc_obj_t best;
+  int found = 0;
+  unsigned j;
+
+  if (flags) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (id >= topology->nr_memattrs) {
+    errno = EINVAL;
+    return -1;
+  }
+  imattr = &topology->memattrs[id];
+
+  if (imattr->iflags & HWLOC_IMATTR_FLAG_CONVENIENCE) {
+    /* convenience attributes */
+    for(j=0; ; j++) {
+      hwloc_obj_t node = hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, j);
+      hwloc_uint64_t value;
+      if (!node)
+        break;
+      value = hwloc__memattr_get_convenience_value(id, node);
+      hwloc__update_best_target(&best_gp_index, &best_type, &best_value, &found,
+                                node->gp_index, HWLOC_OBJ_NUMANODE, value,
+                                imattr->flags & HWLOC_MEMATTR_FLAG_HIGHER_FIRST);
+    }
+    goto done;
+  }
+
+  /* normal attributes */
+
+  if (!(imattr->iflags & HWLOC_IMATTR_FLAG_CACHE_VALID))
+    /* not strictly need */
+    hwloc__imattr_refresh(topology, imattr);
+
+  for(j=0; j<imattr->nr_targets; j++) {
+    struct hwloc_internal_memattr_target_s *imtg = &imattr->targets[j];
+    hwloc_uint64_t value;
+    if (imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR) {
+      /* find the initiator and set its value */
+      struct hwloc_internal_memattr_initiator_s *imi = hwloc__memattr_get_initiator_from_location(imattr, imtg, initiator);
+      if (!imi)
+        continue;
+      value = imi->value;
+    } else {
+      /* get the no-initiator value */
+      value = imtg->noinitiator_value;
+    }
+    hwloc__update_best_target(&best_gp_index, &best_type, &best_value, &found,
+                              imtg->gp_index, imtg->type, value,
+                              imattr->flags & HWLOC_MEMATTR_FLAG_HIGHER_FIRST);
+  }
+
+ done:
+  if (found) {
+    best = hwloc_get_obj_by_type_and_gp_index(topology, best_type, best_gp_index);
+    assert(best);
+    *bestp = best;
+    if (valuep)
+      *valuep = best_value;
+    return 0;
+  } else {
+    errno = ENOENT;
+    return -1;
+  }
+}
+
+/**********************
+ * Best initiators
+ */
+
+static void
+hwloc__update_best_initiator(struct hwloc_internal_location_s *best_initiator, hwloc_uint64_t *best_value, int *found,
+                             struct hwloc_internal_location_s *new_initiator, hwloc_uint64_t new_value,
+                             int keep_highest)
+{
+  if (*found) {
+    if (keep_highest) {
+      if (new_value <= *best_value)
+        return;
+    } else {
+      if (new_value >= *best_value)
+        return;
+    }
+  }
+
+  *best_initiator = *new_initiator;
+  *best_value = new_value;
+  *found = 1;
+}
+
+int
+hwloc_memattr_get_best_initiator(hwloc_topology_t topology,
+                                 hwloc_memattr_id_t id,
+                                 hwloc_obj_t target_node,
+                                 unsigned long flags,
+                                 struct hwloc_location *bestp, hwloc_uint64_t *valuep)
+{
+  struct hwloc_internal_memattr_s *imattr;
+  struct hwloc_internal_memattr_target_s *imtg;
+  struct hwloc_internal_location_s best_initiator;
+  hwloc_uint64_t best_value;
+  int found;
+  unsigned i;
+
+  if (flags) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (id >= topology->nr_memattrs) {
+    errno = EINVAL;
+    return -1;
+  }
+  imattr = &topology->memattrs[id];
+
+  if (!(imattr->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR)) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (!(imattr->iflags & HWLOC_IMATTR_FLAG_CACHE_VALID))
+    /* not strictly need */
+    hwloc__imattr_refresh(topology, imattr);
+
+  imtg = hwloc__memattr_get_target(imattr, target_node->type, target_node->gp_index, target_node->os_index, 0);
+  if (!imtg) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  found = 0;
+  for(i=0; i<imtg->nr_initiators; i++) {
+    struct hwloc_internal_memattr_initiator_s *imi = &imtg->initiators[i];
+    hwloc__update_best_initiator(&best_initiator, &best_value, &found,
+                                 &imi->initiator, imi->value,
+                                 imattr->flags & HWLOC_MEMATTR_FLAG_HIGHER_FIRST);
+  }
+
+  if (found) {
+    if (valuep)
+      *valuep = best_value;
+    return from_internal_location(topology, &best_initiator, bestp);
+  } else {
+    errno = ENOENT;
+    return -1;
+  }
+}

--- a/hwloc/shmem.c
+++ b/hwloc/shmem.c
@@ -97,6 +97,7 @@ hwloc_shmem_topology_write(hwloc_topology_t topology,
    * without being able to free() them.
    */
   hwloc_internal_distances_refresh(topology);
+  hwloc_internal_memattrs_refresh(topology);
 
   header.header_version = HWLOC_SHMEM_HEADER_VERSION;
   header.header_length = sizeof(header);
@@ -136,6 +137,7 @@ hwloc_shmem_topology_write(hwloc_topology_t topology,
 
   /* now refresh the new distances so that adopters can use them without refreshing the R/O shmem mapping */
   hwloc_internal_distances_refresh(new);
+  /* no need to refresh memattrs since we don't cache objects there */
 
   /* topology is saved, release resources now */
   munmap(mmap_address, length);

--- a/hwloc/shmem.c
+++ b/hwloc/shmem.c
@@ -135,9 +135,9 @@ hwloc_shmem_topology_write(hwloc_topology_t topology,
 
   assert((char *)mmap_res <= (char *)mmap_address + length);
 
-  /* now refresh the new distances so that adopters can use them without refreshing the R/O shmem mapping */
+  /* now refresh the new distances/memattrs so that adopters can use them without refreshing the R/O shmem mapping */
   hwloc_internal_distances_refresh(new);
-  /* no need to refresh memattrs since we don't cache objects there */
+  hwloc_internal_memattrs_refresh(topology);
 
   /* topology is saved, release resources now */
   munmap(mmap_address, length);

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -3201,6 +3201,7 @@ hwloc_linux_knl_add_cluster(struct hwloc_topology *topology,
 			    hwloc_obj_t ddr, hwloc_obj_t mcdram,
 			    struct knl_hwdata *knl_hwdata,
 			    int mscache_as_l3,
+                            int snclevel,
 			    unsigned *failednodes)
 {
   hwloc_obj_t cluster = NULL;
@@ -3231,8 +3232,10 @@ hwloc_linux_knl_add_cluster(struct hwloc_topology *topology,
       ddr = NULL;
     }
     res = hwloc__attach_memory_object(topology, cluster, mcdram, "linux:knl:snc:mcdram");
-    if (res != mcdram)
+    if (res != mcdram) {
       (*failednodes)++;
+      mcdram = NULL;
+    }
 
   } else {
     /* we don't know where to attach, let the core find or insert if needed */
@@ -3244,9 +3247,24 @@ hwloc_linux_knl_add_cluster(struct hwloc_topology *topology,
     }
     if (mcdram) {
       res = hwloc__insert_object_by_cpuset(topology, NULL, mcdram, "linux:knl:mcdram");
-      if (res != mcdram)
+      if (res != mcdram) {
 	(*failednodes)++;
+        mcdram = NULL;
+      }
     }
+  }
+
+  if (ddr && mcdram) {
+    /* add memattrs to distinguish DDR and MCDRAM */
+    struct hwloc_internal_location_s loc;
+    hwloc_uint64_t ddrbw;
+    hwloc_uint64_t mcdrambw;
+    ddrbw = 90000/snclevel;
+    mcdrambw = 360000/snclevel;
+    loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+    loc.location.cpuset = ddr->cpuset;
+    hwloc_internal_memattr_set_value(topology, HWLOC_MEMATTR_ID_BANDWIDTH, HWLOC_OBJ_NUMANODE, (hwloc_uint64_t)-1, ddr->os_index, &loc, ddrbw);
+    hwloc_internal_memattr_set_value(topology, HWLOC_MEMATTR_ID_BANDWIDTH, HWLOC_OBJ_NUMANODE, (hwloc_uint64_t)-1, mcdram->os_index, &loc, mcdrambw);
   }
 
   if (ddr && knl_hwdata->mcdram_cache_size > 0) {
@@ -3349,7 +3367,7 @@ hwloc_linux_knl_numa_quirk(struct hwloc_topology *topology,
 	fprintf(stderr, "Found %u NUMA nodes instead of 1 in mode %s-%s\n", nbnodes, hwdata.cluster_mode, hwdata.memory_mode);
 	goto error;
       }
-      hwloc_linux_knl_add_cluster(topology, nodes[0], NULL, &hwdata, mscache_as_l3, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[0], NULL, &hwdata, mscache_as_l3, 1, failednodes);
 
     } else {
       /* Quadrant-Flat/Hybrid */
@@ -3359,7 +3377,7 @@ hwloc_linux_knl_numa_quirk(struct hwloc_topology *topology,
       }
       if (!strcmp(hwdata.memory_mode, "Flat"))
 	hwdata.mcdram_cache_size = 0;
-      hwloc_linux_knl_add_cluster(topology, nodes[0], nodes[1], &hwdata, mscache_as_l3, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[0], nodes[1], &hwdata, mscache_as_l3, 1, failednodes);
     }
 
   } else if (!strcmp(hwdata.cluster_mode, "SNC2")) {
@@ -3369,8 +3387,8 @@ hwloc_linux_knl_numa_quirk(struct hwloc_topology *topology,
 	fprintf(stderr, "Found %u NUMA nodes instead of 2 in mode %s-%s\n", nbnodes, hwdata.cluster_mode, hwdata.memory_mode);
 	goto error;
       }
-      hwloc_linux_knl_add_cluster(topology, nodes[0], NULL, &hwdata, mscache_as_l3, failednodes);
-      hwloc_linux_knl_add_cluster(topology, nodes[1], NULL, &hwdata, mscache_as_l3, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[0], NULL, &hwdata, mscache_as_l3, 2, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[1], NULL, &hwdata, mscache_as_l3, 2, failednodes);
 
     } else {
       /* SNC2-Flat/Hybrid */
@@ -3385,8 +3403,8 @@ hwloc_linux_knl_numa_quirk(struct hwloc_topology *topology,
       }
       if (!strcmp(hwdata.memory_mode, "Flat"))
 	hwdata.mcdram_cache_size = 0;
-      hwloc_linux_knl_add_cluster(topology, nodes[ddr[0]], nodes[mcdram[0]], &hwdata, mscache_as_l3, failednodes);
-      hwloc_linux_knl_add_cluster(topology, nodes[ddr[1]], nodes[mcdram[1]], &hwdata, mscache_as_l3, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[ddr[0]], nodes[mcdram[0]], &hwdata, mscache_as_l3, 2, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[ddr[1]], nodes[mcdram[1]], &hwdata, mscache_as_l3, 2, failednodes);
     }
 
   } else if (!strcmp(hwdata.cluster_mode, "SNC4")) {
@@ -3396,10 +3414,10 @@ hwloc_linux_knl_numa_quirk(struct hwloc_topology *topology,
 	fprintf(stderr, "Found %u NUMA nodes instead of 4 in mode %s-%s\n", nbnodes, hwdata.cluster_mode, hwdata.memory_mode);
 	goto error;
       }
-      hwloc_linux_knl_add_cluster(topology, nodes[0], NULL, &hwdata, mscache_as_l3, failednodes);
-      hwloc_linux_knl_add_cluster(topology, nodes[1], NULL, &hwdata, mscache_as_l3, failednodes);
-      hwloc_linux_knl_add_cluster(topology, nodes[2], NULL, &hwdata, mscache_as_l3, failednodes);
-      hwloc_linux_knl_add_cluster(topology, nodes[3], NULL, &hwdata, mscache_as_l3, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[0], NULL, &hwdata, mscache_as_l3, 4, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[1], NULL, &hwdata, mscache_as_l3, 4, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[2], NULL, &hwdata, mscache_as_l3, 4, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[3], NULL, &hwdata, mscache_as_l3, 4, failednodes);
 
     } else {
       /* SNC4-Flat/Hybrid */
@@ -3414,10 +3432,10 @@ hwloc_linux_knl_numa_quirk(struct hwloc_topology *topology,
       }
       if (!strcmp(hwdata.memory_mode, "Flat"))
 	hwdata.mcdram_cache_size = 0;
-      hwloc_linux_knl_add_cluster(topology, nodes[ddr[0]], nodes[mcdram[0]], &hwdata, mscache_as_l3, failednodes);
-      hwloc_linux_knl_add_cluster(topology, nodes[ddr[1]], nodes[mcdram[1]], &hwdata, mscache_as_l3, failednodes);
-      hwloc_linux_knl_add_cluster(topology, nodes[ddr[2]], nodes[mcdram[2]], &hwdata, mscache_as_l3, failednodes);
-      hwloc_linux_knl_add_cluster(topology, nodes[ddr[3]], nodes[mcdram[3]], &hwdata, mscache_as_l3, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[ddr[0]], nodes[mcdram[0]], &hwdata, mscache_as_l3, 4, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[ddr[1]], nodes[mcdram[1]], &hwdata, mscache_as_l3, 4, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[ddr[2]], nodes[mcdram[2]], &hwdata, mscache_as_l3, 4, failednodes);
+      hwloc_linux_knl_add_cluster(topology, nodes[ddr[3]], nodes[mcdram[3]], &hwdata, mscache_as_l3, 4, failednodes);
     }
   }
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2009-2019 Inria.  All rights reserved.
+# Copyright © 2009-2020 Inria.  All rights reserved.
 # Copyright © 2009-2010 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright © 2011      Oracle and/or its affiliates.  All rights reserved.
@@ -19,6 +19,7 @@ include_hwloc_HEADERS = \
         hwloc/bitmap.h \
         hwloc/helper.h \
         hwloc/inlines.h \
+        hwloc/memattrs.h \
         hwloc/diff.h \
         hwloc/shmem.h \
         hwloc/distances.h \

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -544,6 +544,8 @@ struct hwloc_obj {
                                           * between this object and the NUMA node objects).
                                           *
                                           * In the end, these nodes are those that are close to the current object.
+                                          * Function hwloc_get_local_numanode_objs() may be used to list those NUMA
+                                          * nodes more precisely.
                                           *
                                           * If the ::HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED configuration flag is set,
                                           * some of these nodes may not be allowed for allocation,

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -2441,6 +2441,9 @@ HWLOC_DECLSPEC int hwloc_obj_add_other_obj_sets(hwloc_obj_t dst, hwloc_obj_t src
 /* inline code of some functions above */
 #include "hwloc/inlines.h"
 
+/* memory attributes */
+#include "hwloc/memattrs.h"
+
 /* exporting to XML or synthetic */
 #include "hwloc/export.h"
 

--- a/include/hwloc/memattrs.h
+++ b/include/hwloc/memattrs.h
@@ -1,0 +1,344 @@
+/*
+ * Copyright © 2019-2020 Inria.  All rights reserved.
+ * See COPYING in top-level directory.
+ */
+
+/** \file
+ * \brief Memory node attributes.
+ */
+
+#ifndef HWLOC_MEMATTR_H
+#define HWLOC_MEMATTR_H
+
+#include "hwloc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#elif 0
+}
+#endif
+
+/** \defgroup hwlocality_memattrs Comparing memory node attributes for finding where to allocate on
+ *
+ * Performance usually depends on where the memory access comes from.
+ * This location is called an Initiator while the memory node is a Target.
+ * The following attributes describe the performance of memory accesses
+ * from an Initiator to a memory Target, for instance their latency
+ * or bandwidth.
+ *
+ * Initiators performing these memory accesses are usually some PUs or Cores
+ * (described as a CPU set).
+ * In the future, this API may also provide information about other Initiators
+ * given as objects, for instance GPUs.
+ *
+ * Hence a Core may choose where to allocate memory by comparing the
+ * attributes of different memory node targets nearby.
+ *
+ * There are also some attributes that are system-wide.
+ * Their value does not depend on a specific initiator performing
+ * an access.
+ * The memory node Capacity is an example of such attribute without
+ * initiator.
+ *
+ * One way to use this API is to start with a cpuset describing the Cores where
+ * a program is bound. The best target NUMA node for allocating memory in this
+ * program on these Cores may be obtained by passing this cpuset as an initiator
+ * to hwloc_memattr_get_best_target() with the relevant memory attribute.
+ *
+ * \note The interface actually also accepts targets that are not NUMA nodes.
+ * @{
+ */
+
+/** \brief Memory node attributes. */
+enum hwloc_memattr_id_e {
+  /** \brief "Capacity".
+   * The capacity is returned in bytes
+   * (local_memory attribute in objects).
+   *
+   * Best capacity nodes are nodes with <b>higher capacity</b>.
+   *
+   * No initiator is involved when looking at this attribute.
+   * The corresponding attribute flags are ::HWLOC_MEMATTR_FLAG_HIGHER_FIRST.
+   */
+  HWLOC_MEMATTR_ID_CAPACITY = 0,
+
+  /** \brief "Locality".
+   * The locality is returned as the number of PUs in that locality
+   * (e.g. the weight of its cpuset).
+   *
+   * Best locality nodes are nodes with <b>smaller locality</b>
+   * (nodes that are local to very few PUs).
+   * Poor locality nodes are nodes with larger locality
+   * (nodes that are local to the entire machine).
+   *
+   * No initiator is involved when looking at this attribute.
+   * The corresponding attribute flags are ::HWLOC_MEMATTR_FLAG_HIGHER_FIRST.
+   */
+  HWLOC_MEMATTR_ID_LOCALITY = 1,
+
+  /** \brief "Bandwidth".
+   * The bandwidth is returned in MiB/s, as seen from the given initiator location.
+   * Best bandwidth nodes are nodes with <b>higher bandwidth</b>.
+   * The corresponding attribute flags are ::HWLOC_MEMATTR_FLAG_HIGHER_FIRST
+   * and ::HWLOC_MEMATTR_FLAG_NEED_INITIATOR.
+   */
+  HWLOC_MEMATTR_ID_BANDWIDTH = 2,
+
+  /** \brief "Latency".
+   * The latency is returned as nanoseconds, as seen from the given initiator location.
+   * Best latency nodes are nodes with <b>smaller latency</b>.
+   * The corresponding attribute flags are ::HWLOC_MEMATTR_FLAG_LOWER_FIRST
+   * and ::HWLOC_MEMATTR_FLAG_NEED_INITIATOR.
+   */
+  HWLOC_MEMATTR_ID_LATENCY = 3
+
+  /* TODO read vs write, persistence? */
+};
+
+/** \brief A memory attribute identifier.
+ * May be either one of ::hwloc_memattr_id_e or a new id returned by hwloc_memattr_register().
+ */
+typedef unsigned hwloc_memattr_id_t;
+
+/** \brief Return the identifier of the memory attribute with the given name.
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_get_by_name(hwloc_topology_t topology,
+                          const char *name,
+                          hwloc_memattr_id_t *id);
+
+
+/** \brief Where to measure attributes from. */
+struct hwloc_location {
+  /** \brief Type of location. */
+  enum hwloc_location_type_e {
+    /** \brief Location is given as an object, in the location object union field. */
+    HWLOC_LOCATION_TYPE_OBJECT = 0,
+    /** \brief Location is given as an cpuset, in the location cpuset union field. */
+    HWLOC_LOCATION_TYPE_CPUSET = 1
+  } type;
+  /** \brief Actual location. */
+  union hwloc_location_u {
+    /** \brief Location as an object, when the location type is HWLOC_LOCATION_TYPE_OBJECT. */
+    hwloc_obj_t object;
+    /** \brief Location as a cpuset, when the location type is HWLOC_LOCATION_TYPE_CPUSET. */
+    hwloc_cpuset_t cpuset;
+  } location;
+};
+
+
+
+/** \brief Return an attribute value for a specific target NUMA node.
+ *
+ * If the attribute does not relate to a specific initiator
+ * (it does not have the flag ::HWLOC_MEMATTR_FLAG_NEED_INITIATOR),
+ * location \p initiator is ignored and may be \c NULL.
+ *
+ * \p flags must be \c 0 for now.
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_get_value(hwloc_topology_t topology,
+                        hwloc_memattr_id_t attribute,
+                        hwloc_obj_t target_node,
+                        struct hwloc_location *initiator,
+                        unsigned long flags,
+                        hwloc_uint64_t *value);
+
+/** \brief Return the best target NUMA node for the given attribute and initiator.
+ *
+ * If the attribute does not relate to a specific initiator
+ * (it does not have the flag ::HWLOC_MEMATTR_FLAG_NEED_INITIATOR),
+ * location \p initiator is ignored and may be \c NULL.
+ *
+ * If \p value is non \c NULL, the corresponding value is returned there.
+ *
+ * If multiple targets have the same attribute values, only one is
+ * returned (and there is no way to clarify how that one is chosen).
+ * Applications that want to detect targets with identical/similar
+ * values, or that want to look at values for multiple attributes,
+ * should rather get all values using hwloc_memattr_get_value()
+ * and manually select the target they consider the best.
+ *
+ * \p flags must be \c 0 for now.
+ *
+ * If there are no matching targets, \c -1 is returned with \p errno set to \c ENOENT;
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_get_best_target(hwloc_topology_t topology,
+                              hwloc_memattr_id_t attribute,
+                              struct hwloc_location *initiator,
+                              unsigned long flags,
+                              hwloc_obj_t *best_target, hwloc_uint64_t *value);
+
+/** \brief Return the best initiator for the given attribute and target NUMA node.
+ *
+ * If the attribute does not relate to a specific initiator
+ * (it does not have the flag ::HWLOC_MEMATTR_FLAG_NEED_INITIATOR),
+ * \c -1 is returned and \p errno is set to \c EINVAL.
+ *
+ * If \p value is non \c NULL, the corresponding value is returned there.
+ *
+ * If multiple initiators have the same attribute values, only one is
+ * returned (and there is no way to clarify how that one is chosen).
+ * Applications that want to detect initiators with identical/similar
+ * values, or that want to look at values for multiple attributes,
+ * should rather get all values using hwloc_memattr_get_value()
+ * and manually select the initiator they consider the best.
+ *
+ * The returned initiator should not be modified or freed,
+ * it belongs to the topology.
+ *
+ * \p flags must be \c 0 for now.
+ *
+ * If there are no matching initiators, \c -1 is returned with \p errno set to \c ENOENT;
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_get_best_initiator(hwloc_topology_t topology,
+                                 hwloc_memattr_id_t attribute,
+                                 hwloc_obj_t target,
+                                 unsigned long flags,
+                                 struct hwloc_location *best_initiator, hwloc_uint64_t *value);
+
+/** @} */
+
+
+/** \defgroup hwlocality_memattrs_manage Managing memory attributes
+ * @{
+ */
+
+/** \brief Return the name of a memory attribute.
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_get_name(hwloc_topology_t topology,
+                       hwloc_memattr_id_t attribute,
+                       const char **name);
+
+/** \brief Return the flags of the given attribute.
+ *
+ * Flags are a OR'ed set of ::hwloc_memattr_flag_e.
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_get_flags(hwloc_topology_t topology,
+                        hwloc_memattr_id_t attribute,
+                        unsigned long *flags);
+
+/** \brief Memory attribute flags.
+ * Given to hwloc_memattr_register() and returned by hwloc_memattr_get_flags().
+ */
+enum hwloc_memattr_flag_e {
+  /** \brief The best nodes for this memory attribute are those with the higher values.
+   * For instance Bandwidth.
+   */
+  HWLOC_MEMATTR_FLAG_HIGHER_FIRST = (1UL<<0),
+  /** \brief The best nodes for this memory attribute are those with the lower values.
+   * For instance Latency.
+   */
+  HWLOC_MEMATTR_FLAG_LOWER_FIRST = (1UL<<1),
+  /** \brief The value returned for this memory attribute depends on the given initiator.
+   * For instance Bandwidth and Latency, but not Capacity.
+   */
+  HWLOC_MEMATTR_FLAG_NEED_INITIATOR = (1UL<<2)
+};
+
+/** \brief Register a new memory attribute.
+ *
+ * Add a specific memory attribute that is not defined in ::hwloc_memattr_id_e.
+ * Flags are a OR'ed set of ::hwloc_memattr_flag_e. It must contain at least
+ * one of ::HWLOC_MEMATTR_FLAG_HIGHER_FIRST or ::HWLOC_MEMATTR_FLAG_LOWER_FIRST.
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_register(hwloc_topology_t topology,
+                       const char *name,
+                       unsigned long flags,
+                       hwloc_memattr_id_t *id);
+
+/** \brief Set an attribute value for a specific target NUMA node.
+ *
+ * If the attribute does not relate to a specific initiator
+ * (it does not have the flag ::HWLOC_MEMATTR_FLAG_NEED_INITIATOR),
+ * location \p initiator is ignored and may be \c NULL.
+ *
+ * The initiator will be copied into the topology,
+ * the caller should free anything allocated to store the initiator,
+ * for instance the cpuset.
+ *
+ * \p flags must be \c 0 for now.
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_set_value(hwloc_topology_t topology,
+                        hwloc_memattr_id_t attribute,
+                        hwloc_obj_t target_node,
+                        struct hwloc_location *initiator,
+                        unsigned long flags,
+                        hwloc_uint64_t value);
+
+/** \brief Return the target NUMA nodes that have some values for a given attribute.
+ *
+ * Return targets for the given attribute in the \p targets array
+ * (for the given initiator if any).
+ * If \p values is not \c NULL, the corresponding attribute values
+ * are stored in the array it points to.
+ *
+ * On input, \p nr points to the number of targets that may be stored
+ * in the array \p targets (and \p values).
+ * On output, \p nr points to the number of targets (and values) that
+ * were actually found, even if some of them couldn't be stored in the array.
+ * Targets that couldn't be stored are ignored, but the function still
+ * returns success (\c 0). The caller may find out by comparing the value pointed
+ * by \p nr before and after the function call.
+ *
+ * The returned targets should not be modified or freed,
+ * they belong to the topology.
+ *
+ * Argument \p initiator is ignored if the attribute does not relate to a specific
+ * initiator (it does not have the flag ::HWLOC_MEMATTR_FLAG_NEED_INITIATOR).
+ * Otherwise \p initiator may be non \c NULL to report only targets
+ * that have a value for that initiator.
+ *
+ * \p flags must be \c 0 for now.
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_get_targets(hwloc_topology_t topology,
+                          hwloc_memattr_id_t attribute,
+                          struct hwloc_location *initiator,
+                          unsigned long flags,
+                          unsigned *nrp, hwloc_obj_t *targets, hwloc_uint64_t *values);
+
+/** \brief Return the initiators that have values for a given attribute for a specific target NUMA node.
+ *
+ * Return initiators for the given attribute and target node in the
+ * \p initiators array.
+ * If \p values is not \c NULL, the corresponding attribute values
+ * are stored in the array it points to.
+ *
+ * On input, \p nr points to the number of initiators that may be stored
+ * in the array \p initiators (and \p values).
+ * On output, \p nr points to the number of initiators (and values) that
+ * were actually found, even if some of them couldn't be stored in the array.
+ * Initiators that couldn't be stored are ignored, but the function still
+ * returns success (\c 0). The caller may find out by comparing the value pointed
+ * by \p nr before and after the function call.
+ *
+ * The returned initiators should not be modified or freed,
+ * they belong to the topology.
+ *
+ * \p flags must be \c 0 for now.
+ *
+ * If the attribute does not relate to a specific initiator
+ * (it does not have the flag ::HWLOC_MEMATTR_FLAG_NEED_INITIATOR),
+ * no initiator is returned.
+ */
+HWLOC_DECLSPEC int
+hwloc_memattr_get_initiators(hwloc_topology_t topology,
+                             hwloc_memattr_id_t attribute,
+                             hwloc_obj_t target_node,
+                             unsigned long flags,
+                             unsigned *nr, struct hwloc_location *initiators, hwloc_uint64_t *values);
+/** @} */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+
+#endif /* HWLOC_MEMATTR_H */

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -719,6 +719,8 @@ extern "C" {
 
 #define hwloc__attach_memory_object HWLOC_NAME(insert_memory_object)
 
+#define hwloc_get_obj_by_type_and_gp_index HWLOC_NAME(get_obj_by_type_and_gp_index)
+
 #define hwloc_pci_discovery_init HWLOC_NAME(pci_discovery_init)
 #define hwloc_pci_discovery_prepare HWLOC_NAME(pci_discovery_prepare)
 #define hwloc_pci_discovery_exit HWLOC_NAME(pci_discovery_exit)

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -369,6 +369,38 @@ extern "C" {
 #define hwloc_cpuset_to_nodeset HWLOC_NAME(cpuset_to_nodeset)
 #define hwloc_cpuset_from_nodeset HWLOC_NAME(cpuset_from_nodeset)
 
+/* memattrs.h */
+
+#define hwloc_memattr_id_e HWLOC_NAME(memattr_id_e)
+#define HWLOC_MEMATTR_ID_CAPACITY HWLOC_NAME_CAPS(MEMATTR_ID_CAPACITY)
+#define HWLOC_MEMATTR_ID_LOCALITY HWLOC_NAME_CAPS(MEMATTR_ID_LOCALITY)
+#define HWLOC_MEMATTR_ID_BANDWIDTH HWLOC_NAME_CAPS(MEMATTR_ID_BANDWIDTH)
+#define HWLOC_MEMATTR_ID_LATENCY HWLOC_NAME_CAPS(MEMATTR_ID_LATENCY)
+
+#define hwloc_memattr_id_t HWLOC_NAME(memattr_id_t)
+#define hwloc_memattr_get_by_name HWLOC_NAME(memattr_get_by_name)
+
+#define hwloc_location HWLOC_NAME(location)
+#define hwloc_location_type_e HWLOC_NAME(location_type_e)
+#define HWLOC_LOCATION_TYPE_OBJECT HWLOC_NAME_CAPS(LOCATION_TYPE_OBJECT)
+#define HWLOC_LOCATION_TYPE_CPUSET HWLOC_NAME_CAPS(LOCATION_TYPE_CPUSET)
+#define hwloc_location_u HWLOC_NAME(location_u)
+
+#define hwloc_memattr_get_value HWLOC_NAME(memattr_get_value)
+#define hwloc_memattr_get_best_target HWLOC_NAME(memattr_get_best_target)
+#define hwloc_memattr_get_best_initiator HWLOC_NAME(memattr_get_best_initiator)
+
+#define hwloc_memattr_get_name HWLOC_NAME(memattr_get_name)
+#define hwloc_memattr_get_flags HWLOC_NAME(memattr_get_flags)
+#define hwloc_memattr_flag_e HWLOC_NAME(memattr_flag_e)
+#define HWLOC_MEMATTR_FLAG_HIGHER_FIRST HWLOC_NAME_CAPS(MEMATTR_FLAG_HIGHER_FIRST)
+#define HWLOC_MEMATTR_FLAG_LOWER_FIRST HWLOC_NAME_CAPS(MEMATTR_FLAG_LOWER_FIRST)
+#define HWLOC_MEMATTR_FLAG_NEED_INITIATOR HWLOC_NAME_CAPS(MEMATTR_FLAG_NEED_INITIATOR)
+#define hwloc_memattr_register HWLOC_NAME(memattr_register)
+#define hwloc_memattr_set_value HWLOC_NAME(memattr_set_value)
+#define hwloc_memattr_get_targets HWLOC_NAME(memattr_get_targets)
+#define hwloc_memattr_get_initiators HWLOC_NAME(memattr_get_initiators)
+
 /* export.h */
 
 #define hwloc_topology_export_xml_flags_e HWLOC_NAME(topology_export_xml_flags_e)
@@ -697,6 +729,8 @@ extern "C" {
 
 /* private/private.h */
 
+#define hwloc_internal_location_s HWLOC_NAME(internal_location_s)
+
 #define hwloc_special_level_s HWLOC_NAME(special_level_s)
 
 #define hwloc_pci_forced_locality_s HWLOC_NAME(pci_forced_locality_s)
@@ -771,6 +805,16 @@ extern "C" {
 #define hwloc_internal_distances_add HWLOC_NAME(internal_distances_add)
 #define hwloc_internal_distances_add_by_index HWLOC_NAME(internal_distances_add_by_index)
 #define hwloc_internal_distances_invalidate_cached_objs HWLOC_NAME(hwloc_internal_distances_invalidate_cached_objs)
+
+#define hwloc_internal_memattr_s HWLOC_NAME(internal_memattr_s)
+#define hwloc_internal_memattr_target_s HWLOC_NAME(internal_memattr_target_s)
+#define hwloc_internal_memattr_initiator_s HWLOC_NAME(internal_memattr_initiator_s)
+#define hwloc_internal_memattrs_init HWLOC_NAME(internal_memattrs_init)
+#define hwloc_internal_memattrs_prepare HWLOC_NAME(internal_memattrs_prepare)
+#define hwloc_internal_memattrs_dup HWLOC_NAME(internal_memattrs_dup)
+#define hwloc_internal_memattrs_destroy HWLOC_NAME(internal_memattrs_destroy)
+#define hwloc_internal_memattrs_need_refresh HWLOC_NAME(internal_memattrs_need_refresh)
+#define hwloc_internal_memattrs_refresh HWLOC_NAME(internal_memattrs_refresh)
 
 #define hwloc_encode_to_base64 HWLOC_NAME(encode_to_base64)
 #define hwloc_decode_from_base64 HWLOC_NAME(decode_from_base64)

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -390,6 +390,12 @@ extern "C" {
 #define hwloc_memattr_get_best_target HWLOC_NAME(memattr_get_best_target)
 #define hwloc_memattr_get_best_initiator HWLOC_NAME(memattr_get_best_initiator)
 
+#define hwloc_local_numanode_flag_e HWLOC_NAME(local_numanode_flag_e)
+#define HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY HWLOC_NAME_CAPS(LOCAL_NUMANODE_FLAG_LARGER_LOCALITY)
+#define HWLOC_LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY HWLOC_NAME_CAPS(LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY)
+#define HWLOC_LOCAL_NUMANODE_FLAG_ALL HWLOC_NAME_CAPS(LOCAL_NUMANODE_FLAG_ALL)
+#define hwloc_get_local_numanode_objs HWLOC_NAME(get_local_numanode_objs)
+
 #define hwloc_memattr_get_name HWLOC_NAME(memattr_get_name)
 #define hwloc_memattr_get_flags HWLOC_NAME(memattr_get_flags)
 #define hwloc_memattr_flag_e HWLOC_NAME(memattr_flag_e)

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -46,9 +46,9 @@ struct hwloc_internal_location_s {
   enum hwloc_location_type_e type;
   union {
     struct {
+      hwloc_obj_t obj; /* cached between refreshes */
       uint64_t gp_index;
       hwloc_obj_type_t type;
-      // TODO cache object ?
     } object; /* if type == HWLOC_LOCATION_TYPE_OBJECT */
     hwloc_cpuset_t cpuset; /* if type == HWLOC_LOCATION_TYPE_CPUSET */
   } location;
@@ -190,10 +190,10 @@ struct hwloc_topology {
     unsigned nr_targets;
     struct hwloc_internal_memattr_target_s {
       /* target object */
+      hwloc_obj_t obj; /* cached between refreshes */
       hwloc_obj_type_t type;
       unsigned os_index; /* only used temporarily during discovery when there's no obj/gp_index yet */
       hwloc_uint64_t gp_index;
-      /* TODO cache the object */
 
       /* value if there are no initiator for this attr */
       hwloc_uint64_t noinitiator_value;

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -242,6 +242,8 @@ extern void hwloc_topology_clear(struct hwloc_topology *topology);
 extern struct hwloc_obj * hwloc__attach_memory_object(struct hwloc_topology *topology, hwloc_obj_t parent,
                                                       hwloc_obj_t obj, const char *reason);
 
+extern hwloc_obj_t hwloc_get_obj_by_type_and_gp_index(hwloc_topology_t topology, hwloc_obj_type_t type, uint64_t gp_index);
+
 extern void hwloc_pci_discovery_init(struct hwloc_topology *topology);
 extern void hwloc_pci_discovery_prepare(struct hwloc_topology *topology);
 extern void hwloc_pci_discovery_exit(struct hwloc_topology *topology);

--- a/tests/hwloc/Makefile.am
+++ b/tests/hwloc/Makefile.am
@@ -65,6 +65,7 @@ check_PROGRAMS = \
         hwloc_obj_infos \
         hwloc_iodevs \
         cpuset_nodeset \
+        memattrs \
         xmlbuffer \
         gl
 

--- a/tests/hwloc/hwloc_topology_abi.c
+++ b/tests/hwloc/hwloc_topology_abi.c
@@ -65,8 +65,19 @@ int main(void)
     size = sizeof(struct hwloc_internal_distances_s);
     assert(size == 88);
 
+    offset = offsetof(struct hwloc_topology, memattrs);
+    assert(offset == 728);
+    size = sizeof(struct hwloc_internal_memattr_s);
+    assert(size == 32);
+    size = sizeof(struct hwloc_internal_memattr_target_s);
+    assert(size == 40);
+    size = sizeof(struct hwloc_internal_memattr_initiator_s);
+    assert(size == 32);
+    size = sizeof(struct hwloc_internal_location_s);
+    assert(size == 24);
+
     offset = offsetof(struct hwloc_topology, grouping_next_subkind);
-    assert(offset == 756);
+    assert(offset == 768);
 
     /* fields after this one aren't needed after discovery */
 
@@ -138,6 +149,9 @@ int main(void)
 
     size = sizeof(struct hwloc_distances_s);
     assert(size == 32);
+
+    size = sizeof(struct hwloc_location);
+    assert(size == 16);
 
     size = sizeof(union hwloc_topology_diff_u);
     assert(size == 56);

--- a/tests/hwloc/hwloc_topology_abi.c
+++ b/tests/hwloc/hwloc_topology_abi.c
@@ -70,11 +70,11 @@ int main(void)
     size = sizeof(struct hwloc_internal_memattr_s);
     assert(size == 32);
     size = sizeof(struct hwloc_internal_memattr_target_s);
-    assert(size == 40);
+    assert(size == 48);
     size = sizeof(struct hwloc_internal_memattr_initiator_s);
-    assert(size == 32);
+    assert(size == 40);
     size = sizeof(struct hwloc_internal_location_s);
-    assert(size == 24);
+    assert(size == 32);
 
     offset = offsetof(struct hwloc_topology, grouping_next_subkind);
     assert(offset == 768);

--- a/tests/hwloc/linux/64intel64-fakeKNL-SNC4-hybrid-msc.output
+++ b/tests/hwloc/linux/64intel64-fakeKNL-SNC4-hybrid-msc.output
@@ -146,4 +146,13 @@ depth 0:           1 Machine (type #0)
        depth 7:    64 PU (type #3)
 Special depth -3:  8 NUMANode (type #13)
 Special depth -8:  4 MemCache (type #18)
+Memory attribute #2 name `Bandwidth' flags 5
+  NUMANode L#0 = 22500 from cpuset 0x000f000f,0x000f000f (Group0 L#0)
+  NUMANode L#1 = 90000 from cpuset 0x000f000f,0x000f000f (Group0 L#0)
+  NUMANode L#2 = 22500 from cpuset 0x00f000f0,0x00f000f0 (Group0 L#1)
+  NUMANode L#3 = 90000 from cpuset 0x00f000f0,0x00f000f0 (Group0 L#1)
+  NUMANode L#4 = 22500 from cpuset 0x0f000f00,0x0f000f00 (Group0 L#2)
+  NUMANode L#5 = 90000 from cpuset 0x0f000f00,0x0f000f00 (Group0 L#2)
+  NUMANode L#6 = 22500 from cpuset 0xf000f000,0xf000f000 (Group0 L#3)
+  NUMANode L#7 = 90000 from cpuset 0xf000f000,0xf000f000 (Group0 L#3)
 Topology not from this system

--- a/tests/hwloc/linux/64intel64-fakeKNL-SNC4-hybrid.output
+++ b/tests/hwloc/linux/64intel64-fakeKNL-SNC4-hybrid.output
@@ -141,4 +141,13 @@ depth 0:           1 Machine (type #0)
       depth 6:     16 Core (type #2)
        depth 7:    64 PU (type #3)
 Special depth -3:  8 NUMANode (type #13)
+Memory attribute #2 name `Bandwidth' flags 5
+  NUMANode L#0 = 22500 from cpuset 0x000f000f,0x000f000f (L3 L#0)
+  NUMANode L#1 = 90000 from cpuset 0x000f000f,0x000f000f (L3 L#0)
+  NUMANode L#2 = 22500 from cpuset 0x00f000f0,0x00f000f0 (L3 L#1)
+  NUMANode L#3 = 90000 from cpuset 0x00f000f0,0x00f000f0 (L3 L#1)
+  NUMANode L#4 = 22500 from cpuset 0x0f000f00,0x0f000f00 (L3 L#2)
+  NUMANode L#5 = 90000 from cpuset 0x0f000f00,0x0f000f00 (L3 L#2)
+  NUMANode L#6 = 22500 from cpuset 0xf000f000,0xf000f000 (L3 L#3)
+  NUMANode L#7 = 90000 from cpuset 0xf000f000,0xf000f000 (L3 L#3)
 Topology not from this system

--- a/tests/hwloc/linux/fakememinitiators-1npc+1npc.output
+++ b/tests/hwloc/linux/fakememinitiators-1npc+1npc.output
@@ -49,4 +49,18 @@ Relative latency matrix (name NUMALatency kind 5) between 6 NUMANodes (depth -3)
       4    40    40    20    10    50    30
       2    30    30    50    50    10    60
       5    50    50    30    30    60    10
+Memory attribute #2 name `Bandwidth' flags 5
+  NUMANode L#0 = 131072 from cpuset 0x00000001 (L2 L#0)
+  NUMANode L#1 = 131072 from cpuset 0x00000002 (L2 L#1)
+  NUMANode L#3 = 131072 from cpuset 0x00000004 (L2 L#2)
+  NUMANode L#4 = 131072 from cpuset 0x00000008 (L2 L#3)
+  NUMANode L#2 = 78644 from cpuset 0x00000003 (Package L#0)
+  NUMANode L#5 = 78644 from cpuset 0x0000000c (Package L#1)
+Memory attribute #3 name `Latency' flags 6
+  NUMANode L#0 = 26 from cpuset 0x00000001 (L2 L#0)
+  NUMANode L#1 = 26 from cpuset 0x00000002 (L2 L#1)
+  NUMANode L#3 = 26 from cpuset 0x00000004 (L2 L#2)
+  NUMANode L#4 = 26 from cpuset 0x00000008 (L2 L#3)
+  NUMANode L#2 = 77 from cpuset 0x00000003 (Package L#0)
+  NUMANode L#5 = 77 from cpuset 0x0000000c (Package L#1)
 Topology not from this system

--- a/tests/hwloc/memattrs.c
+++ b/tests/hwloc/memattrs.c
@@ -50,6 +50,83 @@ main(void)
   err = hwloc_topology_load(topology);
   assert(!err);
 
+  /* check get local nodes */
+  err = hwloc_get_local_numanode_objs(topology, NULL, NULL, NULL, 0);
+  assert(err < 0);
+  /* get all nodes */
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = hwloc_get_root_obj(topology);
+  nrtgs = 4;
+  err = hwloc_get_local_numanode_objs(topology, &loc, &nrtgs, targets, HWLOC_LOCAL_NUMANODE_FLAG_ALL);
+  assert(!err);
+  assert(nrtgs == 4);
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0));
+  assert(targets[1] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1));
+  assert(targets[2] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2));
+  assert(targets[3] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 3));
+  /* get root local nodes (none) */
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = hwloc_get_root_obj(topology);
+  nrtgs = 4;
+  err = hwloc_get_local_numanode_objs(topology, &loc, &nrtgs, targets, 0);
+  assert(!err);
+  assert(nrtgs == 0);
+  /* get root-or-smaller local nodes (all) */
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = hwloc_get_root_obj(topology);
+  nrtgs = 4;
+  err = hwloc_get_local_numanode_objs(topology, &loc, &nrtgs, targets, HWLOC_LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY);
+  assert(!err);
+  assert(nrtgs == 4);
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0));
+  assert(targets[1] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1));
+  assert(targets[2] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2));
+  assert(targets[3] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 3));
+  /* get PU local nodes (none) */
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = hwloc_get_obj_by_type(topology, HWLOC_OBJ_PU, 1);
+  nrtgs = 4;
+  err = hwloc_get_local_numanode_objs(topology, &loc, &nrtgs, targets, 0);
+  assert(!err);
+  assert(nrtgs == 0);
+  /* get PU-or-larger local nodes (1) */
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = hwloc_get_obj_by_type(topology, HWLOC_OBJ_PU, 7);
+  nrtgs = 4;
+  err = hwloc_get_local_numanode_objs(topology, &loc, &nrtgs, targets, HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY);
+  assert(!err);
+  assert(nrtgs == 1);
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 3));
+  /* get node local nodes (1) */
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2);
+  nrtgs = 4;
+  err = hwloc_get_local_numanode_objs(topology, &loc, &nrtgs, targets, 0);
+  assert(!err);
+  assert(nrtgs == 1);
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2));
+  /* get 2-node local nodes (0) */
+  loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+  loc.location.cpuset = hwloc_bitmap_alloc();
+  hwloc_bitmap_set_range(loc.location.cpuset, 2, 5);
+  nrtgs = 4;
+  err = hwloc_get_local_numanode_objs(topology, &loc, &nrtgs, targets, 0);
+  assert(!err);
+  assert(nrtgs == 0);
+  /* get 2-node-or-larger local nodes (0) */
+  nrtgs = 4;
+  err = hwloc_get_local_numanode_objs(topology, &loc, &nrtgs, targets, HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY);
+  assert(!err);
+  assert(nrtgs == 0);
+  /* get 2-node-or-smaller local nodes (2) */
+  nrtgs = 4;
+  err = hwloc_get_local_numanode_objs(topology, &loc, &nrtgs, targets, HWLOC_LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY);
+  assert(!err);
+  assert(nrtgs == 2);
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1));
+  assert(targets[1] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2));
+  hwloc_bitmap_free(loc.location.cpuset);
+
   /* check default memattrs */
   check_memattr(topology, "Capacity", HWLOC_MEMATTR_ID_CAPACITY, HWLOC_MEMATTR_FLAG_HIGHER_FIRST);
   check_memattr(topology, "Locality", HWLOC_MEMATTR_ID_LOCALITY, HWLOC_MEMATTR_FLAG_LOWER_FIRST);

--- a/tests/hwloc/memattrs.c
+++ b/tests/hwloc/memattrs.c
@@ -1,0 +1,432 @@
+/*
+ * Copyright © 2020 Inria.  All rights reserved.
+ * See COPYING in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "hwloc.h"
+
+static void
+check_memattr(hwloc_topology_t topology, const char *name, hwloc_memattr_id_t id, unsigned long flags)
+{
+  hwloc_memattr_id_t gotid;
+  const char *gotname;
+  unsigned long gotflags;
+  int err;
+
+  err = hwloc_memattr_get_by_name(topology, name, &gotid);
+  assert(!err);
+  assert(id == gotid);
+
+  err = hwloc_memattr_get_name(topology, id, &gotname);
+  assert(!err);
+  assert(!strcmp(gotname, name));
+
+  err = hwloc_memattr_get_flags(topology, id, &gotflags);
+  assert(!err);
+  assert(gotflags == flags);
+}
+
+int
+main(void)
+{
+  hwloc_topology_t topology;
+  const char *gotname;
+  hwloc_memattr_id_t id, id2, gotid;
+  struct hwloc_location loc, locs[2];
+  unsigned nrlocs, nrtgs, i;
+  hwloc_uint64_t gotvalue;
+  hwloc_obj_t node, targets[4];
+  int err;
+  hwloc_bitmap_t bitmap;
+
+  err = hwloc_topology_init(&topology);
+  assert(!err);
+  err = hwloc_topology_set_synthetic(topology, "node:4 pu:2");
+  assert(!err);
+  err = hwloc_topology_load(topology);
+  assert(!err);
+
+  /* check default memattrs */
+  check_memattr(topology, "Capacity", HWLOC_MEMATTR_ID_CAPACITY, HWLOC_MEMATTR_FLAG_HIGHER_FIRST);
+  check_memattr(topology, "Locality", HWLOC_MEMATTR_ID_LOCALITY, HWLOC_MEMATTR_FLAG_LOWER_FIRST);
+  check_memattr(topology, "Bandwidth", HWLOC_MEMATTR_ID_BANDWIDTH, HWLOC_MEMATTR_FLAG_HIGHER_FIRST|HWLOC_MEMATTR_FLAG_NEED_INITIATOR);
+  check_memattr(topology, "Latency", HWLOC_MEMATTR_ID_LATENCY, HWLOC_MEMATTR_FLAG_LOWER_FIRST|HWLOC_MEMATTR_FLAG_NEED_INITIATOR);
+
+  /* check convenience memattr values */
+  err = hwloc_memattr_get_value(topology, HWLOC_MEMATTR_ID_CAPACITY,
+                                hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1), NULL, 0,
+                                &gotvalue);
+  assert(!err);
+  assert(gotvalue == 1024*1024*1024);
+  err = hwloc_memattr_get_value(topology, HWLOC_MEMATTR_ID_LOCALITY,
+                                hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2), NULL, 0,
+                                &gotvalue);
+  assert(!err);
+  assert(gotvalue == 2);
+  nrtgs = 0;
+  err = hwloc_memattr_get_targets(topology, HWLOC_MEMATTR_ID_LOCALITY, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 4);
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, HWLOC_MEMATTR_ID_LOCALITY, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 4);
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0));
+  assert(targets[1] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1));
+  assert(targets[2] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2));
+  assert(targets[3] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 3));
+
+  /* look for unexisting memattr */
+  err = hwloc_memattr_get_by_name(topology, "foobarrrrr", &gotid);
+  assert(err < 0);
+  err = hwloc_memattr_get_name(topology, HWLOC_MEMATTR_ID_LATENCY+1, &gotname);
+  assert(err < 0);
+
+  /* (fail to) register with invalid flags */
+  err = hwloc_memattr_register(topology, "foobar", 0, &id);
+  assert(err < 0);
+  assert(errno == EINVAL);
+
+  /* (fail to) register with existing name */
+  err = hwloc_memattr_register(topology, "Capacity", HWLOC_MEMATTR_FLAG_HIGHER_FIRST, &id);
+  assert(err < 0);
+  assert(errno == EBUSY);
+
+  /********************************
+   * new attribute with initiators
+   */
+
+  /* register with initiator */
+  err = hwloc_memattr_register(topology, "foobar", HWLOC_MEMATTR_FLAG_LOWER_FIRST|HWLOC_MEMATTR_FLAG_NEED_INITIATOR, &id);
+  assert(!err);
+  /* check it */
+  check_memattr(topology, "foobar", id, HWLOC_MEMATTR_FLAG_LOWER_FIRST|HWLOC_MEMATTR_FLAG_NEED_INITIATOR);
+
+  /* check 0 target */
+  nrtgs = 0;
+  err = hwloc_memattr_get_targets(topology, id, NULL, 0, &nrtgs, NULL, NULL);
+  assert(!err);
+  assert(!nrtgs);
+
+  /* add a new value for the first NUMA node */
+  node = hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0);
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = hwloc_get_obj_by_type(topology, HWLOC_OBJ_PU, hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU)-1);
+  err = hwloc_memattr_set_value(topology, id, node,
+                                &loc, 0, 2345);
+  assert(!err);
+
+  /* check 1 target */
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, id, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 1);
+  assert(targets[0] == node);
+
+  /* check that value */
+  err = hwloc_memattr_get_value(topology, id, node, &loc, 0, &gotvalue);
+  assert(!err);
+  assert(gotvalue == 2345);
+
+  /* try with NULL or unknown initiators */
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = NULL;
+  err = hwloc_memattr_get_value(topology, id, node, &loc, 0, &gotvalue);
+  assert(err < 0);
+
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = hwloc_get_root_obj(topology);
+  err = hwloc_memattr_get_value(topology, id, node, &loc, 0, &gotvalue);
+  assert(err < 0);
+
+  loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+  loc.location.cpuset = NULL;
+  err = hwloc_memattr_get_value(topology, id, node, &loc, 0, &gotvalue);
+  assert(err < 0);
+
+  loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+  loc.location.cpuset = hwloc_get_root_obj(topology)->cpuset;
+  err = hwloc_memattr_get_value(topology, id, node, &loc, 0, &gotvalue);
+  assert(err < 0);
+
+  /* check initiators */
+  nrlocs = 0;
+  err = hwloc_memattr_get_initiators(topology, id, node, 0, &nrlocs, NULL, NULL);
+  assert(!err);
+  assert(nrlocs == 1);
+  /* try first without values */
+  err = hwloc_memattr_get_initiators(topology, id, node, 0, &nrlocs, &loc, NULL);
+  assert(!err);
+  assert(nrlocs == 1);
+  assert(loc.type == HWLOC_LOCATION_TYPE_OBJECT);
+  assert(loc.location.object != NULL);
+  assert(loc.location.object->type == HWLOC_OBJ_PU);
+  assert(loc.location.object->logical_index == (unsigned) (hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU) - 1));
+  /* try again with values */
+  err = hwloc_memattr_get_initiators(topology, id, node, 0, &nrlocs, &loc, &gotvalue);
+  assert(!err);
+  assert(nrlocs == 1);
+  assert(loc.type == HWLOC_LOCATION_TYPE_OBJECT);
+  assert(loc.location.object != NULL);
+  assert(loc.location.object->type == HWLOC_OBJ_PU);
+  assert(loc.location.object->logical_index == (unsigned) (hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_PU) - 1));
+  assert(gotvalue == 2345);
+
+  /***********************************
+   * new attribute without initiators
+   */
+
+  /* register without initiator */
+  err = hwloc_memattr_register(topology, "barnoinit", HWLOC_MEMATTR_FLAG_HIGHER_FIRST, &id2);
+  assert(!err);
+  /* check it */
+  check_memattr(topology, "barnoinit", id2, HWLOC_MEMATTR_FLAG_HIGHER_FIRST);
+
+  /* check 0 target */
+  nrtgs = 0;
+  err = hwloc_memattr_get_targets(topology, id2, NULL, 0, &nrtgs, NULL, NULL);
+  assert(!err);
+  assert(!nrtgs);
+
+  /* add a new value for the last NUMA node */
+  node = hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_NUMANODE)-1);
+  err = hwloc_memattr_set_value(topology, id2, node,
+                                NULL, 0, 3456);
+  assert(!err);
+
+  /* check 1 target */
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, id2, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 1);
+  assert(targets[0] == node);
+
+  /* check that value */
+  err = hwloc_memattr_get_value(topology, id2, node, NULL, 0, &gotvalue);
+  assert(!err);
+  assert(gotvalue == 3456);
+
+  /* check that initiator is ignored when getting values */
+  loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+  loc.location.object = hwloc_get_root_obj(topology);
+  gotvalue = 0;
+  err = hwloc_memattr_get_value(topology, id2, node, &loc, 0, &gotvalue);
+  assert(!err);
+  assert(gotvalue == 3456);
+
+  loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+  loc.location.cpuset = hwloc_get_root_obj(topology)->cpuset;
+  gotvalue = 0;
+  err = hwloc_memattr_get_value(topology, id2, node, &loc, 0, &gotvalue);
+  assert(!err);
+  assert(gotvalue == 3456);
+
+  /* check no initiators are returned */
+  nrlocs = 0;
+  err = hwloc_memattr_get_initiators(topology, id2, node, 0, &nrlocs, NULL, NULL);
+  assert(!err);
+  assert(nrlocs == 0);
+
+  /**********************************************
+   * add value for both attributes for all nodes
+   */
+  /* use first node as initiator for first attribute */
+  loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+  loc.location.cpuset = hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0)->cpuset;
+  for(i=0; i<(unsigned)hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_NUMANODE); i++) {
+    node = hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, i);
+    /* increasing value for first attribute, best target will be first node */
+    err = hwloc_memattr_set_value(topology, id, node,
+                                  &loc, 0, (i+1)*10);
+    assert(!err);
+
+    /* increasing value for second attribute without initiator, best target will be last node */
+    err = hwloc_memattr_set_value(topology, id2, node,
+                                  NULL, 0, (i+1)*10);
+    assert(!err);
+  }
+
+  /* check 4 targets for id */
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, id, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 4);
+  /* first target */
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0));
+  nrlocs = 2;
+  err = hwloc_memattr_get_initiators(topology, id, targets[0], 0, &nrlocs, locs, NULL);
+  assert(!err);
+  assert(nrlocs == 2);
+  assert(locs[0].type == HWLOC_LOCATION_TYPE_OBJECT);
+  assert(locs[0].location.object->type == HWLOC_OBJ_PU);
+  assert(locs[0].location.object->os_index == 7);
+  assert(locs[1].type == HWLOC_LOCATION_TYPE_CPUSET);
+  assert(hwloc_bitmap_isequal(locs[1].location.cpuset, hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0)->cpuset));
+  /* second target */
+  assert(targets[1] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1));
+  nrlocs = 2;
+  err = hwloc_memattr_get_initiators(topology, id, targets[1], 0, &nrlocs, locs, NULL);
+  assert(!err);
+  assert(nrlocs == 1);
+  assert(locs[0].type == HWLOC_LOCATION_TYPE_CPUSET);
+  assert(hwloc_bitmap_isequal(locs[0].location.cpuset, hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0)->cpuset));
+  /* third target */
+  assert(targets[2] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2));
+  nrlocs = 2;
+  err = hwloc_memattr_get_initiators(topology, id, targets[2], 0, &nrlocs, locs, NULL);
+  assert(!err);
+  assert(nrlocs == 1);
+  assert(locs[0].type == HWLOC_LOCATION_TYPE_CPUSET);
+  assert(hwloc_bitmap_isequal(locs[0].location.cpuset, hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0)->cpuset));
+  /* fourth target */
+  assert(targets[3] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 3));
+  nrlocs = 2;
+  err = hwloc_memattr_get_initiators(topology, id, targets[3], 0, &nrlocs, locs, NULL);
+  assert(!err);
+  assert(nrlocs == 1);
+  assert(locs[0].type == HWLOC_LOCATION_TYPE_CPUSET);
+  assert(hwloc_bitmap_isequal(locs[0].location.cpuset, hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0)->cpuset));
+
+  /* check 4 targets for id with entire topology cpuset */
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, id, &loc, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 4);
+  /* check 0 targets for id with entire topology cpuset */
+  nrtgs = 4;
+  loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+  loc.location.cpuset = (hwloc_bitmap_t) hwloc_topology_get_topology_cpuset(topology);
+  err = hwloc_memattr_get_targets(topology, id, &loc, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 0);
+
+  /* check 4 targets for id2, no initiators to check */
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, id2, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 4);
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 3)); /* node 3 was added first */
+  assert(targets[1] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0));
+  assert(targets[2] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1));
+  assert(targets[3] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2));
+
+  /* now check best targets from first PU (included in first node used as initiator above) */
+  loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+  loc.location.cpuset = hwloc_get_obj_by_type(topology, HWLOC_OBJ_PU, 0)->cpuset;
+  /* check best is the first node for first attribute (lower first) */
+  err = hwloc_memattr_get_best_target(topology, id, &loc, 0, &node, NULL);
+  assert(!err);
+  assert(node);
+  assert(node->type == HWLOC_OBJ_NUMANODE);
+  assert(node == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0));
+  /* check best is the last node for last attribute (lower first) */
+  err = hwloc_memattr_get_best_target(topology, id2, &loc, 0, &node, NULL);
+  assert(!err);
+  assert(node);
+  assert(node->type == HWLOC_OBJ_NUMANODE);
+  assert(node == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, hwloc_get_nbobjs_by_type(topology, HWLOC_OBJ_NUMANODE)-1));
+
+  /* check best initiator for first NUMA is its own cpuset */
+  err = hwloc_memattr_get_best_initiator(topology, id, node, 0, &loc, NULL);
+  assert(!err);
+  assert(locs[0].type == HWLOC_LOCATION_TYPE_CPUSET);
+  /* check best initiator is invalid for no-initiator memattr */
+  assert(hwloc_bitmap_isequal(locs[0].location.cpuset, hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0)->cpuset));
+  err = hwloc_memattr_get_best_initiator(topology, id2, node, 0, &loc, NULL);
+  assert(err == -1);
+  assert(errno == EINVAL);
+
+  /***************************
+   * restrict to only 3 nodes
+   */
+  bitmap = hwloc_bitmap_alloc();
+  hwloc_bitmap_set_range(bitmap, 0, 2);
+  err = hwloc_topology_restrict(topology, bitmap, HWLOC_RESTRICT_FLAG_BYNODESET);
+  assert(!err);
+  hwloc_bitmap_free(bitmap);
+
+  /* now only 3 targets for id, last target was removed */
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, id, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 3);
+  /* first target unchanged */
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0));
+  nrlocs = 2;
+  err = hwloc_memattr_get_initiators(topology, id, targets[0], 0, &nrlocs, locs, NULL);
+  assert(!err);
+  assert(nrlocs == 2);
+  assert(locs[0].type == HWLOC_LOCATION_TYPE_OBJECT);
+  assert(locs[0].location.object->type == HWLOC_OBJ_PU);
+  assert(locs[0].location.object->os_index == 7);
+  assert(locs[1].type == HWLOC_LOCATION_TYPE_CPUSET);
+  assert(hwloc_bitmap_isequal(locs[1].location.cpuset, hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0)->cpuset));
+  /* second target unchanged */
+  assert(targets[1] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1));
+  nrlocs = 2;
+  err = hwloc_memattr_get_initiators(topology, id, targets[1], 0, &nrlocs, locs, NULL);
+  assert(!err);
+  assert(nrlocs == 1);
+  assert(locs[0].type == HWLOC_LOCATION_TYPE_CPUSET);
+  assert(hwloc_bitmap_isequal(locs[0].location.cpuset, hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0)->cpuset));
+  /* third target unchanged */
+  assert(targets[2] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2));
+  nrlocs = 2;
+  err = hwloc_memattr_get_initiators(topology, id, targets[2], 0, &nrlocs, locs, NULL);
+  assert(!err);
+  assert(nrlocs == 1);
+  assert(locs[0].type == HWLOC_LOCATION_TYPE_CPUSET);
+  assert(hwloc_bitmap_isequal(locs[0].location.cpuset, hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0)->cpuset));
+  /* fourth target removed */
+
+  /* now only 3 targets for id2, last target was removed */
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, id2, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 3);
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0));
+  assert(targets[1] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1));
+  assert(targets[2] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2));
+
+  /********************************************
+   * restrict to only the second half of cores
+   */
+  bitmap = hwloc_bitmap_alloc();
+  hwloc_bitmap_set_range(bitmap, 4, 7);
+  err = hwloc_topology_restrict(topology, bitmap, 0);
+  assert(!err);
+  hwloc_bitmap_free(bitmap);
+
+  /* now only 1 target for id, all cpuset initiators removed */
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, id, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 1);
+  /* first target only has one initiator */
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2)); /* CPUless node:0 became node:2 */
+  nrlocs = 2;
+  err = hwloc_memattr_get_initiators(topology, id, targets[0], 0, &nrlocs, locs, NULL);
+  assert(!err);
+  assert(nrlocs == 1);
+  assert(locs[0].type == HWLOC_LOCATION_TYPE_OBJECT);
+  assert(locs[0].location.object->type == HWLOC_OBJ_PU);
+  assert(locs[0].location.object->os_index == 7);
+  /* second, third and fourth targets removed */
+
+  /* still only 3 targets for id2 */
+  nrtgs = 4;
+  err = hwloc_memattr_get_targets(topology, id2, NULL, 0, &nrtgs, targets, NULL);
+  assert(!err);
+  assert(nrtgs == 3);
+  assert(targets[0] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 2)); /* CPUless node:0 became node:2 */
+  assert(targets[1] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 1)); /* 0 and 1 should be reversed, but the core doesn't current reordered those, see FIXME in restrict_object_by_nodeset() */
+  assert(targets[2] == hwloc_get_obj_by_type(topology, HWLOC_OBJ_NUMANODE, 0));
+
+  hwloc_topology_destroy(topology);
+  return 0;
+}
+

--- a/tests/hwloc/xml/64intel64-fakeKNL-SNC4-hybrid.xml
+++ b/tests/hwloc/xml/64intel64-fakeKNL-SNC4-hybrid.xml
@@ -217,4 +217,14 @@
     </object>
   </object>
   <support name="custom.exported_support"/>
+  <memattr name="Bandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="2" value="22500" initiator_cpuset="0x000f000f,0x000f000f"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="9" value="90000" initiator_cpuset="0x000f000f,0x000f000f"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="3" value="22500" initiator_cpuset="0x00f000f0,0x00f000f0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="6" value="90000" initiator_cpuset="0x00f000f0,0x00f000f0"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="4" value="22500" initiator_cpuset="0x0f000f00,0x0f000f00"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="7" value="90000" initiator_cpuset="0x0f000f00,0x0f000f00"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="5" value="22500" initiator_cpuset="0xf000f000,0xf000f000"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="8" value="90000" initiator_cpuset="0xf000f000,0xf000f000"/>
+  </memattr>
 </topology>

--- a/tests/hwloc/xml/8intel64-4n2t-memattrs.xml
+++ b/tests/hwloc/xml/8intel64-4n2t-memattrs.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topology SYSTEM "hwloc2.dtd">
+<topology version="2.0">
+  <object type="Machine" os_index="0" cpuset="0x000000ff" complete_cpuset="0x000000ff" allowed_cpuset="0x000000ff" nodeset="0x0000000f" complete_nodeset="0x0000000f" allowed_nodeset="0x0000000f" gp_index="1">
+    <info name="Backend" value="Synthetic"/>
+    <info name="SyntheticDescription" value="node:4 pu:2"/>
+    <info name="hwlocVersion" value="2.2.0a1-git"/>
+    <info name="ProcessName" value="memattrs"/>
+    <object type="Group" cpuset="0x00000003" complete_cpuset="0x00000003" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="5" kind="1001" subkind="0">
+      <object type="NUMANode" os_index="0" cpuset="0x00000003" complete_cpuset="0x00000003" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="4" local_memory="1073741824">
+        <page_type size="4096" count="262144"/>
+      </object>
+      <object type="PU" os_index="0" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="2"/>
+      <object type="PU" os_index="1" cpuset="0x00000002" complete_cpuset="0x00000002" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3"/>
+    </object>
+    <object type="Group" cpuset="0x0000000c" complete_cpuset="0x0000000c" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="9" kind="1001" subkind="0">
+      <object type="NUMANode" os_index="1" cpuset="0x0000000c" complete_cpuset="0x0000000c" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="8" local_memory="1073741824">
+        <page_type size="4096" count="262144"/>
+      </object>
+      <object type="PU" os_index="2" cpuset="0x00000004" complete_cpuset="0x00000004" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="6"/>
+      <object type="PU" os_index="3" cpuset="0x00000008" complete_cpuset="0x00000008" nodeset="0x00000002" complete_nodeset="0x00000002" gp_index="7"/>
+    </object>
+    <object type="Group" cpuset="0x00000030" complete_cpuset="0x00000030" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="13" kind="1001" subkind="0">
+      <object type="NUMANode" os_index="2" cpuset="0x00000030" complete_cpuset="0x00000030" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="12" local_memory="1073741824">
+        <page_type size="4096" count="262144"/>
+      </object>
+      <object type="PU" os_index="4" cpuset="0x00000010" complete_cpuset="0x00000010" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="10"/>
+      <object type="PU" os_index="5" cpuset="0x00000020" complete_cpuset="0x00000020" nodeset="0x00000004" complete_nodeset="0x00000004" gp_index="11"/>
+    </object>
+    <object type="Group" cpuset="0x000000c0" complete_cpuset="0x000000c0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="17" kind="1001" subkind="0">
+      <object type="NUMANode" os_index="3" cpuset="0x000000c0" complete_cpuset="0x000000c0" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="16" local_memory="1073741824">
+        <page_type size="4096" count="262144"/>
+      </object>
+      <object type="PU" os_index="6" cpuset="0x00000040" complete_cpuset="0x00000040" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="14"/>
+      <object type="PU" os_index="7" cpuset="0x00000080" complete_cpuset="0x00000080" nodeset="0x00000008" complete_nodeset="0x00000008" gp_index="15"/>
+    </object>
+  </object>
+  <support name="custom.exported_support"/>
+  <memattr name="Bandwidth" flags="5">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="8" value="20" initiator_cpuset="0x000000ff"/>
+  </memattr>
+  <memattr name="foobar" flags="6">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="4" value="2345" initiator_obj_gp_index="15" initiator_obj_type="PU"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="4" value="10" initiator_cpuset="0x00000003"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="8" value="20" initiator_cpuset="0x00000003"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="12" value="30" initiator_cpuset="0x00000003"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="12" value="123" initiator_cpuset="0x00000011"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="16" value="40" initiator_cpuset="0x00000003"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="16" value="2345" initiator_cpuset="0x00000011"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="16" value="23456" initiator_cpuset="0x00000012"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="16" value="23456" initiator_obj_gp_index="13" initiator_obj_type="Group"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="16" value="789" initiator_obj_gp_index="12" initiator_obj_type="NUMANode"/>
+  </memattr>
+  <memattr name="barnoinit" flags="1">
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="16" value="2345"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="4" value="10"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="8" value="2345"/>
+    <memattr_value target_obj_type="NUMANode" target_obj_gp_index="12" value="23456"/>
+    <memattr_value target_obj_type="PU" target_obj_gp_index="2" value="478945"/>
+    <memattr_value target_obj_type="Group" target_obj_gp_index="17" value="789"/>
+  </memattr>
+  <memattr name="coincoin" flags="5"/>
+</topology>

--- a/tests/hwloc/xml/Makefile.am
+++ b/tests/hwloc/xml/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2009-2019 Inria.  All rights reserved.
+# Copyright © 2009-2020 Inria.  All rights reserved.
 # Copyright © 2009-2010 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
@@ -9,6 +9,7 @@ AM_LDFLAGS = $(HWLOC_LDFLAGS)
 
 # Add your output files here.
 xml_outputs = \
+        8intel64-4n2t-memattrs.xml \
         16amd64-8n2c-cpusets.xml \
         16amd64-4distances.xml \
         16amd64-4distances.console.output \

--- a/utils/hwloc/hwloc-annotate.1in
+++ b/utils/hwloc/hwloc-annotate.1in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright © 2013-2018 Inria.  All rights reserved.
+.\" Copyright © 2013-2020 Inria.  All rights reserved.
 .\" See COPYING in top-level directory.
 .TH HWLOC-ANNOTATE "1" "%HWLOC_DATE%" "%PACKAGE_VERSION%" "%PACKAGE_NAME%"
 .SH NAME
@@ -81,6 +81,25 @@ value is \fIvalue\fR.
 .B misc <name>
 Specifies a new Misc object name.
 .TP
+.B memattr <name> <ﬂags>
+Register a new memory attribute whose name is \fIname\fR and
+flags is \fIflags\fR.
+\fIlocation\fR is ignored in this mode.
+
+Flags may be given as numeric values or as a comma-separated list of flag names
+that are passed to \fIhwloc_memattr_register()\fR.
+Those names may be substrings of actual flag names as long as a single one matches.
+For instance, a value of \fB1\fR (or \fBhigher\fR) means that
+highest values are considered best for this attribute.
+.TP
+.B memattr <name> <initiator> <value>
+Set the memory attribute (whose name is \fIname\fR)
+from initiator \fIinitiator\fR (either an object or a CPU-set)
+to target NUMA node \fIlocation\fR
+to value \fIvalue\fR.
+If this attribute does not require specific initiators,
+\fIinitiator\fR is ignored.
+.TP
 .B distances <filename> [<flags>]
 Specifies new distances to be added to the topology using specifications in \fI<filename>\fR.
 The optional \fIflags\fR (0 unless specified) corresponds to the flags
@@ -143,6 +162,17 @@ Change package objects to green with red text in the lstopo graphical output:
 
     $ hwloc-annotate topo.xml topo.xml package:all info lstopoStyle "Background=#00ff00;Text=#ff0000"
     $ lstopo -i topo.xml
+
+Set the memory attribute latency to 123 nanoseconds from the PUs in the first package to the first NUMA node:
+
+    $ hwloc-annotate topo.xml topo.xml numanode:0 memattr Latency $(hwloc-calc package:0) 123
+
+Register a memory attribute \fBMyApplicationPerformance\fR
+(with flags specifying that it requires an initiator and reports higher values first)
+and set its value for initiator CPU-set 0x11 to NUMA node #2 to 2345:
+
+    $ hwloc-annotate topo.xml topo.xml ignored memattr MyApplicationPerformance need_init,higher
+    $ hwloc-annotate topo.xml topo.xml numanode:2 memattr MyApplicationPerformance 0x11 2345
 .
 .\" **************************
 .\" Return value section

--- a/utils/hwloc/hwloc-bind.1in
+++ b/utils/hwloc/hwloc-bind.1in
@@ -50,8 +50,14 @@ The default is \fB0\fR (or \fBnone\fR).
 \fB\-\-disallowed\fR
 Include objects disallowed by administrative limitations.
 .TP
+\fB--best-memattr\fR <name>
+Select the best NUMA node among the given memory binding set by looking
+at the memory attribute given by \fI<name>\fR (or as an index).
+If the memory attribute values depend on the initiator, the CPU binding
+set is used as the initiator.
+.TP
 \fB--hbm\fR
-Only take high bandwidth memory nodes (such as Intel Xeon Phi MCDRAM)
+Only take high bandwidth memory nodes (Intel Xeon Phi MCDRAM)
 in account when looking for NUMA nodes in the input locations.
 
 This option must be combined with NUMA node locations,
@@ -59,7 +65,7 @@ such as \fI--hbm numa:1\fR for binding on the second HBM node.
 It may also be written as \fIhbm:1\fR.
 .TP
 \fB--no-hbm\fR
-Ignore high bandwidth memory nodes (such as Intel Xeon Phi MCDRAM)
+Ignore high bandwidth memory nodes (Intel Xeon Phi MCDRAM)
 when looking for NUMA nodes in the input locations.
 .
 .SH OPTIONS
@@ -242,7 +248,11 @@ To bind on the first PU of all cores of the first package:
     $ hwloc-bind package:0.core:all.pu:0 -- echo hello
     $ hwloc-bind --no-smt package:0 -- echo hello
 
-To bind memory on the first high-bandwidth memory node:
+To bind on the memory node local to a PU with largest capacity:
+
+    $ hwloc-bind --best-memattr capacity --cpubind pu:23 --membind pu:23 -- echo hello
+
+To bind memory on the first high-bandwidth memory node on Intel Xeon Phi:
 
     $ hwloc-bind --membind hbm:0 -- echo hello
     $ hwloc-bind --hbm --membind numa:0 -- echo hello

--- a/utils/hwloc/hwloc-calc.1in
+++ b/utils/hwloc/hwloc-calc.1in
@@ -147,6 +147,35 @@ exactly equivalent to the input. No largest object is included in the input
 This is different from \-\-intersect where reported objects may not be
 strictly included in the input.
 .TP
+\fB\-\-local\-memory\fR
+Report the list of NUMA nodes that are local to the input objects.
+
+This option is similar to \fB\-I numa\fR but the way nodes are selected
+is different:
+The selection performed by \fB\-\-local\-memory\fR may be precisely
+configured with \fB\-\-local\-memory\-flags\fR,
+while \fB\-I numa\fR just selects all nodes that are somehow local to
+any of the input objects.
+.TP
+\fB\-\-local\-memory\-flags\fR
+Change the flags used to select local NUMA nodes.
+Flags may be given as numeric values or as a comma-separated list of flag names
+that are passed to \fIhwloc_get_local_numanode_objs()\fR.
+Those names may be substrings of actual flag names as long as a single one matches.
+The default is \fB3\fR (or \fBsmaller,larger\fR)
+which means NUMA nodes are displayed
+if their locality either contains or is contained
+in the locality of the given object.
+
+This option enables \fB\-\-local\-memory\fR.
+.TP
+\fB\-\-best\-memattr\fR <name>
+Enable the listing of local memory nodes with \fB\-\-local\-memory\fR,
+but only display the local node that has the best value for the memory
+attribute given by \fI<name>\fR (or as an index).
+If the memory attribute values depend on the initiator, the hwloc-calc
+input objects are used as the initiator.
+.TP
 \fB\-\-sep <sep>\fR
 Change the field separator in the output.
 By default, a space is used to separate output objects
@@ -252,6 +281,18 @@ To display the list of NUMA nodes, by physical indexes, that intersect a given (
 
     $ hwloc-calc --physical --intersect NUMAnode 0xf0f0f0f0
     0,2
+
+To display the list of NUMA nodes, by physical indexes,
+whose locality is exactly equal to a Package:
+
+    $ hwloc-calc --local-memory-flags 0 pack:1
+    4,7
+
+To display the best-capacity NUMA node, by physical indexe,
+whose locality is exactly equal to a Package:
+
+    $ hwloc-calc --local-memory-flags 0 --best-memattr capacity pack:1
+    4
 
 Converting object logical indexes (default) from/to physical/OS indexes
 may be performed with \fB--intersect\fR combined with either \fB--physical-output\fR

--- a/utils/hwloc/hwloc-info.1in
+++ b/utils/hwloc/hwloc-info.1in
@@ -88,6 +88,28 @@ Display information about the object children.
 \fB\-\-descendants\fR <type>
 Display information about the object descendants that match the given type.
 .TP
+\fB\-\-local\-memory\fR
+Display information about the NUMA nodes that are local to the given object.
+.TP
+\fB\-\-local\-memory\-flags\fR
+Change the flags used to select local NUMA nodes.
+Flags may be given as numeric values or as a comma-separated list of flag names
+that are passed to \fIhwloc_get_local_numanode_objs()\fR.
+Those names may be substrings of actual flag names as long as a single one matches.
+The default is \fB3\fR (or \fBsmaller,larger\fR)
+which means NUMA nodes are displayed
+if their locality either contains or is contained
+in the locality of the given object.
+
+This option enables \fB\-\-local\-memory\fR.
+.TP
+\fB\-\-best\-memattr\fR <name>
+Enable the listing local memory nodes with \fB\-\-local\-memory\fR,
+but only display the local node that has the best value for the memory
+attribute given by \fI<name>\fR (or as an index).
+If the memory attribute values depend on the initiator, the object given
+to hwloc-info is used as the initiator.
+.TP
 \fB\-n\fR
 When outputting object information, prefix each line with the index
 of the considered object within the input.
@@ -224,6 +246,24 @@ To display information about the core whose physical index is 2:
      logical index = 1
      os index = 2
     ...
+
+To list the NUMA nodes that are local a PU:
+
+    $ hwloc-info --local-memory pu:25
+    NUMANode L#6 = local memory #0 of PU L#25
+     type = NUMANode
+    ...
+    NUMANode L#7 = local memory #1 of PU L#25
+     type = NUMANode
+    ...
+
+To show the best-bandwidth node among NUMA nodes local to a PU:
+
+    $ hwloc-info --local-memory --best-memattr bandwidth pu:25
+    NUMANode L#7 = local memory #1 of PU L#25
+     type = NUMANode
+    ...
+
 .
 .\" **************************
 .\"    See also section

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -28,6 +28,9 @@ static int show_ancestor_depth = HWLOC_TYPE_DEPTH_UNKNOWN;
 static int show_children = 0;
 static int show_descendants_depth = HWLOC_TYPE_DEPTH_UNKNOWN;
 static int show_index_prefix = 0;
+static int show_local_memory = 0;
+static int show_local_memory_flags = HWLOC_LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY | HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY;
+static hwloc_memattr_id_t best_memattr_id = (hwloc_memattr_id_t) -1;
 static unsigned current_obj;
 
 void usage(const char *name, FILE *where)
@@ -43,6 +46,9 @@ void usage(const char *name, FILE *where)
   fprintf (where, "  --ancestor <type>     Only display the ancestor of the given type\n");
   fprintf (where, "  --children            Display all children\n");
   fprintf (where, "  --descendants <type>  Only display descendants of the given type\n");
+  fprintf (where, "  --local-memory        Only display the local memory nodes\n");
+  fprintf (where, "  --local-memory-flags <x>   Change flags for selecting local memory nodes\n");
+  fprintf (where, "  --best-memattr <attr> Only display the best target among the local nodes\n");
   fprintf (where, "  -n                    Prefix each line with the index of the considered object\n");
   fprintf (where, "Object filtering options:\n");
   fprintf (where, "  --restrict [nodeset=]<bitmap>\n");
@@ -384,6 +390,59 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
 	i++;
       }
     }
+  } else if (show_local_memory) {
+    unsigned nrnodes;
+    hwloc_obj_t *nodes;
+    nrnodes = hwloc_bitmap_weight(hwloc_topology_get_topology_nodeset(topology));
+    nodes = malloc(nrnodes * sizeof(*nodes));
+    if (nodes) {
+      struct hwloc_location loc;
+      int err;
+      loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+      loc.location.object = obj;
+      err = hwloc_get_local_numanode_objs(topology, &loc, &nrnodes, nodes, show_local_memory_flags);
+      if (!err) {
+        unsigned i;
+        if (best_memattr_id != (hwloc_memattr_id_t) -1) {
+          /* only keep the best one for that memattr */
+          int best;
+
+          /* won't work if obj is CPU-less: perf from I/O is likely different from perf from CPU objects */
+          loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+          loc.location.cpuset = obj->cpuset;
+          best = hwloc_utils_get_best_node_in_array_by_memattr(topology, best_memattr_id,
+                                                               nrnodes, nodes, &loc);
+          if (best == -1) {
+            /* no perf info found, report nothing */
+            if (verbose > 0)
+              fprintf(stderr, "Failed to find a best local node for memory attribute.\n");
+            nrnodes = 0;
+          } else {
+            /* only report the best node, but keep the index intact */
+            for(i=0; i<nrnodes; i++)
+              if (i != (unsigned) best)
+                nodes[i] = NULL;
+          }
+        }
+        for(i=0; i<nrnodes; i++) {
+          char nodestr[128];
+          if (!nodes[i])
+            continue;
+          if (show_index_prefix)
+	    snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
+          hwloc_obj_type_snprintf(nodestr, sizeof(nodestr), nodes[i], 1);
+          if (verbose < 0)
+            printf("%s%s:%u\n", prefix, nodestr, nodes[i]->logical_index);
+          else
+            printf("%s%s L#%u = local memory #%u of %s L#%u\n",
+                   prefix, nodestr, nodes[i]->logical_index, i, objs, obj->logical_index);
+          hwloc_info_show_obj(topology, nodes[i], nodestr, prefix, verbose);
+        }
+      }
+    } else {
+      fprintf(stderr, "Failed to allocate array of local NUMA nodes\n");
+    }
+    free(nodes);
   } else {
     if (verbose < 0)
       printf("%s%s:%u\n", prefix, objs, obj->logical_index);
@@ -408,6 +467,7 @@ main (int argc, char *argv[])
   enum hwloc_utils_input_format input_format = HWLOC_UTILS_INPUT_DEFAULT;
   const char *show_ancestor_type = NULL;
   const char *show_descendants_type = NULL;
+  const char *best_memattr_str = NULL;
   char *restrictstring = NULL;
   size_t typelen;
   int opt;
@@ -475,6 +535,26 @@ main (int argc, char *argv[])
 	}
 	show_descendants_type = argv[1];
 	opt = 1;
+      }
+      else if (!strcmp (argv[0], "--local-memory"))
+        show_local_memory = 1;
+      else if (!strcmp (argv[0], "--local-memory-flags")) {
+	if (argc < 2) {
+	  usage (callname, stderr);
+	  exit(EXIT_FAILURE);
+	}
+        show_local_memory = 1;
+	show_local_memory_flags = hwloc_utils_parse_local_numanode_flags(argv[1]);
+	opt = 1;
+      }
+      else if (!strcmp (argv[0], "--best-memattr")) {
+	if (argc < 2) {
+	  usage (callname, stderr);
+	  exit(EXIT_FAILURE);
+	}
+        show_local_memory = 1;
+        best_memattr_str = argv[1];
+        opt = 1;
       }
       else if (!strcmp (argv[0], "--filter")) {
         hwloc_obj_type_t type;
@@ -672,6 +752,16 @@ main (int argc, char *argv[])
     }
     hwloc_bitmap_free(restrictset);
     free(restrictstring);
+  }
+
+  if (best_memattr_str) {
+    if (!show_local_memory)
+      fprintf(stderr, "--best-memattr is ignored without --local-memory.\n");
+    best_memattr_id = hwloc_utils_parse_memattr_name(topology, best_memattr_str);
+    if (best_memattr_id == (hwloc_memattr_id_t) -1) {
+      fprintf(stderr, "unrecognized memattr %s\n", best_memattr_str);
+      return EXIT_FAILURE;
+    }
   }
 
   if (mode == HWLOC_INFO_MODE_UNKNOWN) {

--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -677,4 +677,15 @@ hwloc_utils_parse_distances_add_flags(char * str) {
   return hwloc_utils_parse_flags(str, possible_flags, (int) sizeof(possible_flags) / sizeof(possible_flags[0]), "distances_add");
 }
 
+static __hwloc_inline unsigned long
+hwloc_utils_parse_memattr_flags(char *str) {
+  struct hwloc_utils_parsing_flag possible_flags[] = {
+    HWLOC_UTILS_PARSING_FLAG(HWLOC_MEMATTR_FLAG_HIGHER_FIRST),
+    HWLOC_UTILS_PARSING_FLAG(HWLOC_MEMATTR_FLAG_LOWER_FIRST),
+    HWLOC_UTILS_PARSING_FLAG(HWLOC_MEMATTR_FLAG_NEED_INITIATOR)
+  };
+
+  return hwloc_utils_parse_flags(str, possible_flags, (int) sizeof(possible_flags) / sizeof(possible_flags[0]), "memattr");
+}
+
 #endif /* HWLOC_UTILS_MISC_H */

--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -688,4 +688,15 @@ hwloc_utils_parse_memattr_flags(char *str) {
   return hwloc_utils_parse_flags(str, possible_flags, (int) sizeof(possible_flags) / sizeof(possible_flags[0]), "memattr");
 }
 
+static __hwloc_inline unsigned long
+hwloc_utils_parse_local_numanode_flags(char *str) {
+  struct hwloc_utils_parsing_flag possible_flags[] = {
+    HWLOC_UTILS_PARSING_FLAG(HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY),
+    HWLOC_UTILS_PARSING_FLAG(HWLOC_LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY),
+    HWLOC_UTILS_PARSING_FLAG(HWLOC_LOCAL_NUMANODE_FLAG_ALL)
+  };
+
+  return hwloc_utils_parse_flags(str, possible_flags, (int) sizeof(possible_flags) / sizeof(possible_flags[0]), "local_numanode");
+}
+
 #endif /* HWLOC_UTILS_MISC_H */

--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -702,6 +702,78 @@ hwloc_utils_get_best_node_in_array_by_memattr(hwloc_topology_t topology, hwloc_m
   return -1;
 }
 
+static __hwloc_inline int
+hwloc_utils_get_best_node_in_nodeset_by_memattr(hwloc_topology_t topology, hwloc_memattr_id_t id,
+                                                hwloc_nodeset_t nodeset,
+                                                struct hwloc_location *initiator)
+{
+  unsigned nbtgs, i, j;
+  hwloc_obj_t *tgs;
+  int best;
+  hwloc_uint64_t *values, bestvalue;
+  unsigned long mflags;
+  int err;
+
+  err = hwloc_memattr_get_flags(topology, id, &mflags);
+  if (err < 0)
+    goto out;
+
+  nbtgs = 0;
+  err = hwloc_memattr_get_targets(topology, id, initiator, 0, &nbtgs, NULL, NULL);
+  if (err < 0)
+    goto out;
+
+  tgs = malloc(nbtgs * sizeof(*tgs));
+  values = malloc(nbtgs * sizeof(*values));
+  if (!tgs || !values)
+    goto out_with_arrays;
+
+  err = hwloc_memattr_get_targets(topology, id, initiator, 0, &nbtgs, tgs, values);
+  if (err < 0)
+    goto out_with_arrays;
+
+  best = -1;
+  bestvalue = 0;
+  hwloc_bitmap_foreach_begin(i, nodeset) {
+    for(j=0; j<nbtgs; j++)
+      if (tgs[j]->os_index == i)
+        break;
+    if (j==nbtgs)
+      /* no target info for this node */
+      continue;
+    if (best == -1) {
+      best = i;
+      bestvalue = values[j];
+    } else if (mflags & HWLOC_MEMATTR_FLAG_HIGHER_FIRST) {
+      if (values[j] > bestvalue) {
+        best = i;
+        bestvalue = values[j];
+      }
+    } else {
+      assert(mflags & HWLOC_MEMATTR_FLAG_LOWER_FIRST);
+      if (values[j] < bestvalue) {
+        best = i;
+        bestvalue = values[j];
+      }
+    }
+  } hwloc_bitmap_foreach_end();
+
+  if (best == -1)
+    hwloc_bitmap_zero(nodeset);
+  else
+    hwloc_bitmap_only(nodeset, best);
+
+  free(tgs);
+  free(values);
+  return 0;
+
+ out_with_arrays:
+  free(tgs);
+  free(values);
+ out:
+  return -1;
+}
+
 static __hwloc_inline unsigned long
 hwloc_utils_parse_restrict_flags(char * str){
   struct hwloc_utils_parsing_flag possible_flags[] = {

--- a/utils/hwloc/test-hwloc-annotate.output
+++ b/utils/hwloc/test-hwloc-annotate.output
@@ -158,4 +158,10 @@
     <u64values length="27">10 80 80 80 10 80 80 80 10 </u64values>
   </distances2>
   <support name="custom.exported_support"/>
+  <memattr name="dummymemattr" flags="1">
+    <memattr_value target_obj_type="PU" target_obj_gp_index="9" value="1234"/>
+  </memattr>
+  <memattr name="dummymemattr2" flags="6">
+    <memattr_value target_obj_type="PU" target_obj_gp_index="15" value="123" initiator_cpuset="0x0000000f"/>
+  </memattr>
 </topology>

--- a/utils/hwloc/test-hwloc-annotate.sh.in
+++ b/utils/hwloc/test-hwloc-annotate.sh.in
@@ -58,6 +58,10 @@ $annotate $file $file 'pci[8086:0046]:all' info mypcidev bymatch
 $annotate $file $file bridge:all info mybridges all
 $annotate --cu $file $file L1iCache:0 none
 $annotate --cd $file $file dummy none
+$annotate $file $file -- dummy -- memattr dummymemattr higher
+$annotate $file $file -- pu:0 -- memattr dummymemattr dummy 1234
+$annotate $file $file -- dummy -- memattr dummymemattr2 lower,need_init
+$annotate $file $file -- pu:2 -- memattr dummymemattr2 0xf 123
 cat > $distances << EOF
 5
 3

--- a/utils/hwloc/test-hwloc-calc.output
+++ b/utils/hwloc/test-hwloc-calc.output
@@ -124,6 +124,18 @@ PU:22_PU:23_Core:6_Core:7_Group0:2
 # Converting physical to logical PU indexes when complexly ordered in the topology
 4,20,32,48
 
+# 4 local nodes near a Package (node:3-4@Die + node:5@Package + node:6@Machine)
+3,4,5,6
+
+# 2 local nodes larger or equal to a Package (node:2@Package + node:6@Machine), with space separator
+2 6
+
+# Best-locality local node near a PU (node:1@Die)
+1
+
+# Best-capacity local node near a PU (node:6@Machine)
+6
+
 # Caches with attributes
 0x0000000b
 

--- a/utils/hwloc/test-hwloc-calc.sh.in
+++ b/utils/hwloc/test-hwloc-calc.sh.in
@@ -174,6 +174,19 @@ set -e
   $calc --if synthetic --input "node:4 core:4 pu:4(indexes=node:core)" --pi pu:2-5 -I pu
   echo
 
+  echo "# 4 local nodes near a Package (node:3-4@Die + node:5@Package + node:6@Machine)"
+  $calc --if synthetic --input "[numa] pack:2 [numa] die:2 [numa] pu:2" --local-memory package:1
+  echo
+  echo "# 2 local nodes larger or equal to a Package (node:2@Package + node:6@Machine), with space separator"
+  $calc --if synthetic --input "[numa] pack:2 [numa] die:2 [numa] pu:2" --local-memory-flags 1 --sep " " pack:0
+  echo
+  echo "# Best-locality local node near a PU (node:1@Die)"
+  $calc --if synthetic --input "[numa] pack:2 [numa] die:2 [numa] pu:2" --best-memattr locality pu:3
+  echo
+  echo "# Best-capacity local node near a PU (node:6@Machine)"
+  $calc --if synthetic --input "[numa(memory=1000000)] pack:2 [numa(memory=100000)] die:2 [numa(memory=1000)] pu:2" --best-memattr capacity pu:4
+  echo
+
   echo "# Caches with attributes"
   $calc --if synthetic --input "numa:2 l3:2 pu:1" numa:0 l3u:3
   echo

--- a/utils/hwloc/test-hwloc-info.output
+++ b/utils/hwloc/test-hwloc-info.output
@@ -374,3 +374,87 @@ L1dCache:9
 L1dCache:10
 L1dCache:11
 
+# 2 local memory for one PU
+NUMANode L#1 = local memory #0 of PU L#8
+ type = NUMANode
+ full type = NUMANode
+ logical index = 1
+ os index = 1
+ gp index = 29
+ depth = -3
+ sibling rank = 0
+ children = 0
+ memory children = 0
+ i/o children = 0
+ misc children = 0
+ local memory = 0
+ cpuset = 0x0000ff00
+ complete cpuset = 0x0000ff00
+ allowed cpuset = 0x0000ff00
+ nodeset = 0x00000002
+ complete nodeset = 0x00000002
+ allowed nodeset = 0x00000002
+ symmetric subtree = 0
+ memory attribute Capacity = 0
+ memory attribute Locality = 8
+NUMANode L#2 = local memory #1 of PU L#8
+ type = NUMANode
+ full type = NUMANode
+ logical index = 2
+ os index = 2
+ gp index = 31
+ depth = -3
+ sibling rank = 0
+ children = 0
+ memory children = 0
+ i/o children = 0
+ misc children = 0
+ local memory = 0
+ cpuset = 0x0000ffff
+ complete cpuset = 0x0000ffff
+ allowed cpuset = 0x0000ffff
+ nodeset = 0x00000004
+ complete nodeset = 0x00000004
+ allowed nodeset = 0x00000004
+ symmetric subtree = 0
+ memory attribute Capacity = 0
+ memory attribute Locality = 16
+
+# 2 local-or-larger memories for one PU, silent
+NUMANode:1
+NUMANode:2
+
+# no local-or-larger memory for root, silent
+
+# no local-or-smaller memory for one PU, silent
+
+# 3 local-or-smaller memories for on Package, silent
+NUMANode:3
+NUMANode:4
+NUMANode:5
+
+# no strict-local memory for one PU, silent
+
+# 1 strict-local memory for one NUMANode, silent
+NUMANode:1
+
+# 12 local-all memories for one PU, silent
+NUMANode:0
+NUMANode:1
+NUMANode:2
+NUMANode:3
+NUMANode:4
+NUMANode:5
+NUMANode:6
+NUMANode:7
+NUMANode:8
+NUMANode:9
+NUMANode:10
+NUMANode:11
+
+# only the smallest locality among 2 local-or-larger memories for one PU, silent
+NUMANode:10
+
+# only the highest capacity among 2 local-or-larger memories for one PU, silent
+NUMANode:11
+

--- a/utils/hwloc/test-hwloc-info.sh.in
+++ b/utils/hwloc/test-hwloc-info.sh.in
@@ -74,6 +74,38 @@ set -e
   echo "# L1d descendants of Core range, silent"
   $info --if synthetic --input "node:2 core:2 l2:2 l1d:2 pu:2" --descendants l1d -s core:1-2
   echo
+
+  echo "# 2 local memory for one PU"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] core:4 pu:2" --local-memory pu:8
+  echo
+  echo "# 2 local-or-larger memories for one PU, silent"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] core:4 pu:2" --local-memory-flags larger -s pu:8
+  echo
+  echo "# no local-or-larger memory for root, silent"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] core:4 pu:2" --local-memory-flags larger -s root
+  echo
+  echo "# no local-or-smaller memory for one PU, silent"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] core:4 pu:2" --local-memory-flags smaller -s pu:8
+  echo
+  echo "# 3 local-or-smaller memories for on Package, silent"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] core:4 pu:2" --local-memory-flags smaller -s pack:1
+  echo
+  echo "# no strict-local memory for one PU, silent"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] core:4 pu:2" --local-memory-flags none -s pu:8
+  echo
+  echo "# 1 strict-local memory for one NUMANode, silent"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] core:4 pu:2" --local-memory-flags none -s node:1
+  echo
+  echo "# 12 local-all memories for one PU, silent"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] core:4 pu:2" --local-memory-flags all\$ -s pu:3
+  echo
+  echo "# only the smallest locality among 2 local-or-larger memories for one PU, silent"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] core:4 pu:2" --local-memory-flags larger --best-memattr locality -s pu:63
+  echo
+  echo "# only the highest capacity among 2 local-or-larger memories for one PU, silent"
+  $info --if synthetic --input "pack:4 [numa(memory=1000000)] l3:2 [numa(memory=1000)] core:4 pu:2" --local-memory-flags larger --best-memattr capacity -s pu:63
+  echo
+
 ) > "$file"
 @DIFF@ @HWLOC_DIFF_U@ @HWLOC_DIFF_W@ $srcdir/test-hwloc-info.output "$file"
 rm -rf "$tmp"

--- a/utils/lstopo/lstopo-no-graphics.1in
+++ b/utils/lstopo/lstopo-no-graphics.1in
@@ -90,6 +90,11 @@ Reduce the amount of details to show.
 \fB\-\-distances\fR
 Only display distance matrices.
 .TP
+\fB\-\-memattrs\fR
+Only display memory attributes.
+All of them are displayed (while the default textual output selects
+memory attribute details depending on the verbosity level).
+.TP
 \fB\-f\fR \fB\-\-force\fR
 If the destination file already exists, overwrite it.
 .TP

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -372,6 +372,7 @@ void usage(const char *name, FILE *where)
   fprintf (where, "  -v --verbose          Include additional details\n");
   fprintf (where, "  -s --silent           Reduce the amount of details to show\n");
   fprintf (where, "  --distances           Only show distance matrices\n");
+  fprintf (where, "  --memattrs            Only show memory attributes\n");
   fprintf (where, "  -c --cpuset           Show the cpuset of each object\n");
   fprintf (where, "  -C --cpuset-only      Only show the cpuset of each object\n");
   fprintf (where, "  --taskset             Show taskset-specific cpuset strings\n");
@@ -698,6 +699,7 @@ main (int argc, char *argv[])
   snprintf(loutput.title, sizeof(loutput.title), "lstopo");
 
   loutput.show_distances_only = 0;
+  loutput.show_memattrs_only = 0;
   loutput.show_only = HWLOC_OBJ_TYPE_NONE;
   loutput.show_cpuset = 0;
   loutput.show_taskset = 0;
@@ -759,6 +761,8 @@ main (int argc, char *argv[])
 	loutput.verbose_mode--;
       } else if (!strcmp (argv[0], "--distances")) {
 	loutput.show_distances_only = 1;
+      } else if (!strcmp (argv[0], "--memattrs")) {
+        loutput.show_memattrs_only = 1;
       } else if (!strcmp (argv[0], "-h") || !strcmp (argv[0], "--help")) {
 	usage(callname, stdout);
         exit(EXIT_SUCCESS);
@@ -1243,6 +1247,7 @@ main (int argc, char *argv[])
     if (loutput.show_cpuset
         || loutput.show_only != HWLOC_OBJ_TYPE_NONE
 	|| loutput.show_distances_only
+        || loutput.show_memattrs_only
         || loutput.verbose_mode != LSTOPO_VERBOSE_MODE_DEFAULT)
       output_format = LSTOPO_OUTPUT_CONSOLE;
   }

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -80,6 +80,7 @@ struct lstopo_output {
 
   /* text config */
   int show_distances_only;
+  int show_memattrs_only;
   hwloc_obj_type_t show_only;
   int show_cpuset;
   int show_taskset;

--- a/utils/lstopo/test-lstopo.output
+++ b/utils/lstopo/test-lstopo.output
@@ -60,6 +60,14 @@ depth 0:           1 Machine (type #0)
    depth 3:        4 L2Cache (type #5)
     depth 4:       8 PU (type #3)
 Special depth -3:  2 NUMANode (type #13)
+Memory attribute #0 name `Capacity' flags 1
+  NUMANode L#0 = 1073741824
+  NUMANode L#1 = 1073741824
+Memory attribute #1 name `Locality' flags 2
+  NUMANode L#0 = 4
+  NUMANode L#1 = 4
+Memory attribute #2 name `Bandwidth' flags 5
+Memory attribute #3 name `Latency' flags 6
 Topology not from this system
 ** Export to synthetic...
 Package:1 Core:2 [NUMANode(memory=1073741824)] L2Cache:2(size=4194304) PU:2

--- a/utils/lstopo/test-lstopo.sh.in
+++ b/utils/lstopo/test-lstopo.sh.in
@@ -109,7 +109,7 @@ echo "**** Import from synthetic so that we can check some exact outputs in $fil
   echo "** OS-index output merged..."
   $ls -i "$SI" - -p --merge
   echo "** Logical-index verbose output..."
-  $ls -i "$SI" - -l --verbose
+  $ls -i "$SI" - -l --verbose --verbose
   echo "** Export to synthetic..."
   $ls -i "$SI" -.synthetic
   echo "** Export to XML after changing disallowed..."


### PR DESCRIPTION
* API
  + Add hwloc/memattrs.h for exposing latency/bandwidth information between
    initiators (CPU sets for now) and target NUMA nodes.
    - When available, bandwidths and latencies are read from the ACPI HMAT
      table exposed by Linux kernel 5.2+.
    - Attributes may also be customized to expose user-defined performance
      information.
  + Add hwloc_get_local_numanode_objs() for listing NUMA nodes that are
    local to some locality.
* Tools
  + hwloc-info and hwloc-calc have new --local-memory --local-memory-flags
    and --best-memattr options for reporting local memory nodes and filtering
    by memory attributes.
  + hwloc-bind has a new --best-memattr option for filtering by memory attributes
    among the memory binding set.
