### PR TITLE
Support for NUMA nodes and caches spanning multiple Windows processor groups

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,8 @@ bug fixes (and other actions) for each version of hwloc since version
 Version 2.7.0
 -------------
 * Backends
+  + Add support for NUMA nodes spanning multiple processor groups
+    on recent Windows versions (NUMA nodes with more than 64 PUs).
   + Expose "Cluster" group objects on Linux kernel 5.16+ for CPUs
     that share some internal cache or bus. This can be equivalent
     to the L2 Cache level on some platforms (e.g. x86) or a specific

--- a/NEWS
+++ b/NEWS
@@ -20,7 +20,7 @@ bug fixes (and other actions) for each version of hwloc since version
 Version 2.7.0
 -------------
 * Backends
-  + Add support for NUMA nodes spanning multiple processor groups
+  + Add support for NUMA nodes and caches spanning multiple processor groups
     on recent Windows versions (NUMA nodes with more than 64 PUs).
   + Expose "Cluster" group objects on Linux kernel 5.16+ for CPUs
     that share some internal cache or bus. This can be equivalent

--- a/hwloc/topology-windows.c
+++ b/hwloc/topology-windows.c
@@ -13,6 +13,7 @@
 #include "hwloc.h"
 #include "hwloc/windows.h"
 #include "private/private.h"
+#include "private/windows.h" /* must be before windows.h */
 #include "private/debug.h"
 
 #include <windows.h>

--- a/hwloc/topology-windows.c
+++ b/hwloc/topology-windows.c
@@ -415,6 +415,8 @@ hwloc_win_get_processor_groups(void)
 
     assert(procInfo->Relationship == RelationGroup);
 
+    hwloc_debug("Found %u active windows processor groups\n",
+                (unsigned) procInfo->Group.ActiveGroupCount);
     for (id = 0; id < procInfo->Group.ActiveGroupCount; id++) {
       KAFFINITY mask;
       hwloc_bitmap_t set;
@@ -424,8 +426,8 @@ hwloc_win_get_processor_groups(void)
         goto error_with_cpusets;
 
       mask = procInfo->Group.GroupInfo[id].ActiveProcessorMask;
-      hwloc_debug("group %u %d cpus mask %lx\n", id,
-                  procInfo->Group.GroupInfo[id].ActiveProcessorCount, mask);
+      hwloc_debug("group %u with %u cpus mask 0x%llx\n", id,
+                  (unsigned) procInfo->Group.GroupInfo[id].ActiveProcessorCount, (unsigned long long) mask);
       /* KAFFINITY is ULONG_PTR */
       hwloc_bitmap_set_ith_ULONG_PTR(set, id, mask);
       /* FIXME: what if running 32bits on a 64bits windows with 64-processor groups?

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -47,6 +47,7 @@ noinst_HEADERS = \
         private/components.h \
         private/internal-components.h \
         private/cpuid-x86.h \
+        private/windows.h \
         private/netloc.h \
         netloc/utarray.h \
         netloc/uthash.h

--- a/include/private/windows.h
+++ b/include/private/windows.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2009 Université Bordeaux
+ * Copyright © 2020 Inria.  All rights reserved.
+ *
+ * See COPYING in top-level directory.
+ */
+
+#ifndef HWLOC_PRIVATE_WINDOWS_H
+#define HWLOC_PRIVATE_WINDOWS_H
+
+#ifdef __GNUC__
+#define _ANONYMOUS_UNION __extension__
+#define _ANONYMOUS_STRUCT __extension__
+#else
+#define _ANONYMOUS_UNION
+#define _ANONYMOUS_STRUCT
+#endif /* __GNUC__ */
+#define DUMMYUNIONNAME
+#define DUMMYSTRUCTNAME
+
+#endif /* HWLOC_PRIVATE_WINDOWS_H */

--- a/tests/hwloc/ports/include/windows/windows.h
+++ b/tests/hwloc/ports/include/windows/windows.h
@@ -89,15 +89,6 @@ typedef struct _SIZE {
 typedef PVOID HANDLE; */
 typedef int HANDLE;
 
-#ifdef __GNUC__
-#define _ANONYMOUS_UNION __extension__
-#define _ANONYMOUS_STRUCT __extension__
-#else
-#define _ANONYMOUS_UNION
-#define _ANONYMOUS_STRUCT
-#endif /* __GNUC__ */
-#define DUMMYUNIONNAME
-#define DUMMYSTRUCTNAME
 #define WINAPI
 
 #define ANYSIZE_ARRAY 1

--- a/utils/lstopo/lstopo-windows.c
+++ b/utils/lstopo/lstopo-windows.c
@@ -16,6 +16,8 @@
 #endif
 #include <string.h>
 
+#include "private/windows.h" /* must be before windows.h */
+
 #include <windows.h>
 #include <windowsx.h>
 


### PR DESCRIPTION
Recent windows 10 builds (and windows 11) can expose the locality of NUMA nodes and caches across multiple processor groups. Support is backward compatible, no need to wait for all users to upgrade to those recent windows releases.

There's still an issue about processor groups spanning across multiple sockets/NUMAs #497 but it's not clear if that's a Windows bug (all this Windows changes are fairly recent and documentation is not finalized yet) or if that's expected.