### PR TITLE
linux: use MPOL_PREFERRED_MANY when available

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,9 @@ Version 2.6.0
     high-performance cores (firestorm) on Apple M1 on Mac OS X.
   + Use sysfs CPU "capacity" to rank hybrid cores by efficiency
     on Linux when available (mostly on recent ARM platforms for now).
+  + Improve HWLOC_MEMBIND_BIND (without the STRICT flag) on Linux kernel
+    >= 5.15: If more than one node is given, the kernel may now use all
+    of them instead of only the first one before falling back to others.
 * Build
   + Allow to specify the ROCm installation for building the RSMI backend:
     - Use a custom installation path if specified with --with-rocm=<dir>.


### PR DESCRIPTION
MPOL_PREFERRED is less strict than MPOL_BIND since it falls back
to other node if the given one is full. But it works only with
a single node. Other (non-first physical index) are just ignored.

MPOL_PREFERRED_MANY in 5.15 fixes this.

Use MPOL_PREFERRED_MANY by default for membind. If it fails,
try MPOL_PREFERRED. If it works, assume MPOL_PREFERRED_MANY isn't
supported in the current kernel.

Closes #236

Signed-off-by: Brice Goglin <Brice.Goglin@inria.fr>