### PR TITLE
configure: add --with-cuda=<dir>

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
 Copyright © 2009 CNRS
-Copyright © 2009-2020 Inria.  All rights reserved.
+Copyright © 2009-2021 Inria.  All rights reserved.
 Copyright © 2009-2013 Université Bordeaux
 Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
 Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
@@ -15,6 +15,14 @@ $HEADER$
 This file contains the main features as well as overviews of specific
 bug fixes (and other actions) for each version of hwloc since version
 0.9.
+
+
+Version 2.5.0
+-------------
+* Build
+  + Add --with-cuda=<dir> to specify the CUDA installation path
+    (and its NVML and OpenCL components) without environment variables.
+    Thanks to Andrea Bocci for the suggestion.
 
 
 Version 2.4.0

--- a/config/hwloc_internal.m4
+++ b/config/hwloc_internal.m4
@@ -1,6 +1,6 @@
 dnl -*- Autoconf -*-
 dnl
-dnl Copyright © 2010-2020 Inria.  All rights reserved.
+dnl Copyright © 2010-2021 Inria.  All rights reserved.
 dnl Copyright © 2009, 2011 Université Bordeaux
 dnl Copyright © 2004-2005 The Trustees of Indiana University and Indiana
 dnl                         University Research and Technology
@@ -92,6 +92,11 @@ AC_DEFUN([HWLOC_DEFINE_ARGS],[
     AC_ARG_ENABLE([nvml],
                   AS_HELP_STRING([--disable-nvml],
                                  [Disable the NVML device discovery build (instead of only disabling NVML at runtime by default)]))
+
+    # CUDA install path (and NVML and OpenCL)
+    AC_ARG_WITH([cuda],
+                AS_HELP_STRING([--with-cuda=<dir>],
+                               [Specify the CUDA installation directory, used for NVIDIA NVML and OpenCL too]))
 
     # RSMI?
     AC_ARG_ENABLE([rsmi],

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2020 Inria.  All rights reserved.
+ * Copyright © 2009-2021 Inria.  All rights reserved.
  * Copyright © 2009-2013 Université Bordeaux
  * Copyright © 2009-2020 Cisco Systems, Inc.  All rights reserved.
  * Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
@@ -134,6 +134,7 @@ The hwloc core may also benefit from the following development packages:
 <li>AMD or NVIDIA OpenCL implementations for OpenCL device discovery.
 </li>
 <li>the NVIDIA CUDA Toolkit for CUDA device discovery.
+  It's installation path may be specified at configure time with <tt>--with-cuda=/path/to/cuda</tt>.
 </li>
 <li>the NVIDIA Management Library (NVML) for NVML device discovery.
   It is included in CUDA since version 8.0.

--- a/hwloc/Makefile.am
+++ b/hwloc/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2009-2020 Inria.  All rights reserved.
+# Copyright © 2009-2021 Inria.  All rights reserved.
 # Copyright © 2009-2012 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright © 2011-2012 Oracle and/or its affiliates.  All rights reserved.
@@ -77,7 +77,7 @@ sources += topology-opencl.c
 else
 plugins_LTLIBRARIES += hwloc_opencl.la
 hwloc_opencl_la_SOURCES = topology-opencl.c
-hwloc_opencl_la_CFLAGS = $(AM_CFLAGS) $(HWLOC_OPENCL_CFLAGS) -DHWLOC_INSIDE_PLUGIN
+hwloc_opencl_la_CFLAGS = $(AM_CFLAGS) $(HWLOC_OPENCL_CPPFLAGS) -DHWLOC_INSIDE_PLUGIN
 hwloc_opencl_la_LDFLAGS = $(plugins_ldflags) $(HWLOC_OPENCL_LIBS) $(HWLOC_OPENCL_LDFLAGS)
 endif
 endif HWLOC_HAVE_OPENCL
@@ -88,8 +88,8 @@ sources += topology-cuda.c
 else
 plugins_LTLIBRARIES += hwloc_cuda.la
 hwloc_cuda_la_SOURCES = topology-cuda.c
-hwloc_cuda_la_CFLAGS = $(AM_CFLAGS) $(HWLOC_CUDA_CFLAGS) -DHWLOC_INSIDE_PLUGIN
-hwloc_cuda_la_LDFLAGS = $(plugins_ldflags) $(HWLOC_CUDA_LIBS)
+hwloc_cuda_la_CFLAGS = $(AM_CFLAGS) $(HWLOC_CUDA_CPPFLAGS) -DHWLOC_INSIDE_PLUGIN
+hwloc_cuda_la_LDFLAGS = $(plugins_ldflags) $(HWLOC_CUDA_LIBS) $(HWLOC_CUDA_LDFLAGS)
 endif
 endif HWLOC_HAVE_CUDART
 
@@ -99,8 +99,8 @@ sources += topology-nvml.c
 else
 plugins_LTLIBRARIES += hwloc_nvml.la
 hwloc_nvml_la_SOURCES = topology-nvml.c
-hwloc_nvml_la_CFLAGS = $(AM_CFLAGS) $(HWLOC_NVML_CFLAGS) -DHWLOC_INSIDE_PLUGIN
-hwloc_nvml_la_LDFLAGS = $(plugins_ldflags) $(HWLOC_NVML_LIBS)
+hwloc_nvml_la_CFLAGS = $(AM_CFLAGS) $(HWLOC_NVML_CPPFLAGS) -DHWLOC_INSIDE_PLUGIN
+hwloc_nvml_la_LDFLAGS = $(plugins_ldflags) $(HWLOC_NVML_LIBS) $(HWLOC_NVML_LDFLAGS)
 endif
 endif HWLOC_HAVE_NVML
 


### PR DESCRIPTION
Specifies where CUDA is installed to avoid having to pass
C_INCLUDE_PATH and LIBRARY_PATH at build time.
LD_LIBRARY_PATH is still required at runtime.

The CUDA directory is also used for looking for OpenCL and NVML
subcomponents.

Thanks to Andrea Bocci for the suggestion.

Refs #392.

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>