### PR TITLE
hwloc/windows.h for querying Windows processor groups

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,8 @@ Version 2.5.0
 -------------
 * API
   + Add hwloc/windows.h to query Windows processor groups.
+* Tools
+  + lstopo now has a --windows-processor-groups option on Windows.
 * Build
   + Add --with-cuda=<dir> to specify the CUDA installation path
     (and its NVML and OpenCL components) without environment variables.

--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,8 @@ bug fixes (and other actions) for each version of hwloc since version
 
 Version 2.5.0
 -------------
+* API
+  + Add hwloc/windows.h to query Windows processor groups.
 * Build
   + Add --with-cuda=<dir> to specify the CUDA installation path
     (and its NVML and OpenCL components) without environment variables.

--- a/contrib/windows/libhwloc.vcxproj
+++ b/contrib/windows/libhwloc.vcxproj
@@ -242,6 +242,7 @@
     <ClInclude Include="..\..\include\hwloc\inlines.h" />
     <ClInclude Include="..\..\include\hwloc\memattrs.h" />
     <ClInclude Include="..\..\include\hwloc\cpukinds.h" />
+    <ClInclude Include="..\..\include\hwloc\windows.h" />
     <ClInclude Include="..\..\include\hwloc\plugins.h" />
     <ClInclude Include="..\..\include\hwloc\shmem.h" />
     <ClInclude Include="..\..\include\hwloc\rename.h" />

--- a/contrib/windows/libhwloc.vcxproj.filters
+++ b/contrib/windows/libhwloc.vcxproj.filters
@@ -110,6 +110,9 @@
     <ClInclude Include="..\..\include\hwloc\cpukinds.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\hwloc\windows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\hwloc\plugins.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/contrib/windows/lstopo-no-graphics.vcxproj
+++ b/contrib/windows/lstopo-no-graphics.vcxproj
@@ -89,6 +89,7 @@
     <ClInclude Include="..\..\include\hwloc\bitmap.h" />
     <ClInclude Include="..\..\include\hwloc\helper.h" />
     <ClInclude Include="..\..\include\hwloc\openfabrics-verbs.h" />
+    <ClInclude Include="..\..\include\hwloc\windows.h" />
     <ClInclude Include="..\..\include\hwloc\plugins.h" />
     <ClInclude Include="..\..\include\hwloc\rename.h" />
     <ClInclude Include="..\..\include\private\components.h" />

--- a/contrib/windows/lstopo-no-graphics.vcxproj.filters
+++ b/contrib/windows/lstopo-no-graphics.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClInclude Include="..\..\include\hwloc\openfabrics-verbs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\hwloc\windows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\hwloc\plugins.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/contrib/windows/lstopo-win.vcxproj
+++ b/contrib/windows/lstopo-win.vcxproj
@@ -91,6 +91,7 @@
     <ClInclude Include="..\..\include\hwloc\bitmap.h" />
     <ClInclude Include="..\..\include\hwloc\helper.h" />
     <ClInclude Include="..\..\include\hwloc\openfabrics-verbs.h" />
+    <ClInclude Include="..\..\include\hwloc\windows.h" />
     <ClInclude Include="..\..\include\hwloc\plugins.h" />
     <ClInclude Include="..\..\include\hwloc\rename.h" />
     <ClInclude Include="..\..\include\private\components.h" />

--- a/contrib/windows/lstopo-win.vcxproj.filters
+++ b/contrib/windows/lstopo-win.vcxproj.filters
@@ -59,6 +59,9 @@
     <ClInclude Include="..\..\include\hwloc\openfabrics-verbs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\hwloc\windows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\hwloc\plugins.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/contrib/windows/lstopo.vcxproj
+++ b/contrib/windows/lstopo.vcxproj
@@ -90,6 +90,7 @@
     <ClInclude Include="..\..\include\hwloc\bitmap.h" />
     <ClInclude Include="..\..\include\hwloc\helper.h" />
     <ClInclude Include="..\..\include\hwloc\openfabrics-verbs.h" />
+    <ClInclude Include="..\..\include\hwloc\windows.h" />
     <ClInclude Include="..\..\include\hwloc\plugins.h" />
     <ClInclude Include="..\..\include\hwloc\rename.h" />
     <ClInclude Include="..\..\include\private\components.h" />

