### PR TITLE
New API for adding distances

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,8 @@ Version 2.5.0
     with same locality, for instance NUMA nodes and Packages,
     or OS devices within a PCI device.
   + Add hwloc_distances_transform() to modify distances structures.
+  + Add hwloc_distances_add() is replaced with _add_create() followed
+    by _add_values() and _add_commit(). See hwloc/distances.h for details.
 * Backends
   + Add a levelzero backend for oneAPI L0 devices, exposed as OS devices
     of subtype "LevelZero" and name such as "ze0".

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -671,10 +671,13 @@ man3_distances_DATA = \
         $(DOX_MAN_DIR)/man3/hwloc_distances_obj_index.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_obj_pair_values.3 \
         $(DOX_MAN_DIR)/man3/hwlocality_distances_add.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_distances_add_handle_t.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_add_flag_e.3 \
         $(DOX_MAN_DIR)/man3/HWLOC_DISTANCES_ADD_FLAG_GROUP.3 \
         $(DOX_MAN_DIR)/man3/HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE.3 \
-        $(DOX_MAN_DIR)/man3/hwloc_distances_add.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_distances_add_create.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_distances_add_values.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_distances_add_commit.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_remove.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_remove_by_depth.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_remove_by_type.3 \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -678,6 +678,7 @@ man3_distances_DATA = \
         $(DOX_MAN_DIR)/man3/hwloc_distances_add_create.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_add_values.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_add_commit.3 \
+        $(DOX_MAN_DIR)/man3/hwlocality_distances_remove.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_remove.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_remove_by_depth.3 \
         $(DOX_MAN_DIR)/man3/hwloc_distances_remove_by_type.3 \

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -2621,7 +2621,7 @@ For reference, ::hwloc_topology_t modification operations include
   (see \ref hwlocality_tinker) may modify the topology significantly by adding
   objects inside the tree, changing the topology depth, etc.
 
-  <tt>hwloc_distances_add()</tt> and <tt>hwloc_distances_remove()</tt>
+  <tt>hwloc_distances_add_commit()</tt> and <tt>hwloc_distances_remove()</tt>
   (see \ref hwlocality_distances_add) modify the list of distance structures
   in the topology, and the former may even insert new Group objects.
 

--- a/hwloc/distances.c
+++ b/hwloc/distances.c
@@ -17,6 +17,16 @@
 static struct hwloc_internal_distances_s *
 hwloc__internal_distances_from_public(hwloc_topology_t topology, struct hwloc_distances_s *distances);
 
+static void
+hwloc__groups_by_distances(struct hwloc_topology *topology, unsigned nbobjs, struct hwloc_obj **objs, uint64_t *values, unsigned long kind, unsigned nbaccuracies, float *accuracies, int needcheck);
+
+static void
+hwloc_internal_distances_restrict(hwloc_obj_t *objs,
+				  uint64_t *indexes,
+				  hwloc_obj_type_t *different_types,
+				  uint64_t *values,
+				  unsigned nbobjs, unsigned disappeared);
+
 /******************************************************
  * Global init, prepare, destroy, dup
  */
