### PR TITLE
XGMIBandwidth matrix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,8 +38,10 @@ Version 2.5.0
     Thanks to Anara Kozhokanova, Tim Cramer and Erich Focht for the help.
   + Add a NVLinkBandwidth distances structure between NVIDIA GPUs
     (and POWER processor or NVSwitches) in the NVML backend.
-    See Topology Attributes: Distances, Memory Attributes and CPU Kinds
-    in the documentation.
+  + Add a XGMIBandwidth distances structure between AMD GPUs
+    in the RSMI backends.
+  + See Topology Attributes: Distances, Memory Attributes and CPU Kinds
+    in the documentation for details about these new distances.
 * Build
   + Add --with-cuda-version=<version> or look at the CUDA_VERSION
     environment variable to find the appropriate CUDA pkg-config files.

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -2091,6 +2091,12 @@ Distances structures currently created by hwloc are:
 <dt>NUMALatency (Linux, Solaris, FreeBSD)</dt>
 <dd>This is the matrix of theoretical latencies described above.
 </dd>
+<dt>XGMIBandwidth (RSMI)</dt>
+<dd>This is matrix of unidirectional XGMI bandwidths between AMD GPUs (in MB/s).
+It contains 0 when there is no direct XGMI link between objects.
+Values on the diagonal are artificially set to very high so
+that local access always appears faster than remote access.
+</dt>
 <dt>NVLinkBandwidth (NVML)</dt>
 <dd>This is the matrix of unidirectional NVLink bandwidths between
 NVIDIA GPUs (in MB/s).

--- a/include/hwloc/distances.h
+++ b/include/hwloc/distances.h
@@ -35,7 +35,7 @@ extern "C" {
  * from a core in another node.
  * The corresponding kind is ::HWLOC_DISTANCES_KIND_FROM_OS | ::HWLOC_DISTANCES_KIND_FROM_USER.
  * The name of this distances structure is "NUMALatency".
- * Others distance structures include "NVLinkBandwidth".
+ * Others distance structures include and "XGMIBandwidth" and "NVLinkBandwidth".
  *
  * The matrix may also contain bandwidths between random sets of objects,
  * possibly provided by the user, as specified in the \p kind attribute.
@@ -157,7 +157,7 @@ hwloc_distances_get_by_type(hwloc_topology_t topology, hwloc_obj_type_t type,
  * Usually only one distances structure may match a given name.
  *
  * The name of the most common structure is "NUMALatency".
- * Others include "NVLinkBandwidth".
+ * Others include "XGMIBandwidth" and "NVLinkBandwidth".
  */
 HWLOC_DECLSPEC int
 hwloc_distances_get_by_name(hwloc_topology_t topology, const char *name,


### PR DESCRIPTION
@miketxli Here's a totally untested draft of XGMI distance matrix. I just put 100 in the matrix when your code found a XGMI peer (you said InfinityFabric links are 100GB/s, right). The code isn't ready to merge (I'd need to export the distances_add() function to plugins, right now it will only work when the RSMI backend is not a separate plugin), but I'd like you to test/fix/discuss the code in the meantime. I am working on NVLink and oneAPI support at the same time.

If you run lstopo -v, you should get a distance matrix between OSDev at the bottom of the output. The numbers on the first row and first column are the OS Devices logical indexes (those you see as L#1 in lstopo --only osdev -v | grep rsmi).

The diagonal would keep 0 which is a normal because because there's no XGMI link to myself, but also a bit strange since the bandwidth to myself is likely higher than the XGMI link bandwidth. I don't see what else to put in there. UINT64_MAX would case horribly large ugly values to be displayed in lstopo.

Instead of 100 or 100000 for bandwidth in GB/s or MB/s, we could also just put 1 in the matrix when there's a link. If XGMI ever support multiple links between a pair of GPUs (looks like NVLink already does), we'd still be able to put 2 instead of 1. The question is whether we could have something more complicated with different kinds of links at some point. That's why I used 100 for a 100GB/s single link here, seemed more flexible than 0 or 1.