### PR TITLE
Fix xl compiler check

### DIFF
--- a/config/hwloc_check_vendor.m4
+++ b/config/hwloc_check_vendor.m4
@@ -158,7 +158,7 @@ AC_DEFUN([_HWLOC_CHECK_COMPILER_VENDOR], [
 
     # IBM XL C/C++
     AS_IF([test "$hwloc_check_compiler_vendor_result" = "unknown"],
-          [HWLOC_IF_IFELSE([defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__)],
+          [HWLOC_IF_IFELSE([defined(__xlC__) || defined(__IBMC__) || defined(__IBMCPP__) || defined(__ibmxl__)],
                [hwloc_check_compiler_vendor_result="ibm"],
                [HWLOC_IF_IFELSE([defined(_AIX) && !defined(__GNUC__)],
                     [hwloc_check_compiler_vendor_result="ibm"])])])

--- a/config/hwloc_check_vendor.m4
+++ b/config/hwloc_check_vendor.m4
@@ -106,11 +106,6 @@ AC_DEFUN([_HWLOC_CHECK_COMPILER_VENDOR], [
           [HWLOC_IFDEF_IFELSE([__PGI],
                [hwloc_check_compiler_vendor_result="portland group"])])
 
-    # GNU
-    AS_IF([test "$hwloc_check_compiler_vendor_result" = "unknown"],
-          [HWLOC_IFDEF_IFELSE([__GNUC__],
-               [hwloc_check_compiler_vendor_result="gnu"])])
-
     # Borland Turbo C
     AS_IF([test "$hwloc_check_compiler_vendor_result" = "unknown"],
           [HWLOC_IFDEF_IFELSE([__TURBOC__],
@@ -241,6 +236,11 @@ AC_DEFUN([_HWLOC_CHECK_COMPILER_VENDOR], [
     AS_IF([test "$hwloc_check_compiler_vendor_result" = "unknown"],
           [HWLOC_IFDEF_IFELSE([__WATCOMC__],
                [hwloc_check_compiler_vendor_result="watcom"])])
+
+    # GNU
+    AS_IF([test "$hwloc_check_compiler_vendor_result" = "unknown"],
+          [HWLOC_IFDEF_IFELSE([__GNUC__],
+               [hwloc_check_compiler_vendor_result="gnu"])])
 
     $1="$hwloc_check_compiler_vendor_result"
     unset hwloc_check_compiler_vendor_result


### PR DESCRIPTION
- By default newer xlc compilers only define __ibmxl__ now.

https://www.ibm.com/support/knowledgecenter/en/SSXVZZ_13.1.6/com.ibm.xlcpp1316.lelinux.doc/compiler_ref/xlmacros.html

- Most compilers define the __GNU__ macro, so put it at the bottom
as a catch-all.

Tested with gcc, xlc, pgi and clang.