@@ -248,9 +258,6 @@ int hwloc_distances_release_remove(hwloc_topology_t topology,
  * Add distances to the topology
  */
 
-static void
-hwloc__groups_by_distances(struct hwloc_topology *topology, unsigned nbobjs, struct hwloc_obj **objs, uint64_t *values, unsigned long kind, unsigned nbaccuracies, float *accuracies, int needcheck);
-
 /* insert a distance matrix in the topology.
  * the caller gives us the distances and objs pointers, we'll free them later.
  */
@@ -361,13 +368,6 @@ int hwloc_internal_distances_add_by_index(hwloc_topology_t topology, const char 
   free(different_types);
   return -1;
 }
-
-static void
-hwloc_internal_distances_restrict(hwloc_obj_t *objs,
-				  uint64_t *indexes,
-				  hwloc_obj_type_t *different_types,
-				  uint64_t *values,
-				  unsigned nbobjs, unsigned disappeared);
 
 int hwloc_internal_distances_add(hwloc_topology_t topology, const char *name,
 				 unsigned nbobjs, hwloc_obj_t *objs, uint64_t *values,

--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -1568,7 +1568,7 @@ hwloc__xml_v2import_distances(hwloc_topology_t topology,
     }
   }
 
-  hwloc_internal_distances_add_by_index(topology, name, unique_type, different_types, nbobjs, indexes, u64values, kind, 0);
+  hwloc_internal_distances_add_by_index(topology, name, unique_type, different_types, nbobjs, indexes, u64values, kind, 0 /* assume grouping was applied when this matrix was discovered before exporting to XML */);
 
   /* prevent freeing below */
   indexes = NULL;

--- a/include/hwloc/deprecated.h
+++ b/include/hwloc/deprecated.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2018 Inria.  All rights reserved.
+ * Copyright © 2009-2021 Inria.  All rights reserved.
  * Copyright © 2009-2012 Université Bordeaux
  * Copyright © 2009-2010 Cisco Systems, Inc.  All rights reserved.
  * See COPYING in top-level directory.
@@ -29,6 +29,15 @@ extern "C" {
 #define HWLOC_OBJ_SOCKET HWLOC_OBJ_PACKAGE
 /* backward compat with v1.10 before Node->NUMANode clarification */
 #define HWLOC_OBJ_NODE HWLOC_OBJ_NUMANODE
+
+/** \brief Add a distances structure.
+ *
+ * Superseded by hwloc_distances_add_create()+hwloc_distances_add_values()+hwloc_distances_add_commit()
+ * in v2.5.
+ */
+HWLOC_DECLSPEC int hwloc_distances_add(hwloc_topology_t topology,
+				       unsigned nbobjs, hwloc_obj_t *objs, hwloc_uint64_t *values,
+				       unsigned long kind, unsigned long flags) __hwloc_attribute_deprecated;
 
 /** \brief Insert a misc object by parent.
  *

--- a/include/hwloc/distances.h
+++ b/include/hwloc/distances.h
@@ -284,6 +284,7 @@ hwloc_distances_obj_pair_values(struct hwloc_distances_s *distances,
 /** \brief Flags for adding a new distances to a topology. */
 enum hwloc_distances_add_flag_e {
   /** \brief Try to group objects based on the newly provided distance information.
+   * This is ignored for distances between objects of different types.
    * \hideinitializer
    */
   HWLOC_DISTANCES_ADD_FLAG_GROUP = (1UL<<0),

--- a/include/hwloc/distances.h
+++ b/include/hwloc/distances.h
@@ -280,7 +280,7 @@ hwloc_distances_obj_pair_values(struct hwloc_distances_s *distances,
 
 
 
-/** \defgroup hwlocality_distances_add Add or remove distances between objects
+/** \defgroup hwlocality_distances_add Add distances between objects
  *
  * The usual way to add distances is:
  * \code
@@ -389,6 +389,13 @@ HWLOC_DECLSPEC int hwloc_distances_add_commit(hwloc_topology_t topology,
                                               hwloc_distances_add_handle_t handle,
                                               unsigned long flags);
 
+/** @} */
+
+
+
+/** \defgroup hwlocality_distances_remove Remove distances between objects
+ * @{
+ */
 
 /** \brief Remove all distance matrices from a topology.
  *

--- a/include/hwloc/distances.h
+++ b/include/hwloc/distances.h
@@ -211,10 +211,13 @@ enum hwloc_distances_transform_e {
  *
  * Modify a distances structure that was previously obtained with
  * hwloc_distances_get() or one of its variants.
+ *
  * This modifies the local copy of the distances structures but does
- * not modify the distances information stored inside the topology.
- * Hence these changes cannot be exported to XML or retrieved by
- * another call to hwloc_distances_get().
+ * not modify the distances information stored inside the topology
+ * (retrieved by another call to hwloc_distances_get() or exported to XML).
+ * To do so, one should add a new distances structure with same
+ * name, kind, objects and values (see \ref hwlocality_distances_add)
+ * and then remove this old one with hwloc_distances_release_remove().
  *
  * \p transform must be one of the transformations listed
  * in ::hwloc_distances_transform_e.
@@ -278,8 +281,78 @@ hwloc_distances_obj_pair_values(struct hwloc_distances_s *distances,
 
 
 /** \defgroup hwlocality_distances_add Add or remove distances between objects
+ *
+ * The usual way to add distances is:
+ * \code
+ * hwloc_distances_add_handle_t handle;
+ * int err = -1;
+ * handle = hwloc_distances_add_create(topology, "name", kind, 0);
+ * if (handle) {
+ *   err = hwloc_distances_add_values(topology, handle, nbobjs, objs, values, 0);
+ *   if (!err)
+ *     err = hwloc_distances_add_commit(topology, handle, flags);
+ * }
+ * \endcode
+ * If \p err is \c 0 at the end, then addition was successful.
+ *
  * @{
  */
+
+/** \brief Handle to a new distances structure during its addition to the topology. */
+typedef void * hwloc_distances_add_handle_t;
+
+/** \brief Create a new empty distances structure.
+ *
+ * Create an empty distances structure
+ * to be filled with hwloc_distances_add_values()
+ * and then committed with hwloc_distances_add_commit().
+ *
+ * Parameter \p name is optional, it may be \c NULL.
+ * Otherwise, it will be copied internally and may later be freed by the caller.
+ *
+ * \p kind specifies the kind of distance as a OR'ed set of ::hwloc_distances_kind_e.
+ * Kind ::HWLOC_DISTANCES_KIND_HETEROGENEOUS_TYPES will be automatically set
+ * according to objects having different types in hwloc_distances_add_values().
+ *
+ * \p flags must be \c 0 for now.
+ *
+ * \return A hwloc_distances_add_handle_t that should then be passed
+ * to hwloc_distances_add_values() and hwloc_distances_add_commit().
+ *
+ * \return \c NULL on error.
+ */
+HWLOC_DECLSPEC hwloc_distances_add_handle_t
+hwloc_distances_add_create(hwloc_topology_t topology,
+                           const char *name, unsigned long kind,
+                           unsigned long flags);
+
+/** \brief Specify the objects and values in a new empty distances structure.
+ *
+ * Specify the objects and values for a new distances structure
+ * that was returned as a handle by hwloc_distances_add_create().
+ * The structure must then be committed with hwloc_distances_add_commit().
+ *
+ * The number of objects is \p nbobjs and the array of objects is \p objs.
+ * Distance values are stored as a one-dimension array in \p values.
+ * The distance from object i to object j is in slot i*nbobjs+j.
+ *
+ * \p nbobjs must be at least 2.
+ *
+ * Arrays \p objs and \p values will be copied internally,
+ * they may later be freed by the caller.
+ *
+ * On error, the temporary distances structure and its content are destroyed.
+ *
+ * \p flags must be \c 0 for now.
+ *
+ * \return \c 0 on success.
+ * \return \c -1 on error.
+ */
+HWLOC_DECLSPEC int hwloc_distances_add_values(hwloc_topology_t topology,
+                                              hwloc_distances_add_handle_t handle,
+                                              unsigned nbobjs, hwloc_obj_t *objs,
+                                              hwloc_uint64_t *values,
+                                              unsigned long flags);
 
 /** \brief Flags for adding a new distances to a topology. */
 enum hwloc_distances_add_flag_e {
@@ -296,23 +369,26 @@ enum hwloc_distances_add_flag_e {
   HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE = (1UL<<1)
 };
 
-/** \brief Provide a new distance matrix.
+/** \brief Commit a new distances structure.
  *
- * Provide the matrix of distances between a set of objects given by \p nbobjs
- * and the \p objs array. \p nbobjs must be at least 2.
- * The distances are stored as a one-dimension array in \p values.
- * The distance from object i to object j is in slot i*nbobjs+j.
+ * This function finalizes the distances structure and inserts in it the topology.
  *
- * \p kind specifies the kind of distance as a OR'ed set of ::hwloc_distances_kind_e.
- * Kind ::HWLOC_DISTANCES_KIND_HETEROGENEOUS_TYPES will be automatically added
- * if objects of different types are given.
+ * Parameter \p handle was previously returned by hwloc_distances_add_create().
+ * Then objects and values were specified with hwloc_distances_add_values().
  *
  * \p flags configures the behavior of the function using an optional OR'ed set of
  * ::hwloc_distances_add_flag_e.
+ * It may be used to request the grouping of existing objects based on distances.
+ *
+ * On error, the temporary distances structure and its content are destroyed.
+ *
+ * \return \c 0 on success.
+ * \return \c -1 on error.
  */
-HWLOC_DECLSPEC int hwloc_distances_add(hwloc_topology_t topology,
-				       unsigned nbobjs, hwloc_obj_t *objs, hwloc_uint64_t *values,
-				       unsigned long kind, unsigned long flags);
+HWLOC_DECLSPEC int hwloc_distances_add_commit(hwloc_topology_t topology,
+                                              hwloc_distances_add_handle_t handle,
+                                              unsigned long flags);
+
 
 /** \brief Remove all distance matrices from a topology.
  *

--- a/include/hwloc/plugins.h
+++ b/include/hwloc/plugins.h
@@ -624,6 +624,86 @@ HWLOC_DECLSPEC int hwloc_pcidisc_tree_attach(struct hwloc_topology *topology, st
  */
 HWLOC_DECLSPEC struct hwloc_obj * hwloc_pci_find_parent_by_busid(struct hwloc_topology *topology, unsigned domain, unsigned bus, unsigned dev, unsigned func);
 
+/** \brief Handle to a new distances structure during its addition to the topology. */
+typedef void * hwloc_backend_distances_add_handle_t;
+
+/** \brief Create a new empty distances structure.
+ *
+ * Create an empty distances structure
+ * to be filled with hwloc_backend_distances_add_values()
+ * and then committed with hwloc_backend_distances_add_commit().
+ *
+ * Parameter \p name is optional, it may be \c NULL.
+ * Otherwise, it will be copied internally and may later be freed by the caller.
+ *
+ * \p kind specifies the kind of distance as a OR'ed set of ::hwloc_distances_kind_e.
+ * Kind ::HWLOC_DISTANCES_KIND_HETEROGENEOUS_TYPES will be automatically set
+ * according to objects having different types in hwloc_backend_distances_add_values().
+ *
+ * \p flags must be \c 0 for now.
+ *
+ * \return A hwloc_backend_distances_add_handle_t that should then be passed
+ * to hwloc_backend_distances_add_values() and hwloc_backend_distances_add_commit().
+ *
+ * \return \c NULL on error.
+ */
+HWLOC_DECLSPEC hwloc_backend_distances_add_handle_t
+hwloc_backend_distances_add_create(hwloc_topology_t topology,
+                                   const char *name, unsigned long kind,
+                                   unsigned long flags);
+
+/** \brief Specify the objects and values in a new empty distances structure.
+ *
+ * Specify the objects and values for a new distances structure
+ * that was returned as a handle by hwloc_backend_distances_add_create().
+ * The structure must then be committed with hwloc_backend_distances_add_commit().
+ *
+ * The number of objects is \p nbobjs and the array of objects is \p objs.
+ * Distance values are stored as a one-dimension array in \p values.
+ * The distance from object i to object j is in slot i*nbobjs+j.
+ *
+ * \p nbobjs must be at least 2.
+ *
+ * Arrays \p objs and \p values are directly attached to the topology.
+ * On success, these arrays are given to the core and should not
+ * ever be freed by the caller anymore.
+ *
+ * On error, the temporary distances structure and its content are destroyed.
+ *
+ * \p flags must be \c 0 for now.
+ *
+ * \return \c 0 on success.
+ * \return \c -1 on error.
+ */
+HWLOC_DECLSPEC int
+hwloc_backend_distances_add_values(hwloc_topology_t topology,
+                                   hwloc_backend_distances_add_handle_t handle,
+                                   unsigned nbobjs, hwloc_obj_t *objs,
+                                   hwloc_uint64_t *values,
+                                   unsigned long flags);
+
+/** \brief Commit a new distances structure.
+ *
+ * This function finalizes the distances structure and inserts in it the topology.
+ *
+ * Parameter \p handle was previously returned by hwloc_backend_distances_add_create().
+ * Then objects and values were specified with hwloc_backend_distances_add_values().
+ *
+ * \p flags configures the behavior of the function using an optional OR'ed set of
+ * ::hwloc_distances_add_flag_e.
+ * It may be used to request the grouping of existing objects based on distances.
+ *
+ * On error, the temporary distances structure is destroyed, together
+ * with arrays that were attached in hwloc_backend_distances_set_values().
+ *
+ * \return \c 0 on success.
+ * \return \c -1 on error.
+ */
+HWLOC_DECLSPEC int
+hwloc_backend_distances_add_commit(hwloc_topology_t topology,
+                                   hwloc_backend_distances_add_handle_t handle,
+                                   unsigned long flags);
+
 /** @} */
 
 

--- a/include/hwloc/plugins.h
+++ b/include/hwloc/plugins.h
@@ -629,23 +629,9 @@ typedef void * hwloc_backend_distances_add_handle_t;
 
 /** \brief Create a new empty distances structure.
  *
- * Create an empty distances structure
- * to be filled with hwloc_backend_distances_add_values()
- * and then committed with hwloc_backend_distances_add_commit().
- *
- * Parameter \p name is optional, it may be \c NULL.
- * Otherwise, it will be copied internally and may later be freed by the caller.
- *
- * \p kind specifies the kind of distance as a OR'ed set of ::hwloc_distances_kind_e.
- * Kind ::HWLOC_DISTANCES_KIND_HETEROGENEOUS_TYPES will be automatically set
- * according to objects having different types in hwloc_backend_distances_add_values().
- *
- * \p flags must be \c 0 for now.
- *
- * \return A hwloc_backend_distances_add_handle_t that should then be passed
- * to hwloc_backend_distances_add_values() and hwloc_backend_distances_add_commit().
- *
- * \return \c NULL on error.
+ * This is identical to hwloc_distances_add_create()
+ * but this variant is designed for backend inserting
+ * distances during topology discovery.
  */
 HWLOC_DECLSPEC hwloc_backend_distances_add_handle_t
 hwloc_backend_distances_add_create(hwloc_topology_t topology,
@@ -654,26 +640,14 @@ hwloc_backend_distances_add_create(hwloc_topology_t topology,
 
 /** \brief Specify the objects and values in a new empty distances structure.
  *
- * Specify the objects and values for a new distances structure
- * that was returned as a handle by hwloc_backend_distances_add_create().
- * The structure must then be committed with hwloc_backend_distances_add_commit().
+ * This is similar to hwloc_distances_add_values()
+ * but this variant is designed for backend inserting
+ * distances during topology discovery.
  *
- * The number of objects is \p nbobjs and the array of objects is \p objs.
- * Distance values are stored as a one-dimension array in \p values.
- * The distance from object i to object j is in slot i*nbobjs+j.
- *
- * \p nbobjs must be at least 2.
- *
- * Arrays \p objs and \p values are directly attached to the topology.
+ * The only semantical difference is that \p objs and \p values
+ * are not duplicated, but directly attached to the topology.
  * On success, these arrays are given to the core and should not
  * ever be freed by the caller anymore.
- *
- * On error, the temporary distances structure and its content are destroyed.
- *
- * \p flags must be \c 0 for now.
- *
- * \return \c 0 on success.
- * \return \c -1 on error.
  */
 HWLOC_DECLSPEC int
 hwloc_backend_distances_add_values(hwloc_topology_t topology,
@@ -684,20 +658,9 @@ hwloc_backend_distances_add_values(hwloc_topology_t topology,
 
 /** \brief Commit a new distances structure.
  *
- * This function finalizes the distances structure and inserts in it the topology.
- *
- * Parameter \p handle was previously returned by hwloc_backend_distances_add_create().
- * Then objects and values were specified with hwloc_backend_distances_add_values().
- *
- * \p flags configures the behavior of the function using an optional OR'ed set of
- * ::hwloc_distances_add_flag_e.
- * It may be used to request the grouping of existing objects based on distances.
- *
- * On error, the temporary distances structure is destroyed, together
- * with arrays that were attached in hwloc_backend_distances_set_values().
- *
- * \return \c 0 on success.
- * \return \c -1 on error.
+ * This is similar to hwloc_distances_add_commit()
+ * but this variant is designed for backend inserting
+ * distances during topology discovery.
  */
 HWLOC_DECLSPEC int
 hwloc_backend_distances_add_commit(hwloc_topology_t topology,

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -638,6 +638,11 @@ extern "C" {
 
 #define hwloc_pci_find_parent_by_busid HWLOC_NAME(pcidisc_find_busid_parent)
 
+#define hwloc_backend_distances_add_handle_t HWLOC_NAME(backend_distances_add_handle_t)
+#define hwloc_backend_distances_add_create HWLOC_NAME(backend_distances_add_create)
+#define hwloc_backend_distances_add_values HWLOC_NAME(backend_distances_add_values)
+#define hwloc_backend_distances_add_commit HWLOC_NAME(backend_distances_add_commit)
+
 /* hwloc/deprecated.h */
 
 #define hwloc_topology_insert_misc_object_by_parent HWLOC_NAME(topology_insert_misc_object_by_parent)

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -833,7 +833,6 @@ extern "C" {
 #define hwloc_internal_distances_dup HWLOC_NAME(internal_distances_dup)
 #define hwloc_internal_distances_refresh HWLOC_NAME(internal_distances_refresh)
 #define hwloc_internal_distances_destroy HWLOC_NAME(internal_distances_destroy)
-
 #define hwloc_internal_distances_add HWLOC_NAME(internal_distances_add)
 #define hwloc_internal_distances_add_by_index HWLOC_NAME(internal_distances_add_by_index)
 #define hwloc_internal_distances_invalidate_cached_objs HWLOC_NAME(hwloc_internal_distances_invalidate_cached_objs)

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -464,7 +464,11 @@ extern "C" {
 #define HWLOC_DISTANCES_ADD_FLAG_GROUP HWLOC_NAME_CAPS(DISTANCES_ADD_FLAG_GROUP)
 #define HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE HWLOC_NAME_CAPS(DISTANCES_ADD_FLAG_GROUP_INACCURATE)
 
-#define hwloc_distances_add HWLOC_NAME(distances_add)
+#define hwloc_distances_add_handle_t HWLOC_NAME(distances_add_handle_t)
+#define hwloc_distances_add_create HWLOC_NAME(distances_add_create)
+#define hwloc_distances_add_values HWLOC_NAME(distances_add_values)
+#define hwloc_distances_add_commit HWLOC_NAME(distances_add_commit)
+
 #define hwloc_distances_remove HWLOC_NAME(distances_remove)
 #define hwloc_distances_remove_by_depth HWLOC_NAME(distances_remove_by_depth)
 #define hwloc_distances_remove_by_type HWLOC_NAME(distances_remove_by_type)
@@ -644,6 +648,8 @@ extern "C" {
 #define hwloc_backend_distances_add_commit HWLOC_NAME(backend_distances_add_commit)
 
 /* hwloc/deprecated.h */
+
+#define hwloc_distances_add HWLOC_NAME(distances_add)
 
 #define hwloc_topology_insert_misc_object_by_parent HWLOC_NAME(topology_insert_misc_object_by_parent)
 #define hwloc_obj_cpuset_snprintf HWLOC_NAME(obj_cpuset_snprintf)

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -409,9 +409,13 @@ extern void hwloc_internal_distances_prepare(hwloc_topology_t topology);
 extern void hwloc_internal_distances_destroy(hwloc_topology_t topology);
 extern int hwloc_internal_distances_dup(hwloc_topology_t new, hwloc_topology_t old);
 extern void hwloc_internal_distances_refresh(hwloc_topology_t topology);
-extern int hwloc_internal_distances_add(hwloc_topology_t topology, const char *name, unsigned nbobjs, hwloc_obj_t *objs, uint64_t *values, unsigned long kind, unsigned long flags);
-extern int hwloc_internal_distances_add_by_index(hwloc_topology_t topology, const char *name, hwloc_obj_type_t unique_type, hwloc_obj_type_t *different_types, unsigned nbobjs, uint64_t *indexes, uint64_t *values, unsigned long kind, unsigned long flags);
 extern void hwloc_internal_distances_invalidate_cached_objs(hwloc_topology_t topology);
+
+/* these distances_add() functions are higher-level than those in hwloc/plugins.h
+ * but they may change in the future, hence they are not exported to plugins.
+ */
+extern int hwloc_internal_distances_add_by_index(hwloc_topology_t topology, const char *name, hwloc_obj_type_t unique_type, hwloc_obj_type_t *different_types, unsigned nbobjs, uint64_t *indexes, uint64_t *values, unsigned long kind, unsigned long flags);
+extern int hwloc_internal_distances_add(hwloc_topology_t topology, const char *name, unsigned nbobjs, hwloc_obj_t *objs, uint64_t *values, unsigned long kind, unsigned long flags);
 
 extern void hwloc_internal_memattrs_init(hwloc_topology_t topology);
 extern void hwloc_internal_memattrs_prepare(hwloc_topology_t topology);

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009      CNRS
- * Copyright © 2009-2020 Inria.  All rights reserved.
+ * Copyright © 2009-2021 Inria.  All rights reserved.
  * Copyright © 2009-2012, 2020 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
  *
@@ -166,6 +166,7 @@ struct hwloc_topology {
     unsigned long kind;
 
 #define HWLOC_INTERNAL_DIST_FLAG_OBJS_VALID (1U<<0) /* if the objs array is valid below */
+#define HWLOC_INTERNAL_DIST_FLAG_NOT_COMMITTED (1U<<1) /* if the distances isn't in the list yet */
     unsigned iflags;
 
     /* objects are currently stored in physical_index order */

--- a/tests/hwloc/hwloc_distances.c
+++ b/tests/hwloc/hwloc_distances.c
@@ -67,6 +67,7 @@ int main(void)
   struct hwloc_distances_s *distances[2];
   hwloc_obj_t objs[16];
   hwloc_uint64_t values[16*16], value1, value2;
+  hwloc_distances_add_handle_t handle;
   int topodepth;
   unsigned i, j, k, nr;
   int err;
@@ -94,9 +95,14 @@ int main(void)
   values[3+4*2] = 4;
   for(i=0; i<4; i++)
     values[i+4*i] = 1;
-  err = hwloc_distances_add(topology, 4, objs, values,
-			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 4, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   err = hwloc_topology_refresh(topology);
@@ -163,9 +169,14 @@ int main(void)
   }
   for(i=0; i<16; i++)
     values[i+16*i] = 1;
-  err = hwloc_distances_add(topology, 16, objs, values,
-			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 16, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   topodepth = hwloc_topology_get_depth(topology);
@@ -206,9 +217,14 @@ int main(void)
     values[i] = 3;
   for(i=0; i<4; i++)
     values[i+4*i] = 7;
-  err = hwloc_distances_add(topology, 4, objs, values,
-			    HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 4, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   topodepth = hwloc_topology_get_depth(topology);
@@ -248,9 +264,14 @@ int main(void)
       values[i*3+j] = 10;
     values[i*3+i] = 5;
   }
-  err = hwloc_distances_add(topology, 3, objs, values,
-			    HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH|HWLOC_DISTANCES_KIND_FROM_USER,
-			    0);
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 3, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   0);
   assert(!err);
 
   /* check distances by kind */
@@ -343,9 +364,14 @@ int main(void)
   values[3+4*2] = 100;
   for(i=0; i<4; i++)
     values[i+4*i] = 1000;
-  err = hwloc_distances_add(topology, 4, objs, values,
-			    HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_BANDWIDTH|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 4, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   nr = 1;

--- a/tests/hwloc/hwloc_groups.c
+++ b/tests/hwloc/hwloc_groups.c
@@ -17,6 +17,7 @@ int main(void)
   hwloc_obj_t obj, group, saved, res, root;
   hwloc_obj_t objs[32];
   hwloc_uint64_t values[32*32];
+  hwloc_distances_add_handle_t handle;
   int depth;
   hwloc_obj_type_t type;
   unsigned width;
@@ -148,9 +149,14 @@ int main(void)
   values[0] = 1; values[1] = 4; values[2] = 4;
   values[3] = 4; values[4] = 1; values[5] = 2;
   values[6] = 4; values[7] = 2; values[8] = 1;
-  err = hwloc_distances_add(topology, 3, objs, values,
-			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 3, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
   /* 1 groups at depth 1 and 2 */
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_GROUP);
@@ -199,9 +205,14 @@ int main(void)
   values[10] = 4; values[11] = 4; values[12] = 1; values[13] = 4; values[14] = 4;
   values[15] = 4; values[16] = 4; values[17] = 4; values[18] = 1; values[19] = 2;
   values[20] = 4; values[21] = 4; values[22] = 4; values[23] = 2; values[24] = 1;
-  err = hwloc_distances_add(topology, 5, objs, values,
-			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 5, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
   /* 1 node */
   depth = hwloc_get_type_depth(topology, HWLOC_OBJ_NUMANODE);
@@ -274,9 +285,15 @@ int main(void)
   /* group 8cores as 2*2*2 */
   for(i=0; i<16; i++)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
-  assert(!hwloc_distances_add(topology, 16, objs, values,
-			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_ADD_FLAG_GROUP));
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 16, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  assert(!err);
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 6);
   width = hwloc_get_nbobjs_by_depth(topology, 0);
@@ -302,9 +319,15 @@ int main(void)
   hwloc_topology_load(topology);
   for(i=0; i<16; i++)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
-  assert(!hwloc_distances_add(topology, 16, objs, values,
-			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE));
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 16, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE);
+  assert(!err);
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 6);
   hwloc_topology_destroy(topology);
@@ -315,9 +338,15 @@ int main(void)
   hwloc_topology_load(topology);
   for(i=0; i<16; i++)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
-  assert(!hwloc_distances_add(topology, 16, objs, values,
-			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE));
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 16, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE);
+  assert(!err);
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 6);
   hwloc_topology_destroy(topology);
@@ -327,9 +356,15 @@ int main(void)
   hwloc_topology_load(topology);
   for(i=0; i<16; i++)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
-  assert(!hwloc_distances_add(topology, 16, objs, values,
-			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_ADD_FLAG_GROUP /* no inaccurate flag, cannot group */));
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 16, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP /* no inaccurate flag, cannot group */);
+  assert(!err);
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 4);
   hwloc_topology_destroy(topology);
@@ -340,9 +375,15 @@ int main(void)
   hwloc_topology_load(topology);
   for(i=0; i<16; i++)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
-  assert(!hwloc_distances_add(topology, 16, objs, values,
-			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE));
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 16, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE);
+  assert(!err);
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 4);
   hwloc_topology_destroy(topology);
@@ -353,9 +394,15 @@ int main(void)
   hwloc_topology_load(topology);
   for(i=0; i<16; i++)
     objs[i] = hwloc_get_obj_by_type(topology, HWLOC_OBJ_CORE, i);
-  assert(!hwloc_distances_add(topology, 16, objs, values,
-			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE));
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 16, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP|HWLOC_DISTANCES_ADD_FLAG_GROUP_INACCURATE);
+  assert(!err);
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 4);
   hwloc_topology_destroy(topology);
@@ -387,9 +434,15 @@ int main(void)
       else
         values[i+8*j] = values[j+8*i] = 8;
   }
-  assert(!hwloc_distances_add(topology, 8, objs, values,
-			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_ADD_FLAG_GROUP));
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 8, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  assert(!err);
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 4);
   /* group 4cores as 2*2 */
@@ -403,9 +456,15 @@ int main(void)
       else
         values[i+8*j] = values[j+8*i] = 8;
   }
-  assert(!hwloc_distances_add(topology, 8, objs, values,
-			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_ADD_FLAG_GROUP));
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 8, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  assert(!err);
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 5);
   width = hwloc_get_nbobjs_by_depth(topology, 0);
@@ -431,9 +490,15 @@ int main(void)
       else
         values[i+32*j] = values[j+32*i] = 8;
   }
-  assert(!hwloc_distances_add(topology, 32, objs, values,
-			      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			      HWLOC_DISTANCES_ADD_FLAG_GROUP));
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 32, objs, values, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  assert(!err);
   depth = hwloc_topology_get_depth(topology);
   assert(depth == 6);
   width = hwloc_get_nbobjs_by_depth(topology, 0);

--- a/tests/hwloc/hwloc_topology_dup.c
+++ b/tests/hwloc/hwloc_topology_dup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2011-2017 Inria.  All rights reserved.
+ * Copyright © 2011-2021 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -18,6 +18,7 @@ int main(void)
   struct hwloc_distances_s *distances;
   hwloc_obj_t nodes[3], cores[6];
   hwloc_uint64_t node_distances[9], core_distances[36];
+  hwloc_distances_add_handle_t handle;
   unsigned i,j,nr;
   int err;
 
@@ -30,9 +31,14 @@ int main(void)
     for(j=0; j<3; j++)
       node_distances[i*3+j] = (i == j ? 10 : 20);
   }
