### PR TITLE
Detect cpukinds on Mac OS X for Apple M1 hybrid CPU support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,13 @@ bug fixes (and other actions) for each version of hwloc since version
 0.9.
 
 
+Version 2.6.0
+-------------
+* Backends
+  + Expose two cpukinds for energy-efficient cores (icestorm) and
+    high-performance cores (firestorm) on Apple M1 on Mac OS X.
+
+
 Version 2.5.0
 -------------
 * API

--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -548,6 +548,46 @@ EOF])
       echo
     fi
 
+    if test x$hwloc_darwin = xyes; then
+      echo
+      echo "**** Darwin-specific checks"
+
+      AC_MSG_CHECKING([for the Foundation framework])
+      tmp_save_LDFLAGS="$LDFLAGS"
+      LDFLAGS="$LDFLAGS -framework Foundation"
+      AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([
+#include <CoreFoundation/CoreFoundation.h>
+          ], [
+return CFDictionaryGetTypeID();
+          ])],
+        [AC_MSG_RESULT(yes)
+         HWLOC_DARWIN_LDFLAGS="$HWLOC_DARWIN_LDFLAGS -framework Foundation"
+         AC_DEFINE(HWLOC_HAVE_DARWIN_FOUNDATION, 1, `Define to 1 if you have the Foundation Darwin framework')],
+        [AC_MSG_RESULT(no)])
+      LDFLAGS="$tmp_save_LDFLAGS"
+
+      AC_MSG_CHECKING([for the IOKit framework])
+      tmp_save_LDFLAGS="$LDFLAGS"
+      LDFLAGS="$LDFLAGS -framework IOKit"
+      AC_LINK_IFELSE([
+        AC_LANG_PROGRAM([
+#include <IOKit/IOKitLib.h>
+          ], [
+io_registry_entry_t service = IORegistryGetRootEntry(kIOMasterPortDefault);
+          ])],
+        [AC_MSG_RESULT(yes)
+         HWLOC_DARWIN_LDFLAGS="$HWLOC_DARWIN_LDFLAGS -framework IOKit"
+         AC_DEFINE(HWLOC_HAVE_DARWIN_IOKIT, 1, `Define to 1 if you have the IOKit Darwin framework')],
+        [AC_MSG_RESULT(no)])
+      LDFLAGS="$tmp_save_LDFLAGS"
+
+      AC_SUBST(HWLOC_DARWIN_LDFLAGS)
+
+      echo "**** end of Darwin-specific checks"
+      echo
+    fi
+
     if test x$hwloc_linux = xyes; then
       echo
       echo "**** Linux-specific checks"

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -2206,6 +2206,12 @@ on some Intel processors.
 such as <tt>intel_atom_0</tt>,
 as reported by future Linux kernels on some Intel processors.
 </dd>
+<dt>DarwinCompatible (Darwin / Mac OS X)</dt>
+<dd>The compatibility attribute of the CPUs as found
+in the IO registry on Darwin / Mac OS X.
+For instance <tt>apple,icestorm;ARM,v8</tt> for energy-efficient cores
+and <tt>apple,firestorm;ARM,v8</tt> on performance cores on Apple M1 CPU.
+</dd>
 </dl>
 
 See \ref hwlocality_cpukinds for details.

--- a/hwloc/Makefile.am
+++ b/hwloc/Makefile.am
@@ -166,6 +166,7 @@ endif HWLOC_HAVE_WINDOWS
 
 if HWLOC_HAVE_DARWIN
 sources += topology-darwin.c
+ldflags += $(HWLOC_DARWIN_LDFLAGS)
 endif HWLOC_HAVE_DARWIN
 
 if HWLOC_HAVE_FREEBSD

--- a/include/hwloc/cpukinds.h
+++ b/include/hwloc/cpukinds.h
@@ -53,7 +53,7 @@ extern "C" {
  *
  * When available, efficiency values are gathered from the operating system.
  * If so, \p cpukind_efficiency is set in the struct hwloc_topology_discovery_support array.
- * This is currently available on Windows 10 only.
+ * This is currently available on Windows 10 and Mac OS X (Darwin).
  *
  * If the operating system does not expose core efficiencies natively,
  * hwloc tries to compute efficiencies by comparing CPU kinds using

--- a/tests/hwloc/ports/Makefile.am
+++ b/tests/hwloc/ports/Makefile.am
@@ -66,10 +66,13 @@ libhwloc_port_bgq_la_CPPFLAGS = $(common_CPPFLAGS) \
 
 nodist_libhwloc_port_darwin_la_SOURCES = topology-darwin.c
 libhwloc_port_darwin_la_SOURCES = \
-        include/darwin/sys/sysctl.h
+        include/darwin/sys/sysctl.h \
+        include/darwin/IOKit/IOKitLib.h \
+        include/darwin/CoreFoundation/CoreFoundation.h
 libhwloc_port_darwin_la_CPPFLAGS = $(common_CPPFLAGS) \
         -I$(HWLOC_top_srcdir)/tests/hwloc/ports/include/darwin \
-        -DHWLOC_DARWIN_SYS
+        -DHWLOC_DARWIN_SYS \
+	-DHWLOC_HAVE_DARWIN_FOUNDATION -DHWLOC_HAVE_DARWIN_IOKIT
 
 nodist_libhwloc_port_freebsd_la_SOURCES = topology-freebsd.c
 libhwloc_port_freebsd_la_SOURCES = \

--- a/tests/hwloc/ports/include/darwin/CoreFoundation/CoreFoundation.h
+++ b/tests/hwloc/ports/include/darwin/CoreFoundation/CoreFoundation.h
@@ -1,0 +1,38 @@
+#ifndef HWLOC_PORT_DARWIN_COREFOUNDATION_COREFOUNDATION_H
+#define HWLOC_PORT_DARWIN_COREFOUNDATION_COREFOUNDATION_H
+
+typedef unsigned char UInt8;
+typedef long int CFIndex;
+typedef const int * CFNumberRef;
+typedef const void * CFDataRef;
+typedef const char * CFStringRef;
+typedef const void * CFTypeRef;
+
+#define CFSTR(x) (x)
+
+#define CFRangeMake(x,y) (x)
+typedef unsigned CFRange;
+
+typedef unsigned CFTypeID;
+extern CFTypeID CFGetTypeID(CFTypeRef);
+extern CFTypeID CFNumberGetTypeID(void);
+extern CFTypeID CFDataGetTypeID(void);
+
+typedef int CFNumberType;
+#define kCFNumberLongLongType 0
+extern int CFNumberGetValue(CFNumberRef, CFNumberType, void *);
+
+extern CFIndex CFDataGetLength(CFDataRef);
+extern void CFDataGetBytes(CFDataRef, CFRange, UInt8 *);
+
+typedef unsigned CFStringEncoding;
+#define kCFStringEncodingUTF8 0
+extern const char * CFStringGetCStringPtr(CFStringRef, CFStringEncoding);
+extern CFStringRef CFCopyTypeIDDescription(CFTypeID);
+
+extern void CFRelease(CFTypeRef);
+
+typedef const void * CFAllocatorRef;
+#define kCFAllocatorDefault NULL
+
+#endif /* HWLOC_PORT_DARWIN_COREFOUNDATION_COREFOUNDATION_H */

--- a/tests/hwloc/ports/include/darwin/IOKit/IOKitLib.h
+++ b/tests/hwloc/ports/include/darwin/IOKit/IOKitLib.h
@@ -1,0 +1,30 @@
+#ifndef HWLOC_PORT_DARWIN_IOKIT_IOKITLIB_H
+#define HWLOC_PORT_DARWIN_IOKIT_IOKITLIB_H
+
+#include "CoreFoundation/CoreFoundation.h"
+
+typedef int io_registry_entry_t;
+typedef int io_iterator_t;
+typedef int io_object_t;
+typedef const char io_name_t[10];
+typedef const char * io_string_t;
+
+typedef int kern_return_t;
+#define KERN_SUCCESS 0
+
+typedef int mach_port_t;
+#define kIOMasterPortDefault 0
+extern io_registry_entry_t IORegistryEntryFromPath(mach_port_t, const io_string_t);
+extern kern_return_t IOObjectRelease(io_object_t);
+
+extern kern_return_t IORegistryEntryGetChildIterator(io_registry_entry_t, const io_name_t, io_iterator_t *);
+extern io_object_t IOIteratorNext(io_iterator_t);
+
+extern kern_return_t IORegistryEntryGetNameInPlane(io_registry_entry_t, const io_name_t, io_name_t);
+
+typedef unsigned IOOptionBits;
+#define kNilOptions 0
+extern CFTypeRef IORegistryEntrySearchCFProperty(io_registry_entry_t, const io_name_t, CFStringRef, CFAllocatorRef, IOOptionBits);
+
+#endif /* HWLOC_PORT_DARWIN_IOKIT_IOKITLIB_H */
+


### PR DESCRIPTION
```
$ lstopo --cpukinds
CPU kind #0 efficiency 0 cpuset 0x0000000f
  DarwinCompatible = apple,icestorm;ARM,v8
CPU kind #1 efficiency 1 cpuset 0x000000f0
  DarwinCompatible = apple,firestorm;ARM,v8

$ utils/hwloc/hwloc-calc --cpukind 1 -N core all
4
```
