### PR TITLE
Make -ltermcap the last option for ncurses

### DIFF
--- a/config/hwloc_internal.m4
+++ b/config/hwloc_internal.m4
@@ -339,7 +339,7 @@ EOF
     chosen_curses=""
     for curses in ncurses curses
     do
-      for lib in "" -ltermcap -l${curses}w -l$curses -ltinfo
+      for lib in "" -l${curses}w -l$curses -ltinfo -ltermcap
       do
         AC_MSG_CHECKING(termcap support using $curses and $lib)
         LIBS="$hwloc_old_LIBS $lib"


### PR DESCRIPTION
On macOS there seems to be a symlink from /usr/lib/libtermcap.dylib to
libncurses.5.4.dylib, which is the first option hwloc currently
considers for detecting ncurses. If you install ncurses with brew or
spack, you don't get this symlink, so hwloc will always link to the
system ncurses instead of the brew/spack version.

By considering libncurses first this should be fixed.