### PR TITLE
Windows Die and Module (and NumaNodeEx) relationships

### DIFF
--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -479,6 +479,7 @@ EOF])
                       CACHE_DESCRIPTOR,
                       LOGICAL_PROCESSOR_RELATIONSHIP,
                       RelationProcessorPackage,
+                      RelationProcessorDie,
                       GROUP_AFFINITY,
                       PROCESSOR_RELATIONSHIP,
                       NUMA_NODE_RELATIONSHIP,

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -3814,7 +3814,8 @@ hwloc currently uses Groups for the following reasons:
  but these objects are usually merged with the L3 caches or Dies.</li>
 <li>AMD Bulldozer dual-core compute units (<tt>subtype</tt> is <tt>ComputeUnit</tt>, in the x86 backend),
  but these objects are usually merged with the L2 caches.</li>
-<li>Intel Extended Topology Enumeration levels (in the x86 backend).</li>
+<li>Intel Extended Topology Enumeration levels such as Module and Tile
+ (in the x86 and Windows backends).</li>
 <li>Windows processor groups when HWLOC_WINDOWS_PROCESSOR_GROUP_OBJS=1 is set in the environment
   (except if they contain exactly a single NUMA node, or a single Package, etc.).</li>
 <li>IBM S/390 "Books" on Linux (<tt>subtype</tt> is <tt>Book</tt>).</li>

--- a/hwloc/topology-windows.c
+++ b/hwloc/topology-windows.c
@@ -56,6 +56,9 @@ typedef enum _LOGICAL_PROCESSOR_RELATIONSHIP {
   RelationCache,
   RelationProcessorPackage,
   RelationGroup,
+  RelationProcessorDie,
+  RelationNumaNodeEx, /* only used to *request* extended numa info only, but included in RelationAll, never returned on output */
+  RelationProcessorModule,
   RelationAll = 0xffff
 } LOGICAL_PROCESSOR_RELATIONSHIP;
 #else /* HAVE_LOGICAL_PROCESSOR_RELATIONSHIP */
@@ -64,6 +67,11 @@ typedef enum _LOGICAL_PROCESSOR_RELATIONSHIP {
 #    define RelationGroup 4
 #    define RelationAll 0xffff
 #  endif /* HAVE_RELATIONPROCESSORPACKAGE */
+#  ifndef HAVE_RELATIONPROCESSORDIE
+#    define RelationProcessorDie 5
+#    define RelationNumaNodeEx 6
+#    define RelationProcessorModule 7
+#  endif
 #endif /* HAVE_LOGICAL_PROCESSOR_RELATIONSHIP */
 
 #ifndef HAVE_GROUP_AFFINITY
@@ -1070,6 +1078,7 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
 
 	id = HWLOC_UNKNOWN_INDEX;
 	switch (procInfo->Relationship) {
+          case RelationNumaNodeEx: /* only used on input anyway */
 	  case RelationNumaNode:
 	    type = HWLOC_OBJ_NUMANODE;
             /* Starting with Windows 11 and Server 2022, the GroupCount field is valid and >=1
@@ -1089,9 +1098,20 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
 	    break;
 	  case RelationProcessorPackage:
 	    type = HWLOC_OBJ_PACKAGE;
+	    num = procInfo->Processor.GroupCount;
+	    GroupMask = procInfo->Processor.GroupMask;
+	    break;
+	  case RelationProcessorDie:
+            type = HWLOC_OBJ_DIE;
             num = procInfo->Processor.GroupCount;
             GroupMask = procInfo->Processor.GroupMask;
-	    break;
+            /* TODO: have the core filter-out DIE if they *ALL* are identical to packages */
+            break;
+	  case RelationProcessorModule:
+            type = HWLOC_OBJ_GROUP;
+            num = procInfo->Processor.GroupCount;
+            GroupMask = procInfo->Processor.GroupMask;
+            break;
 	  case RelationCache:
 	    type = (procInfo->Cache.Type == CacheInstruction ? HWLOC_OBJ_L1ICACHE : HWLOC_OBJ_L1CACHE) + procInfo->Cache.Level - 1;
             /* GroupCount added approximately with NumaNode.GroupCount above */
@@ -1213,6 +1233,19 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
 		continue;
 	    }
 	    break;
+          case HWLOC_OBJ_GROUP:
+            switch (procInfo[i].Relationship) {
+            case RelationGroup:
+              obj->attr->group.kind = HWLOC_GROUP_KIND_WINDOWS_PROCESSOR_GROUP;
+              break;
+            case RelationProcessorModule:
+              obj->attr->group.kind = HWLOC_GROUP_KIND_INTEL_MODULE;
+              obj->subtype = strdup("Module");
+              break;
+            default:
+              obj->attr->group.kind = HWLOC_GROUP_KIND_WINDOWS_RELATIONSHIP_UNKNOWN;
+            }
+            break;
 	  default:
 	    break;
 	}


### PR DESCRIPTION
Some future Windows release (TBD) will expose "Die" and "Module" information as well as NUMA nodes spanning mulitple processor groups. Bits are appearing in the onlie doc, we don't know all the details yet, and we don't have a way to test yet.