-  err = hwloc_distances_add(oldtopology, 3, nodes, node_distances,
-			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(oldtopology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(oldtopology, handle, 3, nodes, node_distances, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(oldtopology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   for(i=0; i<6; i++) {
@@ -40,9 +46,14 @@ int main(void)
     for(j=0; j<6; j++)
       core_distances[i*6+j] = (i == j ? 4 : 8);
   }
-  err = hwloc_distances_add(oldtopology, 6, cores, core_distances,
-			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(oldtopology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(oldtopology, handle, 6, cores, core_distances, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(oldtopology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   printf("duplicating\n");

--- a/tests/hwloc/hwloc_topology_restrict.c
+++ b/tests/hwloc/hwloc_topology_restrict.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2011-2020 Inria.  All rights reserved.
+ * Copyright © 2011-2021 Inria.  All rights reserved.
  * Copyright © 2011 Université Bordeaux.  All rights reserved.
  * See COPYING in top-level directory.
  */
@@ -107,6 +107,7 @@ int main(void)
   hwloc_bitmap_t cpuset = hwloc_bitmap_alloc();
   hwloc_obj_t nodes[3], cores[6];
   hwloc_uint64_t node_distances[9], core_distances[36];
+  hwloc_distances_add_handle_t handle;
   hwloc_obj_t obj;
   unsigned i,j;
   int err;
@@ -120,9 +121,14 @@ int main(void)
     for(j=0; j<3; j++)
       node_distances[i*3+j] = (i == j ? 10 : 20);
   }
-  err = hwloc_distances_add(topology, 3, nodes, node_distances,
-			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 3, nodes, node_distances, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   for(i=0; i<6; i++) {
@@ -130,9 +136,14 @@ int main(void)
     for(j=0; j<6; j++)
       core_distances[i*6+j] = (i == j ? 4 : 8);
   }
-  err = hwloc_distances_add(topology, 6, cores, core_distances,
-			    HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-			    HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(topology, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(topology, handle, 6, cores, core_distances, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(topology, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   /* entire topology */

--- a/tests/hwloc/shmem.c
+++ b/tests/hwloc/shmem.c
@@ -204,6 +204,7 @@ int main(int argc, char *argv[])
   static hwloc_topology_t orig;
   hwloc_obj_t nodes[3];
   uint64_t node_distances[9];
+  hwloc_distances_add_handle_t handle;
   unsigned i,j;
   const char *top_srcdir;
   int err, ret, ret2;
@@ -268,9 +269,14 @@ int main(int argc, char *argv[])
     for(j=0; j<3; j++)
       node_distances[i*3+j] = (i == j ? 10 : 20);
   }
-  err = hwloc_distances_add(orig, 3, nodes, node_distances,
-                            HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
-                            HWLOC_DISTANCES_ADD_FLAG_GROUP);
+  handle = hwloc_distances_add_create(orig, NULL,
+                                      HWLOC_DISTANCES_KIND_MEANS_LATENCY|HWLOC_DISTANCES_KIND_FROM_USER,
+                                      0);
+  assert(handle);
+  err = hwloc_distances_add_values(orig, handle, 3, nodes, node_distances, 0);
+  assert(!err);
+  err = hwloc_distances_add_commit(orig, handle,
+                                   HWLOC_DISTANCES_ADD_FLAG_GROUP);
   assert(!err);
 
   ret2 = test(orig, argv[0]);

--- a/utils/hwloc/hwloc-annotate.c
+++ b/utils/hwloc/hwloc-annotate.c
@@ -195,6 +195,7 @@ add_distances(hwloc_topology_t topology, int topodepth)
 	FILE *file;
 	char line[64];
 	unsigned i, x, y, z;
+        hwloc_distances_add_handle_t handle;
 	int err;
 
 	file = fopen(distancesfilename, "r");
@@ -283,10 +284,17 @@ add_distances(hwloc_topology_t topology, int topodepth)
 		}
 	}
 
-	err = hwloc_distances_add(topology, nbobjs, objs, values, kind, distancesflags);
-	if (err < 0) {
-		fprintf(stderr, "Failed to add distances\n");
-		goto out;
+        err = -1;
+        handle = hwloc_distances_add_create(topology, NULL, kind, 0);
+        if (handle) {
+          err = hwloc_distances_add_values(topology, handle, nbobjs, objs, values, 0);
+          if (!err) {
+            err = hwloc_distances_add_commit(topology, handle, distancesflags);
+          }
+        }
+        if (err < 0 || !handle) {
+          fprintf(stderr, "Failed to add distances\n");
+          goto out;
 	}
 
 out:


### PR DESCRIPTION
hwlc_distances_add() is split into add_create()+add_values()+add_commit() to allow specifying a name argument without having yet another function with too many arguments. Splitting will also let us add intermediate calls if we ever need to add more parameters.
The main end-user API in hwloc/distances is deprecated in favor of this new API. And a plugin-specific one is added because GPU backends will need it (only non-plugin backends could add distances before).
