### PR TITLE
Fixed a memory leak when destroying hwloc_linux_cpufreqs objects.

### DIFF
--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -4149,6 +4149,8 @@ hwloc_linux_cpufreqs_destroy(struct hwloc_linux_cpufreqs *cpufreqs)
   for(i=0; i<cpufreqs->nr_sets; i++)
     hwloc_bitmap_free(cpufreqs->sets[i].cpuset);
   cpufreqs->nr_sets = 0;
+  cpufreqs->nr_sets_allocated = 0;
+  free (cpufreqs->sets);
 }
 
 


### PR DESCRIPTION
Running hwloc-ls with valgrind shows two memory leak when bailling out.

```
  ==21928== 64 bytes in 1 blocks are definitely lost in loss record 1 of 2
  ==21928==    at 0x4835753: malloc (vg_replace_malloc.c:309)
  ==21928==    by 0x4895E45: hwloc_linux_cpufreqs_init (topology-linux.c:4078)
  ==21928==    by 0x4895E45: look_sysfscpu (topology-linux.c:4236)
  ==21928==    by 0x4899584: hwloc_linuxfs_look_cpu (topology-linux.c:5309)
  ==21928==    by 0x4899584: hwloc_look_linuxfs (topology-linux.c:6538)
  ==21928==    by 0x4865DED: hwloc_discover_by_phase.isra.0 (topology.c:3229)
  ==21928==    by 0x486DE06: hwloc_discover (topology.c:3309)
  ==21928==    by 0x486DE06: hwloc_topology_load (topology.c:3958)
  ==21928==    by 0x40510A: main (lstopo.c:1484)
  ==21928== 
  ==21928== 64 bytes in 1 blocks are definitely lost in loss record 2 of 2
  ==21928==    at 0x4835753: malloc (vg_replace_malloc.c:309)
  ==21928==    by 0x4895E5F: hwloc_linux_cpufreqs_init (topology-linux.c:4078)
  ==21928==    by 0x4895E5F: look_sysfscpu (topology-linux.c:4237)
  ==21928==    by 0x4899584: hwloc_linuxfs_look_cpu (topology-linux.c:5309)
  ==21928==    by 0x4899584: hwloc_look_linuxfs (topology-linux.c:6538)
  ==21928==    by 0x4865DED: hwloc_discover_by_phase.isra.0 (topology.c:3229)
  ==21928==    by 0x486DE06: hwloc_discover (topology.c:3309)
  ==21928==    by 0x486DE06: hwloc_topology_load (topology.c:3958)
  ==21928==    by 0x40510A: main (lstopo.c:1484)
```
the hwloc_linux_cpufreqs_init () does allocate cpufreqs->sets, but hwloc_linux_cpufreqs_destroy () does not call free () on this member, which leads to a memory leak. By security, this patch also set the nr_sets_allocated member to zero.