--- a/contrib/windows/lstopo.vcxproj.filters
+++ b/contrib/windows/lstopo.vcxproj.filters
@@ -59,6 +59,9 @@
     <ClInclude Include="..\..\include\hwloc\openfabrics-verbs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\hwloc\windows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\hwloc\plugins.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2009-2020 Inria.  All rights reserved.
+# Copyright © 2009-2021 Inria.  All rights reserved.
 # Copyright © 2009-2013, 2021 Université Bordeaux
 # Copyright © 2009-2016 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
@@ -83,6 +83,7 @@ dox_inputs = $(DOX_CONFIG) \
        $(hwloc_include_dir)/hwloc/nvml.h \
        $(hwloc_include_dir)/hwloc/rsmi.h \
        $(hwloc_include_dir)/hwloc/gl.h \
+       $(hwloc_include_dir)/hwloc/windows.h \
        $(hwloc_include_dir)/hwloc/openfabrics-verbs.h \
        $(srcdir)/netloc.doxy \
        $(hwloc_include_dir)/netloc.h
@@ -796,6 +797,12 @@ man3_linux_libnuma_DATA = \
         $(DOX_MAN_DIR)/man3/hwloc_cpuset_to_linux_libnuma_ulongs.3 \
         $(DOX_MAN_DIR)/man3/hwloc_nodeset_to_linux_libnuma_ulongs.3
 
+man3_windowsdir = $(man3dir)
+man3_windows_DATA = \
+	$(DOX_MAN_DIR)/man3/hwlocality_windows.3 \
+	$(DOX_MAN_DIR)/man3/hwloc_windows_get_nr_processor_groups.3 \
+	$(DOX_MAN_DIR)/man3/hwloc_windows_get_processor_group_cpuset.3
+
 man3_openfabricsdir = $(man3dir)
 man3_openfabrics_DATA = \
         $(DOX_MAN_DIR)/man3/hwlocality_openfabrics.3 \
@@ -856,6 +863,7 @@ $(man3_cuda_DATA): $(DOX_TAG)
 $(man3_glibc_sched_DATA): $(DOX_TAG)
 $(man3_linux_DATA): $(DOX_TAG)
 $(man3_linux_libnuma_DATA): $(DOX_TAG)
+$(man3_windows_DATA): $(DOX_TAG)
 $(man3_openfabrics_DATA): $(DOX_TAG)
 
 $(DOX_LETTERPDF): $(DOX_TAG)

--- a/doc/doxygen-config.cfg.in
+++ b/doc/doxygen-config.cfg.in
@@ -1,4 +1,4 @@
-# Copyright © 2010-2020 Inria.  All rights reserved.
+# Copyright © 2010-2021 Inria.  All rights reserved.
 # Copyright © 2009 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
 
@@ -19,6 +19,7 @@ INPUT          = \
 		@top_srcdir@/include/hwloc/cpukinds.h \
 		@top_srcdir@/include/hwloc/linux.h \
 		@top_srcdir@/include/hwloc/linux-libnuma.h \
+		@top_srcdir@/include/hwloc/windows.h \
 		@top_srcdir@/include/hwloc/glibc-sched.h \
 		@top_srcdir@/include/hwloc/opencl.h \
 		@top_srcdir@/include/hwloc/cuda.h \

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -2417,6 +2417,12 @@ enabled for the current topology.
   through their thread ID ("tid") or parsing kernel CPU mask files.
  </dd>
 
+<dt>Windows specific features</dt>
+ <dd>
+  hwloc/windows.h offers Windows-specific helpers to query information
+  about Windows processor groups.
+ </dd>
+
 <dt>Linux libnuma</dt>
  <dd>
   hwloc/linux-libnuma.h provides conversion helpers between hwloc CPU

--- a/hwloc/topology-windows.c
+++ b/hwloc/topology-windows.c
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2020 Inria.  All rights reserved.
+ * Copyright © 2009-2021 Inria.  All rights reserved.
  * Copyright © 2009-2012, 2020 Université Bordeaux
  * Copyright © 2011 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
@@ -11,6 +11,7 @@
 
 #include "private/autogen/config.h"
 #include "hwloc.h"
+#include "hwloc/windows.h"
 #include "private/private.h"
 #include "private/debug.h"
 
@@ -190,9 +191,6 @@ typedef struct _PROCESSOR_NUMBER {
 typedef WORD (WINAPI *PFN_GETACTIVEPROCESSORGROUPCOUNT)(void);
 static PFN_GETACTIVEPROCESSORGROUPCOUNT GetActiveProcessorGroupCountProc;
 
-static unsigned long nr_processor_groups = 1;
-static unsigned long max_numanode_index = 0;
-
 typedef WORD (WINAPI *PFN_GETACTIVEPROCESSORCOUNT)(WORD);
 static PFN_GETACTIVEPROCESSORCOUNT GetActiveProcessorCountProc;
 
@@ -269,9 +267,6 @@ static void hwloc_win_get_function_ptrs(void)
       VirtualFreeExProc =
 	(PFN_VIRTUALFREEEX) GetProcAddress(kernel32, "VirtualFreeEx");
     }
-
-    if (GetActiveProcessorGroupCountProc)
-      nr_processor_groups = GetActiveProcessorGroupCountProc();
 
     if (!QueryWorkingSetExProc) {
       HMODULE psapi = LoadLibrary("psapi.dll");
@@ -360,6 +355,163 @@ static int hwloc_bitmap_to_single_ULONG_PTR(hwloc_const_bitmap_t set, unsigned *
     return -1;
   *mask = hwloc_bitmap_to_ith_ULONG_PTR(set, first_ulp);
   *index = first_ulp;
+  return 0;
+}
+
+/**********************
+ * Processor Groups
+ */
+
+static unsigned long max_numanode_index = 0;
+
+static unsigned long nr_processor_groups = 1;
+static hwloc_cpuset_t * processor_group_cpusets = NULL;
+
+static void
+hwloc_win_get_processor_groups(void)
+{
+  PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX procInfoTotal, tmpprocInfoTotal, procInfo;
+  DWORD length;
+  unsigned i;
+
+  hwloc_debug("querying windows processor groups\n");
+
+  if (!GetActiveProcessorGroupCountProc || !GetLogicalProcessorInformationExProc)
+    goto error;
+
+  nr_processor_groups = GetActiveProcessorGroupCountProc();
+  if (!nr_processor_groups)
+    goto error;
+
+  length = 0;
+  procInfoTotal = NULL;
+
+  while (1) {
+    if (GetLogicalProcessorInformationExProc(RelationGroup, procInfoTotal, &length))
+      break;
+    if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+      goto error;
+    tmpprocInfoTotal = realloc(procInfoTotal, length);
+    if (!tmpprocInfoTotal)
+      goto error_with_procinfo;
+    procInfoTotal = tmpprocInfoTotal;
+  }
+
+  processor_group_cpusets = calloc(nr_processor_groups, sizeof(*processor_group_cpusets));
+  if (!processor_group_cpusets)
+    goto error_with_procinfo;
+  hwloc_debug("found %lu windows processor groups\n", nr_processor_groups);
+
+  for (procInfo = procInfoTotal;
+       (void*) procInfo < (void*) ((uintptr_t) procInfoTotal + length);
+       procInfo = (void*) ((uintptr_t) procInfo + procInfo->Size)) {
+    unsigned id;
+
+    assert(procInfo->Relationship == RelationGroup);
+
+    for (id = 0; id < procInfo->Group.ActiveGroupCount; id++) {
+      KAFFINITY mask;
+      hwloc_bitmap_t set;
+
+      set = hwloc_bitmap_alloc();
+      if (!set)
+        goto error_with_cpusets;
+
+      mask = procInfo->Group.GroupInfo[id].ActiveProcessorMask;
+      hwloc_debug("group %u %d cpus mask %lx\n", id,
+                  procInfo->Group.GroupInfo[id].ActiveProcessorCount, mask);
+      /* KAFFINITY is ULONG_PTR */
+      hwloc_bitmap_set_ith_ULONG_PTR(set, id, mask);
+      /* FIXME: what if running 32bits on a 64bits windows with 64-processor groups?
+       * ULONG_PTR is 32bits, so half the group is invisible?
+       * maybe scale id to id*8/sizeof(ULONG_PTR) so that groups are 64-PU aligned?
+       */
+      hwloc_debug_2args_bitmap("group %u %d bitmap %s\n", id, procInfo->Group.GroupInfo[id].ActiveProcessorCount, set);
+      processor_group_cpusets[id] = hwloc_bitmap_dup(set);
+    }
+  }
+
+  free(procInfoTotal);
+  return;
+
+ error_with_cpusets:
+  for(i=0; i<nr_processor_groups; i++) {
+    if (processor_group_cpusets[i])
+      hwloc_bitmap_free(processor_group_cpusets[i]);
+  }
+  processor_group_cpusets = NULL;
+ error_with_procinfo:
+  free(procInfoTotal);
+ error:
+  /* on error set nr to 1 and keep cpusets NULL. We'll use the topology cpuset whenever needed */
+  nr_processor_groups = 1;
+}
+
+static void
+hwloc_win_free_processor_groups(void)
+{
+  unsigned i;
+  for(i=0; i<nr_processor_groups; i++) {
+    if (processor_group_cpusets[i])
+      hwloc_bitmap_free(processor_group_cpusets[i]);
+  }
+  processor_group_cpusets = NULL;
+  nr_processor_groups = 1;
+}
+
+
+int
+hwloc_windows_get_nr_processor_groups(hwloc_topology_t topology, unsigned long flags)
+{
+  if (!topology->is_loaded || !topology->is_thissystem) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (flags) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  return nr_processor_groups;
+}
+
+int
+hwloc_windows_get_processor_group_cpuset(hwloc_topology_t topology, unsigned pg_index, hwloc_cpuset_t cpuset, unsigned long flags)
+{
+  if (!topology->is_loaded || !topology->is_thissystem) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (!cpuset) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (flags) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  if (pg_index >= nr_processor_groups) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  if (!processor_group_cpusets) {
+    assert(nr_processor_groups == 1);
+    /* we found no processor groups, return the entire topology as a single one */
+    hwloc_bitmap_copy(cpuset, topology->levels[0][0]->cpuset);
+    return 0;
+  }
+
+  if (!processor_group_cpusets[pg_index]) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  hwloc_bitmap_copy(cpuset, processor_group_cpusets[pg_index]);
   return 0;
 }
 
@@ -1328,11 +1480,13 @@ hwloc_set_windows_hooks(struct hwloc_binding_hooks *hooks,
 static int hwloc_windows_component_init(unsigned long flags __hwloc_attribute_unused)
 {
   hwloc_win_get_function_ptrs();
+  hwloc_win_get_processor_groups();
   return 0;
 }
 
 static void hwloc_windows_component_finalize(unsigned long flags __hwloc_attribute_unused)
 {
+  hwloc_win_free_processor_groups();
 }
 
 static struct hwloc_backend *

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2009-2020 Inria.  All rights reserved.
+# Copyright © 2009-2021 Inria.  All rights reserved.
 # Copyright © 2009-2010 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright © 2011      Oracle and/or its affiliates.  All rights reserved.
@@ -64,5 +64,10 @@ endif HWLOC_HAVE_SOLARIS
 if HWLOC_HAVE_SCHED_SETAFFINITY
 include_hwloc_HEADERS += hwloc/glibc-sched.h
 endif HWLOC_HAVE_SCHED_SETAFFINITY
+
+if HWLOC_HAVE_WINDOWS
+include_hwloc_HEADERS += \
+	hwloc/windows.h
+endif HWLOC_HAVE_WINDOWS
 
 endif HWLOC_BUILD_STANDALONE

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright © 2010-2020 Inria.  All rights reserved.
+ * Copyright © 2010-2021 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -522,6 +522,11 @@ extern "C" {
 #define hwloc_linux_get_tid_cpubind HWLOC_NAME(linux_get_tid_cpubind)
 #define hwloc_linux_get_tid_last_cpu_location HWLOC_NAME(linux_get_tid_last_cpu_location)
 #define hwloc_linux_read_path_as_cpumask HWLOC_NAME(linux_read_file_cpumask)
+
+/* windows.h */
+
+#define hwloc_windows_get_nr_processor_groups HWLOC_NAME(windows_get_nr_processor_groups)
+#define hwloc_windows_get_processor_group_cpuset HWLOC_NAME(windows_get_processor_group_cpuset)
 
 /* openfabrics-verbs.h */
 

--- a/include/hwloc/windows.h
+++ b/include/hwloc/windows.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021 Inria.  All rights reserved.
+ * See COPYING in top-level directory.
+ */
+
+/** \file
+ * \brief Macros to help interaction between hwloc and Windows.
+ *
+ * Applications that use hwloc on Windows may want to include this file
+ * for Windows specific hwloc features.
+ */
+
+#ifndef HWLOC_WINDOWS_H
+#define HWLOC_WINDOWS_H
+
+#include "hwloc.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/** \defgroup hwlocality_windows Windows-specific helpers
+ *
+ * These functions query Windows processor groups.
+ * These groups partition the operating system into virtual sets
+ * of up to 64 neighbor PUs.
+ * Threads and processes may only be bound inside a single group.
+ * Although Windows processor groups may be exposed in the hwloc
+ * hierarchy as hwloc Groups, they are also often merged into
+ * existing hwloc objects such as NUMA nodes or Packages.
+ * This API provides explicit information about Windows processor
+ * groups so that applications know whether binding to a large
+ * set of PUs may fail because it spans over multiple Windows
+ * processor groups.
+ *
+ * @{
+ */
+
+
+/** \brief Get the number of Windows processor groups
+ *
+ * \p flags must be 0 for now.
+ *
+ * \return at least \c 1 on success.
+ * \return -1 on error, for instance if the topology does not match
+ * the current system (e.g. loaded from another machine through XML).
+ */
+HWLOC_DECLSPEC int hwloc_windows_get_nr_processor_groups(hwloc_topology_t topology, unsigned long flags);
+
+/** \brief Get the CPU-set of a Windows processor group.
+ *
+ * Get the set of PU included in the processor group specified
+ * by \p pg_index.
+ * \p pg_index must be between \c 0 and the value returned
+ * by hwloc_windows_get_nr_processor_groups() minus 1.
+ *
+ * \p flags must be 0 for now.
+ *
+ * \return \c 0 on success.
+ * \return \c -1 on error, for instance if \p pg_index is invalid,
+ * or if the topology does not match the current system (e.g. loaded
+ * from another machine through XML).
+ */
+HWLOC_DECLSPEC int hwloc_windows_get_processor_group_cpuset(hwloc_topology_t topology, unsigned pg_index, hwloc_cpuset_t cpuset, unsigned long flags);
+
+/** @} */
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+
+#endif /* HWLOC_WINDOWS_H */

--- a/tests/hwloc/Makefile.am
+++ b/tests/hwloc/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2009-2020 Inria.  All rights reserved.
+# Copyright © 2009-2021 Inria.  All rights reserved.
 # Copyright © 2009-2012 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
@@ -69,6 +69,10 @@ check_PROGRAMS = \
         cpukinds \
         xmlbuffer \
         gl
+
+if HWLOC_HAVE_WINDOWS
+check_PROGRAMS += windows_processor_groups
+endif HWLOC_HAVE_WINDOWS
 
 if !HWLOC_HAVE_WINDOWS
 if !HWLOC_HAVE_DARWIN

--- a/tests/hwloc/rename/main.c
+++ b/tests/hwloc/rename/main.c
@@ -45,6 +45,7 @@
 #include "hwloc/rsmi.h"
 #endif
 #include "hwloc/gl.h"
+#include "hwloc/windows.h"
 
 #include "private/components.h"
 #include "private/internal-components.h"

--- a/tests/hwloc/windows_processor_groups.c
+++ b/tests/hwloc/windows_processor_groups.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 Inria.  All rights reserved.
+ * See COPYING in top-level directory.
+ */
+
+#include "private/autogen/config.h"
+#include "hwloc.h"
+#include "hwloc/windows.h"
+
+#include <assert.h>
+
+int main(void)
+{
+  hwloc_topology_t topology;
+  hwloc_bitmap_t set;
+  int nr, i, err;
+  char *s;
+
+  hwloc_topology_init(&topology);
+  hwloc_topology_load(topology);
+
+  set = hwloc_bitmap_alloc();
+  assert(set);
+
+  /* check invalid flag */
+  nr = hwloc_windows_get_nr_processor_groups(topology, 1);
+  assert(nr < 0);
+  assert(errno == EINVAL);
+
+  nr = hwloc_windows_get_nr_processor_groups(topology, 0);
+  assert(nr >= 1);
+  printf("found %d groups\n", nr);
+
+  /* check invalid flag */
+  err = hwloc_windows_get_processor_group_cpuset(topology, 0, set, 1);
+  assert(err < 0);
+  assert(errno == EINVAL);
+  /* check invalid index */
+  err = hwloc_windows_get_processor_group_cpuset(topology, nr, set, 0);
+  assert(err < 0);
+  assert(errno == ENOENT);
+
+  for(i=0; i<nr; i++) {
+    hwloc_bitmap_zero(set);
+    err = hwloc_windows_get_processor_group_cpuset(topology, i, set, 0);
+    assert(err == 0);
+    assert(!hwloc_bitmap_iszero(set));
+    err = hwloc_bitmap_asprintf(&s, set);
+    assert(err >= 0);
+    printf("processor group #%d has cpuset %s\n", i, s);
+    free(s);
+  }
+
+  hwloc_bitmap_free(set);
+  hwloc_topology_destroy(topology);
+  return 0;
+}

--- a/utils/lstopo/lstopo-no-graphics.1in
+++ b/utils/lstopo/lstopo-no-graphics.1in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright © 2009-2020 Inria.  All rights reserved.
+.\" Copyright © 2009-2021 Inria.  All rights reserved.
 .\" Copyright © 2009-2010 Université of Bordeaux
 .\" Copyright © 2009-2010 Cisco Systems, Inc.  All rights reserved.
 .\" Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
@@ -97,6 +97,11 @@ memory attribute details depending on the verbosity level).
 .TP
 \fB\-\-cpukinds\fR
 Only display CPU kinds.
+.TP
+B\-\-windows\-processor\-groups\fR
+On Windows, only show information about processor groups.
+All of them are displayed, while the default verbose output
+only shows them if there are more than one.
 .TP
 \fB\-f\fR \fB\-\-force\fR
 If the destination file already exists, overwrite it.

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -408,6 +408,9 @@ void usage(const char *name, FILE *where)
   fprintf (where, "  --distances           Only show distance matrices\n");
   fprintf (where, "  --memattrs            Only show memory attributes\n");
   fprintf (where, "  --cpukinds            Only show CPU kinds\n");
+#ifdef HWLOC_WIN_SYS
+  fprintf (where, "  --processor-groups    Only show Windows processor groups\n");
+#endif
   fprintf (where, "  -c --cpuset           Show the cpuset of each object\n");
   fprintf (where, "  -C --cpuset-only      Only show the cpuset of each object\n");
   fprintf (where, "  --taskset             Show taskset-specific cpuset strings\n");
@@ -741,6 +744,7 @@ main (int argc, char *argv[])
   loutput.show_distances_only = 0;
   loutput.show_memattrs_only = 0;
   loutput.show_cpukinds_only = 0;
+  loutput.show_windows_processor_groups_only = 0;
   loutput.show_only = HWLOC_OBJ_TYPE_NONE;
   loutput.show_cpuset = 0;
   loutput.show_taskset = 0;
@@ -810,6 +814,10 @@ main (int argc, char *argv[])
         loutput.show_memattrs_only = 1;
       } else if (!strcmp (argv[0], "--cpukinds")) {
         loutput.show_cpukinds_only = 1;
+#ifdef HWLOC_WIN_SYS
+      } else if (!strcmp (argv[0], "--processor-groups")) {
+        loutput.show_windows_processor_groups_only = 1;
+#endif
       } else if (!strcmp (argv[0], "-h") || !strcmp (argv[0], "--help")) {
 	usage(callname, stdout);
         exit(EXIT_SUCCESS);
@@ -1305,6 +1313,7 @@ main (int argc, char *argv[])
 	|| loutput.show_distances_only
         || loutput.show_memattrs_only
         || loutput.show_cpukinds_only
+        || loutput.show_windows_processor_groups_only
         || loutput.verbose_mode != LSTOPO_VERBOSE_MODE_DEFAULT)
       output_format = LSTOPO_OUTPUT_CONSOLE;
   }

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2020 Inria.  All rights reserved.
+ * Copyright © 2009-2021 Inria.  All rights reserved.
  * Copyright © 2009-2010, 2012, 2015 Université Bordeaux
  * Copyright © 2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
@@ -90,6 +90,7 @@ struct lstopo_output {
   int show_distances_only;
   int show_memattrs_only;
   int show_cpukinds_only;
+  int show_windows_processor_groups_only;
   hwloc_obj_type_t show_only;
   int show_cpuset;
   int show_taskset;


### PR DESCRIPTION
Windows processor groups are not a physical hierarchical level (although it may be exposed by hwloc if it's different from NUMA nodes, packages, etc) but it has an impact of application because binding must remain inside a single group. Expose those groups explicitly so that applications know what their binding masks should be restricted to.
