### PR TITLE
lstopo: improve color management and add grey and white palettes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,8 @@ Version 2.7.0
     Thanks to Jonathan Cameron for the help.
     - HWLOC_DONT_MERGE_CLUSTER_GROUPS=1 may be set in the environment
       to prevent these groups from being merged with identical caches, etc.
+* Tools
+  + Add --grey option to switch lstopo to greyscale graphics.
 
 
 Version 2.6.0

--- a/NEWS
+++ b/NEWS
@@ -31,7 +31,7 @@ Version 2.7.0
       to prevent these groups from being merged with identical caches, etc.
 * Tools
   + Add --grey and --palette options to switch lstopo to greyscale or
-    white-background-only graphics.
+    white-background-only graphics, or to tune individual colors.
 
 
 Version 2.6.0

--- a/NEWS
+++ b/NEWS
@@ -30,7 +30,8 @@ Version 2.7.0
     - HWLOC_DONT_MERGE_CLUSTER_GROUPS=1 may be set in the environment
       to prevent these groups from being merged with identical caches, etc.
 * Tools
-  + Add --grey option to switch lstopo to greyscale graphics.
+  + Add --grey and --palette options to switch lstopo to greyscale or
+    white-background-only graphics.
 
 
 Version 2.6.0

--- a/contrib/completion/bash/hwloc
+++ b/contrib/completion/bash/hwloc
@@ -69,6 +69,8 @@ _lstopo() {
 		   --no-legend
 		   --no-default-legend
 		   --append-legend
+		   --grey --greyscale
+		   --palette
 		   --binding-color
 		   --disallowed-color
 		   --top-color
@@ -125,6 +127,9 @@ _lstopo() {
 		;;
 	    --append-legend)
 		COMPREPLY=( "<line of text>" "" )
+		;;
+	    --palette)
+		COMPREPLY=( `compgen -W "grey" "greyscale" "default" "colors" -- "$cur"` )
 		;;
 	    --binding-color | --disallowed-color)
 		COMPREPLY=( `compgen -W "none" -- "$cur"` )

--- a/contrib/completion/bash/hwloc
+++ b/contrib/completion/bash/hwloc
@@ -131,11 +131,8 @@ _lstopo() {
 	    --palette)
 		COMPREPLY=( `compgen -W "grey" "greyscale" "default" "colors" "white" "none" -- "$cur"` )
 		;;
-	    --binding-color | --disallowed-color)
-		COMPREPLY=( `compgen -W "none" -- "$cur"` )
-		;;
-	    --top-color)
-		COMPREPLY=( `compgen -W "none <#xxyyzz>" -- "$cur"` )
+	    --binding-color | --disallowed-color | --top-color)
+		COMPREPLY=( `compgen -W "none <#rrggbb>" -- "$cur"` )
 		;;
 	    --children-order)
 		COMPREPLY=( `compgen -W "plain memoryabove" -- "$cur"` )

--- a/contrib/completion/bash/hwloc
+++ b/contrib/completion/bash/hwloc
@@ -129,7 +129,7 @@ _lstopo() {
 		COMPREPLY=( "<line of text>" "" )
 		;;
 	    --palette)
-		COMPREPLY=( `compgen -W "grey" "greyscale" "default" "colors" -- "$cur"` )
+		COMPREPLY=( `compgen -W "grey" "greyscale" "default" "colors" "white" "none" -- "$cur"` )
 		;;
 	    --binding-color | --disallowed-color)
 		COMPREPLY=( `compgen -W "none" -- "$cur"` )

--- a/utils/lstopo/lstopo-android.c
+++ b/utils/lstopo/lstopo-android.c
@@ -45,7 +45,7 @@ static void native_android_box(struct lstopo_output *loutput, const struct lstop
 
 
 static void
-native_android_line(struct lstopo_output *loutput __hwloc_attribute_unused, const struct lstopo_color *lcolor __hwloc_attribute_unused, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
+native_android_line(struct lstopo_output *loutput __hwloc_attribute_unused, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
 {
     JNIline(x1, y1, x2, y2);
 }

--- a/utils/lstopo/lstopo-ascii.c
+++ b/utils/lstopo/lstopo-ascii.c
@@ -349,7 +349,7 @@ ascii_box(struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsi
 }
 
 static void
-ascii_line(struct lstopo_output *loutput, const struct lstopo_color *lcolor __hwloc_attribute_unused, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
+ascii_line(struct lstopo_output *loutput, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
 {
   struct lstopo_ascii_output *disp = loutput->backend_data;
   unsigned i, j, z;

--- a/utils/lstopo/lstopo-cairo.c
+++ b/utils/lstopo/lstopo-cairo.c
@@ -90,14 +90,13 @@ topo_cairo_box(struct lstopo_output *loutput, const struct lstopo_color *lcolor,
 }
 
 static void
-topo_cairo_line(struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
+topo_cairo_line(struct lstopo_output *loutput, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
 {
   struct lstopo_cairo_output *coutput = loutput->backend_data;
   cairo_t *c = coutput->context;
-  int r = lcolor->r, g = lcolor->g, b = lcolor->b;
 
   cairo_move_to(c, x1, y1);
-  cairo_set_source_rgb(c, (float) r / 255, (float) g / 255, (float) b / 255);
+  cairo_set_source_rgb(c, 0, 0, 0);
   cairo_line_to(c, x2, y2);
   cairo_stroke(c);
 }

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -46,6 +46,7 @@ struct lstopo_color DISALLOWED_COLOR = { 0xff, 0, 0, 0 };
 struct lstopo_color CACHE_COLOR = { 0xff, 0xff, 0xff, 0 };
 struct lstopo_color MACHINE_COLOR = { 0xff, 0xff, 0xff, 0 };
 struct lstopo_color GROUP_IN_PACKAGE_COLOR = { EPOXY_R_COLOR, EPOXY_G_COLOR, EPOXY_B_COLOR, 0 };
+struct lstopo_color GROUP_COLOR = { 0xff, 0xff, 0xff, 0 };
 struct lstopo_color MISC_COLOR = { 0xff, 0xff, 0xff, 0 };
 struct lstopo_color PCI_DEVICE_COLOR = { DARKER_EPOXY_R_COLOR, DARKER_EPOXY_G_COLOR, DARKER_EPOXY_B_COLOR, 0 };
 struct lstopo_color OS_DEVICE_COLOR = { 0xde, 0xde, 0xde, 0 };
@@ -94,6 +95,7 @@ declare_colors(struct lstopo_output *output)
   declare_color(output, &CACHE_COLOR);
   declare_color(output, &MACHINE_COLOR);
   declare_color(output, &GROUP_IN_PACKAGE_COLOR);
+  declare_color(output, &GROUP_COLOR);
   declare_color(output, &MISC_COLOR);
   declare_color(output, &PCI_DEVICE_COLOR);
   declare_color(output, &OS_DEVICE_COLOR);
@@ -1001,7 +1003,7 @@ lstopo_set_object_color(struct lstopo_output *loutput,
 
   case HWLOC_OBJ_GROUP: {
     hwloc_obj_t parent;
-    s->bg = &MISC_COLOR;
+    s->bg = &GROUP_COLOR;
     parent = obj->parent;
     while (parent) {
       if (parent->type == HWLOC_OBJ_PACKAGE) {

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -54,7 +54,7 @@ struct lstopo_color BRIDGE_COLOR = { 0xff, 0xff, 0xff, 0 };
 #pragma GCC diagnostic warning "-Wmissing-field-initializers"
 #endif
 
-static struct lstopo_color *colors = NULL;
+static struct lstopo_color *color_list = NULL;
 
 static struct lstopo_color *
 declare_color(struct lstopo_output *loutput, struct lstopo_color *color)
@@ -69,8 +69,8 @@ declare_color(struct lstopo_output *loutput, struct lstopo_color *color)
   }
 
   /* insert */
-  color->next = colors;
-  colors = color;
+  color->next = color_list;
+  color_list = color;
 
   return color;
 }
@@ -103,7 +103,7 @@ declare_colors(struct lstopo_output *output)
 void
 destroy_colors(struct lstopo_output *loutput)
 {
-  struct lstopo_color *tmp = colors;
+  struct lstopo_color *tmp = color_list;
 
   while (tmp) {
     struct lstopo_color *next = tmp->next;
@@ -115,7 +115,7 @@ destroy_colors(struct lstopo_output *loutput)
     tmp = next;
   }
 
-  colors = NULL; /* so that it works after refresh */
+  color_list = NULL; /* so that it works after refresh */
 }
 
 static struct lstopo_color *
@@ -123,7 +123,7 @@ find_or_declare_rgb_color(struct lstopo_output *loutput, int r, int g, int b)
 {
   struct lstopo_color *color, *tmp;
 
-  for(tmp = colors; tmp; tmp = tmp->next)
+  for(tmp = color_list; tmp; tmp = tmp->next)
     if (tmp->r == r && tmp->g == g && tmp->b == b)
       return tmp;
 

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -46,7 +46,7 @@
 #define DARKER_EPOXY_GREY_COLOR ((DARK_EPOXY_GREY_COLOR * 100) / 110)
 #define RGB_GREY_DARKER_EPOXY RGB_GREY(DARKER_EPOXY_GREY_COLOR)
 
-struct lstopo_color_palette lstopo_main_palette, lstopo_grey_palette;
+struct lstopo_color_palette lstopo_main_palette, lstopo_grey_palette, lstopo_white_palette;
 
 void
 lstopo_palette_init(struct lstopo_output *loutput)
@@ -85,6 +85,25 @@ lstopo_palette_init(struct lstopo_output *loutput)
   lstopo_grey_palette.binding =          RGB_GREY(0xbb);
   lstopo_grey_palette.disallowed =       RGB_GREY(0x77);
 
+  memcpy(&lstopo_white_palette, &lstopo_main_palette, sizeof(lstopo_main_palette));
+  /* replace everything but white/black with white */
+  lstopo_white_palette.machine =          RGB_WHITE;
+  lstopo_white_palette.group =            RGB_WHITE;
+  lstopo_white_palette.package =          RGB_WHITE;
+  lstopo_white_palette.group_in_package = RGB_WHITE;
+  lstopo_white_palette.die =              RGB_WHITE;
+  lstopo_white_palette.core =             RGB_WHITE;
+  lstopo_white_palette.pu =               RGB_WHITE;
+  lstopo_white_palette.numanode =         RGB_WHITE;
+  lstopo_white_palette.memories =         RGB_WHITE;
+  lstopo_white_palette.cache =            RGB_WHITE;
+  lstopo_white_palette.pcidev =           RGB_WHITE;
+  lstopo_white_palette.osdev =            RGB_WHITE;
+  lstopo_white_palette.bridge =           RGB_WHITE;
+  lstopo_white_palette.misc =             RGB_WHITE;
+  lstopo_white_palette.binding =          RGB_WHITE;
+  lstopo_white_palette.disallowed =       RGB_WHITE;
+
 #ifdef HWLOC_HAVE_GCC_W_MISSING_FIELD_INITIALIZERS
 #pragma GCC diagnostic warning "-Wmissing-field-initializers"
 #endif
@@ -100,6 +119,8 @@ lstopo_palette_select(struct lstopo_output *loutput, const char *name)
     loutput->palette = &lstopo_grey_palette;
   else if (!strcmp(name, "colors") || !strcmp(name, "default"))
     loutput->palette = &lstopo_main_palette;
+  else if (!strcmp(name, "white") || !strcmp(name, "none"))
+    loutput->palette = &lstopo_white_palette;
   else
     fprintf(stderr, "Unrecognized palette name `%s', ignoring\n", name);
 }

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -136,6 +136,42 @@ lstopo_palette_set_color(struct lstopo_color *color, unsigned rrggbb)
   color->b = (rrggbb >>  0) & 0xff;
 }
 
+void
+lstopo_palette_set_color_by_name(struct lstopo_output *loutput, const char *name, unsigned rrggbb)
+{
+  if (!strcasecmp(name, "machine"))
+    lstopo_palette_set_color(&loutput->palette->machine, rrggbb);
+  else if (!strcasecmp(name, "group"))
+    lstopo_palette_set_color(&loutput->palette->group, rrggbb);
+  else if (!strcasecmp(name, "package"))
+    lstopo_palette_set_color(&loutput->palette->package, rrggbb);
+  else if (!strcasecmp(name, "group_in_package"))
+    lstopo_palette_set_color(&loutput->palette->group_in_package, rrggbb);
+  else if (!strcasecmp(name, "die"))
+    lstopo_palette_set_color(&loutput->palette->die, rrggbb);
+  else if (!strcasecmp(name, "core"))
+    lstopo_palette_set_color(&loutput->palette->core, rrggbb);
+  else if (!strcasecmp(name, "pu"))
+    lstopo_palette_set_color(&loutput->palette->pu, rrggbb);
+  else if (!strcasecmp(name, "numanode"))
+    lstopo_palette_set_color(&loutput->palette->numanode, rrggbb);
+  else if (!strcasecmp(name, "memories"))
+    lstopo_palette_set_color(&loutput->palette->memories, rrggbb);
+  else if (!strcasecmp(name, "cache"))
+    lstopo_palette_set_color(&loutput->palette->cache, rrggbb);
+  else if (!strcasecmp(name, "pcidev"))
+    lstopo_palette_set_color(&loutput->palette->pcidev, rrggbb);
+  else if (!strcasecmp(name, "osdev"))
+    lstopo_palette_set_color(&loutput->palette->osdev, rrggbb);
+  else if (!strcasecmp(name, "bridge"))
+    lstopo_palette_set_color(&loutput->palette->bridge, rrggbb);
+  else if (!strcasecmp(name, "misc"))
+    lstopo_palette_set_color(&loutput->palette->misc, rrggbb);
+  else
+    fprintf(stderr, "Unrecognized palette color name `%s', ignoring\n", name);
+  /* binding/disallowed/process are handled by --binding/disallowed/top-color */
+}
+
 static struct lstopo_color *color_list = NULL;
 
 static struct lstopo_color *

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -125,6 +125,13 @@ lstopo_palette_select(struct lstopo_output *loutput, const char *name)
     fprintf(stderr, "Unrecognized palette name `%s', ignoring\n", name);
 }
 
+void
+lstopo_palette_set_color(struct lstopo_color *color, unsigned rrggbb)
+{
+  color->r = (rrggbb >> 16) & 0xff;
+  color->g = (rrggbb >>  8) & 0xff;
+  color->b = (rrggbb >>  0) & 0xff;
+}
 
 static struct lstopo_color *color_list = NULL;
 

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -988,7 +988,8 @@ lstopo_set_object_color(struct lstopo_output *loutput,
 {
   struct lstopo_obj_userdata *lud = obj->userdata;
 
-  s->bg = &BLACK_COLOR;
+  /* defaults */
+  s->bg = &WHITE_COLOR; /* always overwritten below */
   s->t = &BLACK_COLOR;
   s->t2 = &BLACK_COLOR;
 

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -27,17 +27,26 @@
 #define EPOXY_B_COLOR 0xb5
 #define RGB_EPOXY RGB(EPOXY_R_COLOR, EPOXY_G_COLOR, EPOXY_B_COLOR)
 
+#define EPOXY_GREY_COLOR ((EPOXY_R_COLOR+EPOXY_G_COLOR+EPOXY_B_COLOR)/3)
+#define RGB_GREY_EPOXY RGB_GREY(EPOXY_GREY_COLOR)
+
 #define DARK_EPOXY_R_COLOR ((EPOXY_R_COLOR * 100) / 110)
 #define DARK_EPOXY_G_COLOR ((EPOXY_G_COLOR * 100) / 110)
 #define DARK_EPOXY_B_COLOR ((EPOXY_B_COLOR * 100) / 110)
 #define RGB_DARK_EPOXY RGB(DARK_EPOXY_R_COLOR, DARK_EPOXY_G_COLOR, DARK_EPOXY_B_COLOR)
+
+#define DARK_EPOXY_GREY_COLOR ((EPOXY_GREY_COLOR * 100) / 110)
+#define RGB_GREY_DARK_EPOXY RGB_GREY(DARK_EPOXY_GREY_COLOR)
 
 #define DARKER_EPOXY_R_COLOR ((DARK_EPOXY_R_COLOR * 100) / 110)
 #define DARKER_EPOXY_G_COLOR ((DARK_EPOXY_G_COLOR * 100) / 110)
 #define DARKER_EPOXY_B_COLOR ((DARK_EPOXY_B_COLOR * 100) / 110)
 #define RGB_DARKER_EPOXY RGB(DARKER_EPOXY_R_COLOR, DARKER_EPOXY_G_COLOR, DARKER_EPOXY_B_COLOR)
 
-struct lstopo_color_palette lstopo_main_palette;
+#define DARKER_EPOXY_GREY_COLOR ((DARK_EPOXY_GREY_COLOR * 100) / 110)
+#define RGB_GREY_DARKER_EPOXY RGB_GREY(DARKER_EPOXY_GREY_COLOR)
+
+struct lstopo_color_palette lstopo_main_palette, lstopo_grey_palette;
 
 void
 lstopo_palette_init(struct lstopo_output *loutput)
@@ -65,11 +74,34 @@ lstopo_palette_init(struct lstopo_output *loutput)
   lstopo_main_palette.binding =          RGB(0, 0xff, 0); /* green */
   lstopo_main_palette.disallowed =       RGB(0xff, 0, 0); /* red */
 
+  memcpy(&lstopo_grey_palette, &lstopo_main_palette, sizeof(lstopo_main_palette));
+  /* replace non-grey colors by some grey */
+  lstopo_grey_palette.package =          RGB_GREY_DARK_EPOXY;
+  lstopo_grey_palette.group_in_package = RGB_GREY_EPOXY;
+  lstopo_grey_palette.die =              RGB_GREY_EPOXY;
+  lstopo_grey_palette.numanode =         RGB_GREY(0xe4);
+  lstopo_grey_palette.memories =         RGB_GREY(0xe8); /* slightly lighter than numanode */
+  lstopo_grey_palette.pcidev =           RGB_GREY_DARKER_EPOXY;
+  lstopo_grey_palette.binding =          RGB_GREY(0xbb);
+  lstopo_grey_palette.disallowed =       RGB_GREY(0x77);
+
 #ifdef HWLOC_HAVE_GCC_W_MISSING_FIELD_INITIALIZERS
 #pragma GCC diagnostic warning "-Wmissing-field-initializers"
 #endif
 
+  /* use the color palette by default */
   loutput->palette = &lstopo_main_palette;
+}
+
+void
+lstopo_palette_select(struct lstopo_output *loutput, const char *name)
+{
+  if (!strcmp(name, "grey") || !strcmp(name, "greyscale"))
+    loutput->palette = &lstopo_grey_palette;
+  else if (!strcmp(name, "colors") || !strcmp(name, "default"))
+    loutput->palette = &lstopo_main_palette;
+  else
+    fprintf(stderr, "Unrecognized palette name `%s', ignoring\n", name);
 }
 
 

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -17,43 +17,61 @@
 
 #include "lstopo.h"
 
+#define RGB(r,g,b) (struct lstopo_color) { r, g, b, 0 }
+#define RGB_GREY(x) (struct lstopo_color) { x, x, x, 0 }
+#define RGB_WHITE RGB_GREY(0xff)
+#define RGB_BLACK RGB_GREY(0)
+
 #define EPOXY_R_COLOR 0xe7
 #define EPOXY_G_COLOR 0xff
 #define EPOXY_B_COLOR 0xb5
+#define RGB_EPOXY RGB(EPOXY_R_COLOR, EPOXY_G_COLOR, EPOXY_B_COLOR)
 
 #define DARK_EPOXY_R_COLOR ((EPOXY_R_COLOR * 100) / 110)
 #define DARK_EPOXY_G_COLOR ((EPOXY_G_COLOR * 100) / 110)
 #define DARK_EPOXY_B_COLOR ((EPOXY_B_COLOR * 100) / 110)
+#define RGB_DARK_EPOXY RGB(DARK_EPOXY_R_COLOR, DARK_EPOXY_G_COLOR, DARK_EPOXY_B_COLOR)
 
 #define DARKER_EPOXY_R_COLOR ((DARK_EPOXY_R_COLOR * 100) / 110)
 #define DARKER_EPOXY_G_COLOR ((DARK_EPOXY_G_COLOR * 100) / 110)
 #define DARKER_EPOXY_B_COLOR ((DARK_EPOXY_B_COLOR * 100) / 110)
+#define RGB_DARKER_EPOXY RGB(DARKER_EPOXY_R_COLOR, DARKER_EPOXY_G_COLOR, DARKER_EPOXY_B_COLOR)
 
+struct lstopo_color_palette lstopo_main_palette;
+
+void
+lstopo_palette_init(struct lstopo_output *loutput)
+{
 #ifdef HWLOC_HAVE_GCC_W_MISSING_FIELD_INITIALIZERS
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
-/* each of these colors must be declared in declare_colors() */
-struct lstopo_color BLACK_COLOR = { 0, 0, 0, 0 };
-struct lstopo_color WHITE_COLOR = { 0xff, 0xff, 0xff, 0 };
-struct lstopo_color PACKAGE_COLOR = { DARK_EPOXY_R_COLOR, DARK_EPOXY_G_COLOR, DARK_EPOXY_B_COLOR, 0 };
-struct lstopo_color DIE_COLOR = { EPOXY_R_COLOR, EPOXY_G_COLOR, EPOXY_B_COLOR, 0 };
-struct lstopo_color MEMORY_COLOR = { 0xef, 0xdf, 0xde, 0 };
-struct lstopo_color MEMORIES_COLOR = { 0xf2, 0xe8, 0xe8, 0}; /* slightly lighter than MEMORY_COLOR */
-struct lstopo_color CORE_COLOR = { 0xbe, 0xbe, 0xbe, 0 };
-struct lstopo_color THREAD_COLOR = { 0xff, 0xff, 0xff, 0 };
-struct lstopo_color BINDING_COLOR = { 0, 0xff, 0, 0 };
-struct lstopo_color DISALLOWED_COLOR = { 0xff, 0, 0, 0 };
-struct lstopo_color CACHE_COLOR = { 0xff, 0xff, 0xff, 0 };
-struct lstopo_color MACHINE_COLOR = { 0xff, 0xff, 0xff, 0 };
-struct lstopo_color GROUP_IN_PACKAGE_COLOR = { EPOXY_R_COLOR, EPOXY_G_COLOR, EPOXY_B_COLOR, 0 };
-struct lstopo_color GROUP_COLOR = { 0xff, 0xff, 0xff, 0 };
-struct lstopo_color MISC_COLOR = { 0xff, 0xff, 0xff, 0 };
-struct lstopo_color PCI_DEVICE_COLOR = { DARKER_EPOXY_R_COLOR, DARKER_EPOXY_G_COLOR, DARKER_EPOXY_B_COLOR, 0 };
-struct lstopo_color OS_DEVICE_COLOR = { 0xde, 0xde, 0xde, 0 };
-struct lstopo_color BRIDGE_COLOR = { 0xff, 0xff, 0xff, 0 };
+  /* each of these colors must be declared in declare_colors() */
+  lstopo_main_palette.white =            RGB_WHITE;
+  lstopo_main_palette.black =            RGB_BLACK;
+  lstopo_main_palette.machine =          RGB_WHITE;
+  lstopo_main_palette.group =            RGB_WHITE;
+  lstopo_main_palette.package =          RGB_DARK_EPOXY;
+  lstopo_main_palette.group_in_package = RGB_EPOXY;
+  lstopo_main_palette.die =              RGB_EPOXY;
+  lstopo_main_palette.core =             RGB_GREY(0xbe);
+  lstopo_main_palette.pu =               RGB_WHITE;
+  lstopo_main_palette.numanode =         RGB(0xef, 0xdf, 0xde);
+  lstopo_main_palette.memories =         RGB(0xf2, 0xe8, 0xe8); /* slightly lighter than numanode */
+  lstopo_main_palette.cache =            RGB_WHITE;
+  lstopo_main_palette.pcidev =           RGB_DARKER_EPOXY;
+  lstopo_main_palette.osdev =            RGB_GREY(0xde);
+  lstopo_main_palette.bridge =           RGB_WHITE;
+  lstopo_main_palette.misc =             RGB_WHITE;
+  lstopo_main_palette.binding =          RGB(0, 0xff, 0); /* green */
+  lstopo_main_palette.disallowed =       RGB(0xff, 0, 0); /* red */
+
 #ifdef HWLOC_HAVE_GCC_W_MISSING_FIELD_INITIALIZERS
 #pragma GCC diagnostic warning "-Wmissing-field-initializers"
 #endif
+
+  loutput->palette = &lstopo_main_palette;
+}
+
 
 static struct lstopo_color *color_list = NULL;
 
@@ -82,24 +100,24 @@ declare_colors(struct lstopo_output *output)
   /* don't bother looking for duplicate colors here,
    * we want to be able to use those structs so always queue them
    */
-  declare_color(output, &BLACK_COLOR);
-  declare_color(output, &WHITE_COLOR);
-  declare_color(output, &PACKAGE_COLOR);
-  declare_color(output, &DIE_COLOR);
-  declare_color(output, &MEMORY_COLOR);
-  declare_color(output, &MEMORIES_COLOR);
-  declare_color(output, &CORE_COLOR);
-  declare_color(output, &THREAD_COLOR);
-  declare_color(output, &BINDING_COLOR);
-  declare_color(output, &DISALLOWED_COLOR);
-  declare_color(output, &CACHE_COLOR);
-  declare_color(output, &MACHINE_COLOR);
-  declare_color(output, &GROUP_IN_PACKAGE_COLOR);
-  declare_color(output, &GROUP_COLOR);
-  declare_color(output, &MISC_COLOR);
-  declare_color(output, &PCI_DEVICE_COLOR);
-  declare_color(output, &OS_DEVICE_COLOR);
-  declare_color(output, &BRIDGE_COLOR);
+  declare_color(output, &output->palette->white);
+  declare_color(output, &output->palette->black);
+  declare_color(output, &output->palette->machine);
+  declare_color(output, &output->palette->group);
+  declare_color(output, &output->palette->package);
+  declare_color(output, &output->palette->group_in_package);
+  declare_color(output, &output->palette->die);
+  declare_color(output, &output->palette->core);
+  declare_color(output, &output->palette->pu);
+  declare_color(output, &output->palette->numanode);
+  declare_color(output, &output->palette->memories);
+  declare_color(output, &output->palette->cache);
+  declare_color(output, &output->palette->pcidev);
+  declare_color(output, &output->palette->osdev);
+  declare_color(output, &output->palette->bridge);
+  declare_color(output, &output->palette->misc);
+  declare_color(output, &output->palette->binding);
+  declare_color(output, &output->palette->disallowed);
 }
 
 void
@@ -691,7 +709,7 @@ place_children(struct lstopo_output *loutput, hwloc_obj_t parent,
       if (above_children_width < children_width) {
 	above_children_width = mrb_children_width;
       }
-      plud->above_children.boxcolor = &MEMORIES_COLOR;
+      plud->above_children.boxcolor = &loutput->palette->memories;
       plud->above_children.box = 1;
 
     } else {
@@ -943,7 +961,7 @@ lstopo__prepare_custom_styles(struct lstopo_output *loutput, hwloc_obj_t obj)
 	  s->bg = lcolor;
 	  lud->style_set |= LSTOPO_STYLE_BG;
 	  if (!(lud->style_set & LSTOPO_STYLE_T)) {
-	    s->t = (lcolor->r + lcolor->g + lcolor->b < 0xff) ? &WHITE_COLOR : &BLACK_COLOR;
+	    s->t = (lcolor->r + lcolor->g + lcolor->b < 0xff) ? &loutput->palette->white : &loutput->palette->black;
 	    lud->style_set |= LSTOPO_STYLE_T;
 	  }
 	}
@@ -991,23 +1009,23 @@ lstopo_set_object_color(struct lstopo_output *loutput,
   struct lstopo_obj_userdata *lud = obj->userdata;
 
   /* defaults */
-  s->bg = &WHITE_COLOR; /* always overwritten below */
-  s->t = &BLACK_COLOR;
-  s->t2 = &BLACK_COLOR;
+  s->bg = &loutput->palette->white; /* always overwritten below */
+  s->t = &loutput->palette->black;
+  s->t2 = &loutput->palette->black;
 
   switch (obj->type) {
 
   case HWLOC_OBJ_MACHINE:
-    s->bg = &MACHINE_COLOR;
+    s->bg = &loutput->palette->machine;
     break;
 
   case HWLOC_OBJ_GROUP: {
     hwloc_obj_t parent;
-    s->bg = &GROUP_COLOR;
+    s->bg = &loutput->palette->group;
     parent = obj->parent;
     while (parent) {
       if (parent->type == HWLOC_OBJ_PACKAGE) {
-	s->bg = &GROUP_IN_PACKAGE_COLOR;
+	s->bg = &loutput->palette->group_in_package;
 	break;
       }
       parent = parent->parent;
@@ -1016,29 +1034,29 @@ lstopo_set_object_color(struct lstopo_output *loutput,
   }
 
   case HWLOC_OBJ_MISC:
-    s->bg = &MISC_COLOR;
+    s->bg = &loutput->palette->misc;
     break;
 
   case HWLOC_OBJ_NUMANODE:
     if (loutput->show_disallowed && lstopo_numa_disallowed(loutput, obj)) {
-      s->bg = &DISALLOWED_COLOR;
+      s->bg = &loutput->palette->disallowed;
     } else if (loutput->show_binding && lstopo_numa_binding(loutput, obj)) {
-      s->bg = &BINDING_COLOR;
+      s->bg = &loutput->palette->binding;
     } else {
-      s->bg = &MEMORY_COLOR;
+      s->bg = &loutput->palette->numanode;
     }
     break;
 
   case HWLOC_OBJ_PACKAGE:
-    s->bg = &PACKAGE_COLOR;
+    s->bg = &loutput->palette->package;
     break;
 
   case HWLOC_OBJ_DIE:
-    s->bg = &DIE_COLOR;
+    s->bg = &loutput->palette->die;
     break;
 
   case HWLOC_OBJ_CORE:
-    s->bg = &CORE_COLOR;
+    s->bg = &loutput->palette->core;
     break;
 
   case HWLOC_OBJ_L1CACHE:
@@ -1050,29 +1068,29 @@ lstopo_set_object_color(struct lstopo_output *loutput,
   case HWLOC_OBJ_L2ICACHE:
   case HWLOC_OBJ_L3ICACHE:
   case HWLOC_OBJ_MEMCACHE:
-    s->bg = &CACHE_COLOR;
+    s->bg = &loutput->palette->cache;
     break;
 
   case HWLOC_OBJ_PU:
     if (loutput->show_disallowed && lstopo_pu_disallowed(loutput, obj)) {
-      s->bg = &DISALLOWED_COLOR;
+      s->bg = &loutput->palette->disallowed;
     } else if (loutput->show_binding && lstopo_pu_binding(loutput, obj)) {
-      s->bg = &BINDING_COLOR;
+      s->bg = &loutput->palette->binding;
     } else {
-      s->bg = &THREAD_COLOR;
+      s->bg = &loutput->palette->pu;
     }
     break;
 
   case HWLOC_OBJ_BRIDGE:
-    s->bg = &BRIDGE_COLOR;
+    s->bg = &loutput->palette->bridge;
     break;
 
   case HWLOC_OBJ_PCI_DEVICE:
-    s->bg = &PCI_DEVICE_COLOR;
+    s->bg = &loutput->palette->pcidev;
     break;
 
   case HWLOC_OBJ_OS_DEVICE:
-    s->bg = &OS_DEVICE_COLOR;
+    s->bg = &loutput->palette->osdev;
     break;
 
   default:
@@ -1703,7 +1721,7 @@ output_draw(struct lstopo_output *loutput)
     if (loutput->show_legend != LSTOPO_SHOW_LEGEND_NONE
         && (loutput->legend_default_lines_nr + loutput->legend_info_lines_nr + loutput->legend_append_nr)) {
       offset = rlud->height + gridsize;
-      methods->box(loutput, &WHITE_COLOR, depth,
+      methods->box(loutput, &loutput->palette->white, depth,
                    0,
                    loutput->width,
                    totheight,
@@ -1712,16 +1730,16 @@ output_draw(struct lstopo_output *loutput)
                    + fontsize + gridsize,
                    NULL, 0);
       for(i=0; i<loutput->legend_default_lines_nr; i++, offset += linespacing + fontsize)
-	methods->text(loutput, &BLACK_COLOR, fontsize, depth, gridsize, offset, loutput->legend_default_lines[i], NULL, i);
+	methods->text(loutput, &loutput->palette->black, fontsize, depth, gridsize, offset, loutput->legend_default_lines[i], NULL, i);
       for(i=0, j=0; i<root->infos_count; i++) {
         if (!strcmp(root->infos[i].name, "lstopoLegend")) {
-          methods->text(loutput, &BLACK_COLOR, fontsize, depth, gridsize, offset, root->infos[i].value, NULL, j+loutput->legend_default_lines_nr);
+          methods->text(loutput, &loutput->palette->black, fontsize, depth, gridsize, offset, root->infos[i].value, NULL, j+loutput->legend_default_lines_nr);
           j++;
           offset += linespacing + fontsize;
         }
       }
       for(i=0; i<loutput->legend_append_nr; i++, offset += linespacing + fontsize)
-	methods->text(loutput, &BLACK_COLOR, fontsize, depth, gridsize, offset, loutput->legend_append[i], NULL, i+loutput->legend_default_lines_nr+loutput->legend_info_lines_nr);
+	methods->text(loutput, &loutput->palette->black, fontsize, depth, gridsize, offset, loutput->legend_append[i], NULL, i+loutput->legend_default_lines_nr+loutput->legend_info_lines_nr);
     }
   }
 }

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -73,6 +73,7 @@ lstopo_palette_init(struct lstopo_output *loutput)
   lstopo_main_palette.misc =             RGB_WHITE;
   lstopo_main_palette.binding =          RGB(0, 0xff, 0); /* green */
   lstopo_main_palette.disallowed =       RGB(0xff, 0, 0); /* red */
+  lstopo_main_palette.process =          RGB(0xff, 0xff, 0); /* yellow */
 
   memcpy(&lstopo_grey_palette, &lstopo_main_palette, sizeof(lstopo_main_palette));
   /* replace non-grey colors by some grey */
@@ -84,6 +85,7 @@ lstopo_palette_init(struct lstopo_output *loutput)
   lstopo_grey_palette.pcidev =           RGB_GREY_DARKER_EPOXY;
   lstopo_grey_palette.binding =          RGB_GREY(0xbb);
   lstopo_grey_palette.disallowed =       RGB_GREY(0x77);
+  lstopo_grey_palette.process =          RGB_GREY(0x99);
 
   memcpy(&lstopo_white_palette, &lstopo_main_palette, sizeof(lstopo_main_palette));
   /* replace everything but white/black with white */
@@ -103,6 +105,7 @@ lstopo_palette_init(struct lstopo_output *loutput)
   lstopo_white_palette.misc =             RGB_WHITE;
   lstopo_white_palette.binding =          RGB_WHITE;
   lstopo_white_palette.disallowed =       RGB_WHITE;
+  lstopo_white_palette.process =          RGB_WHITE;
 
 #ifdef HWLOC_HAVE_GCC_W_MISSING_FIELD_INITIALIZERS
 #pragma GCC diagnostic warning "-Wmissing-field-initializers"
@@ -178,6 +181,7 @@ declare_colors(struct lstopo_output *output)
   declare_color(output, &output->palette->misc);
   declare_color(output, &output->palette->binding);
   declare_color(output, &output->palette->disallowed);
+  declare_color(output, &output->palette->process);
 }
 
 void
@@ -1094,7 +1098,10 @@ lstopo_set_object_color(struct lstopo_output *loutput,
   }
 
   case HWLOC_OBJ_MISC:
-    s->bg = &loutput->palette->misc;
+    if (loutput->show_process_color && obj->subtype && !strcmp(obj->subtype, "Process"))
+      s->bg = &loutput->palette->process;
+    else
+      s->bg = &loutput->palette->misc;
     break;
 
   case HWLOC_OBJ_NUMANODE:

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -1313,7 +1313,7 @@ bridge_draw(struct lstopo_output *loutput, hwloc_obj_t level, unsigned depth, un
     /* Square and left link */
     lstopo_set_object_color(loutput, level, &style);
     methods->box(loutput, style.bg, depth, x, gridsize, y + BRIDGE_HEIGHT/2 - gridsize/2, gridsize, level, 0);
-    methods->line(loutput, &BLACK_COLOR, depth, x + gridsize, y + BRIDGE_HEIGHT/2, x + 2*gridsize, y + BRIDGE_HEIGHT/2, level, 0);
+    methods->line(loutput, depth, x + gridsize, y + BRIDGE_HEIGHT/2, x + 2*gridsize, y + BRIDGE_HEIGHT/2, level, 0);
 
     if (level->io_arity > 0) {
       hwloc_obj_t child = NULL;
@@ -1325,7 +1325,7 @@ bridge_draw(struct lstopo_output *loutput, hwloc_obj_t level, unsigned depth, un
 	struct lstopo_obj_userdata *clud = child->userdata;
 	unsigned ymid = y + clud->yrel + BRIDGE_HEIGHT/2;
 	/* Line to PCI device */
-	methods->line(loutput, &BLACK_COLOR, depth-1, x+2*gridsize, ymid, x+3*gridsize+speedwidth, ymid, level, i+2);
+	methods->line(loutput, depth-1, x+2*gridsize, ymid, x+3*gridsize+speedwidth, ymid, level, i+2);
 	if (ymin == (unsigned) -1)
 	  ymin = ymid;
 	ymax = ymid;
@@ -1343,7 +1343,7 @@ bridge_draw(struct lstopo_output *loutput, hwloc_obj_t level, unsigned depth, un
 	}
 	i++;
       }
-      methods->line(loutput, &BLACK_COLOR, depth-1, x+2*gridsize, ymin, x+2*gridsize, ymax, level, 1);
+      methods->line(loutput, depth-1, x+2*gridsize, ymin, x+2*gridsize, ymax, level, 1);
 
       /* Draw sublevels for real */
       draw_children(loutput, level, depth-1, x, y);

--- a/utils/lstopo/lstopo-fig.c
+++ b/utils/lstopo/lstopo-fig.c
@@ -75,7 +75,7 @@ fig_box(struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsign
 }
 
 static void
-fig_line(struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsigned depth, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
+fig_line(struct lstopo_output *loutput, unsigned depth, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
 {
   FILE *file = loutput->file;
 
@@ -83,7 +83,7 @@ fig_line(struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsig
   y1 *= FIG_FACTOR;
   x2 *= FIG_FACTOR;
   y2 *= FIG_FACTOR;
-  fprintf(file, "2 1 0 %u 0 %d %u -1 -1 0.0 0 0 -1 0 0 2\n\t", loutput->thickness, lcolor->private.fig.color, depth);
+  fprintf(file, "2 1 0 %u 0 0 %u -1 -1 0.0 0 0 -1 0 0 2\n\t", loutput->thickness, depth);
   fprintf(file, " %u %u", x1, y1);
   fprintf(file, " %u %u", x2, y2);
   fprintf(file, "\n");

--- a/utils/lstopo/lstopo-no-graphics.1in
+++ b/utils/lstopo/lstopo-no-graphics.1in
@@ -432,6 +432,14 @@ passing this option multiple times.
 Additional legend lines may also be specified inside the topology using the
 "lstopoLegend" info attributes on the topology root object.
 .TP
+\fB\-\-grey\fR, \fB\-\-greyscale\fR
+Use greyscale instead of colors in the graphical output.
+.TP
+\fB\-\-palette\fR <grey|greyscale|defaut|colors>
+Change the color palette.
+Passing \fIgrey\fR or \fIgreyscale\fR is identical to passing \fB\-\-grey\fR or \fB\-\-greyscale\fR.
+Passing \fIdefault\fR or \fIcolors\fR reverts back to the default color palette.
+.TP
 \fB\-\-binding\-color\fR none
 Do not colorize PUs and NUMA nodes according to the binding in the graphical output.
 .TP

--- a/utils/lstopo/lstopo-no-graphics.1in
+++ b/utils/lstopo/lstopo-no-graphics.1in
@@ -441,11 +441,13 @@ Passing \fIgrey\fR or \fIgreyscale\fR is identical to passing \fB\-\-grey\fR or 
 Passing \fIwhite\fR or \fInone\fR uses white instead of colors for all box backgrounds.
 Passing \fIdefault\fR or \fIcolors\fR reverts back to the default color palette.
 .TP
-\fB\-\-binding\-color\fR none
+\fB\-\-binding\-color\fR <none|#rrggbb>
 Do not colorize PUs and NUMA nodes according to the binding in the graphical output.
+Or change the color to the given 3x8bit hexadecimal RGB combination (e.g. \fI#ff0000\fR is red).
 .TP
-\fB\-\-disallowed\-color\fR none
+\fB\-\-disallowed\-color\fR <none|#rrggbb>
 Do not colorize disallowed PUs and NUMA nodes in the graphical output.
+Or change the color to the given 3x8bit hexadecimal RGB combination (e.g. \fI#00ff00\fR is green).
 .TP
 \fB\-\-top\-color\fR <none|#xxyyzz>
 Do not colorize task objects in the graphical output when \-\-top is given,

--- a/utils/lstopo/lstopo-no-graphics.1in
+++ b/utils/lstopo/lstopo-no-graphics.1in
@@ -441,6 +441,12 @@ Passing \fIgrey\fR or \fIgreyscale\fR is identical to passing \fB\-\-grey\fR or 
 Passing \fIwhite\fR or \fInone\fR uses white instead of colors for all box backgrounds.
 Passing \fIdefault\fR or \fIcolors\fR reverts back to the default color palette.
 .TP
+\fB\-\-palette\fR type=#rrggbb
+Replace the color of the given box type with the given 3x8bit hexadecimal RGB combination (e.g. \fI#ff0000\fR is red).
+Existing types are \fImachine\fR, \fIgroup\fR, \fIpackage\fR, \fIgroup_in_package\fR, \fIdie\fR, \fIcore\fR, \fIpu\fR, \fInumanode\fR, \fImemories\fR (box containing multiple memory children), \fIcache\fR, \fIpcidev\fR, \fIosdev\fR, \fIbridge\fR, and \fImisc\fR.
+
+See also CUSTOM COLOR below for customizing individual objects.
+.TP
 \fB\-\-binding\-color\fR <none|#rrggbb>
 Do not colorize PUs and NUMA nodes according to the binding in the graphical output.
 Or change the color to the given 3x8bit hexadecimal RGB combination (e.g. \fI#ff0000\fR is red).
@@ -724,7 +730,9 @@ The console mode displays the above characteristics by appending text
 to each PU line if verbose messages are enabled.
 .
 .SH CUSTOM COLORS
-The color of each object in the graphical output may be enforced by
+The colors of different kinds of boxes may be configured with \fB\-\-palette\fR.
+
+The color of each object in the graphical output may also be enforced by
 specifying a "lstopoStyle" info attribute in that object.
 Its value should be a semi-colon separated list of "<attribute>=#rrggbb"
 where rr, gg and bb are the RGB components of a color,

--- a/utils/lstopo/lstopo-no-graphics.1in
+++ b/utils/lstopo/lstopo-no-graphics.1in
@@ -435,9 +435,10 @@ Additional legend lines may also be specified inside the topology using the
 \fB\-\-grey\fR, \fB\-\-greyscale\fR
 Use greyscale instead of colors in the graphical output.
 .TP
-\fB\-\-palette\fR <grey|greyscale|defaut|colors>
+\fB\-\-palette\fR <grey|greyscale|defaut|colors|white|none>
 Change the color palette.
 Passing \fIgrey\fR or \fIgreyscale\fR is identical to passing \fB\-\-grey\fR or \fB\-\-greyscale\fR.
+Passing \fIwhite\fR or \fInone\fR uses white instead of colors for all box backgrounds.
 Passing \fIdefault\fR or \fIcolors\fR reverts back to the default color palette.
 .TP
 \fB\-\-binding\-color\fR none

--- a/utils/lstopo/lstopo-no-graphics.1in
+++ b/utils/lstopo/lstopo-no-graphics.1in
@@ -449,9 +449,9 @@ Or change the color to the given 3x8bit hexadecimal RGB combination (e.g. \fI#ff
 Do not colorize disallowed PUs and NUMA nodes in the graphical output.
 Or change the color to the given 3x8bit hexadecimal RGB combination (e.g. \fI#00ff00\fR is green).
 .TP
-\fB\-\-top\-color\fR <none|#xxyyzz>
-Do not colorize task objects in the graphical output when \-\-top is given,
-or change the background color.
+\fB\-\-top\-color\fR <none|#rrggbb>
+Do not colorize task objects in the graphical output when \-\-top is given.
+Or change the color to the given 3x8bit hexadecimal RGB combination (e.g. \fI#0000ff\fR is blue).
 .TP
 \fB\-\-version\fR
 Report version and exit.

--- a/utils/lstopo/lstopo-svg.c
+++ b/utils/lstopo/lstopo-svg.c
@@ -51,10 +51,9 @@ native_svg_box(struct lstopo_output *loutput, const struct lstopo_color *lcolor,
 
 
 static void
-native_svg_line(struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj, unsigned line_id)
+native_svg_line(struct lstopo_output *loutput, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj, unsigned line_id)
 {
   FILE *file = loutput->file;
-  int r = lcolor->r, g = lcolor->g, b = lcolor->b;
   char id[128] = "";
   char class[128] = "";
   char complement[12] = "";
@@ -70,8 +69,8 @@ native_svg_line(struct lstopo_output *loutput, const struct lstopo_color *lcolor
     snprintf(id, sizeof id, " id='anon_line%s'", complement);
   }
 
-  fprintf(file,"\t<line%s%s x1='%u' y1='%u' x2='%u' y2='%u' stroke='rgb(%d,%d,%d)' stroke-width='%u'/>\n",
-	  id, class, x1, y1, x2, y2, r, g, b, loutput->thickness);
+  fprintf(file,"\t<line%s%s x1='%u' y1='%u' x2='%u' y2='%u' stroke='rgb(0,0,0)' stroke-width='%u'/>\n",
+	  id, class, x1, y1, x2, y2, loutput->thickness);
 }
 
 static void

--- a/utils/lstopo/lstopo-tikz.c
+++ b/utils/lstopo/lstopo-tikz.c
@@ -78,13 +78,12 @@ tikz_box(struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsig
 
 
 static void
-tikz_line(struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
+tikz_line(struct lstopo_output *loutput, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
 {
   FILE *file = loutput->file;
-  int r = lcolor->r, g = lcolor->g, b = lcolor->b;
 
-  fprintf(file, "\t\\draw [draw=hwloc-color-%d-%d-%d,line width=%upt] (%u,%u) -- (%u,%u);\n",
-          r, g, b, loutput->thickness, x1, y1, x2, y2);
+  fprintf(file, "\t\\draw [draw=black,line width=%upt] (%u,%u) -- (%u,%u);\n",
+          loutput->thickness, x1, y1, x2, y2);
 }
 
 static void

--- a/utils/lstopo/lstopo-windows.c
+++ b/utils/lstopo/lstopo-windows.c
@@ -421,12 +421,11 @@ windows_box(struct lstopo_output *loutput, const struct lstopo_color *lcolor, un
 }
 
 static void
-windows_line(struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
+windows_line(struct lstopo_output *loutput, unsigned depth __hwloc_attribute_unused, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj __hwloc_attribute_unused, unsigned line_id __hwloc_attribute_unused)
 {
   struct lstopo_windows_output *woutput = loutput->backend_data;
   PAINTSTRUCT *ps = &woutput->ps;
 
-  SelectObject(ps->hdc, lcolor->private.windows.brush);
   MoveToEx(ps->hdc, x1 - x_delta, y1 - y_delta, NULL);
   LineTo(ps->hdc, x2 - x_delta, y2 - y_delta);
 }

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -551,6 +551,8 @@ void usage(const char *name, FILE *where)
   fprintf (where, "  --append-legend <s>   Append a new line of text at the bottom of the legend\n");
   fprintf (where, "  --grey --palette grey Use greyscale instead of colors\n");
   fprintf (where, "  --palette white       Use white instead of colors for background\n");
+  fprintf (where, "  --palette <type>=<#xxyyzz>\n"
+                  "                        Replace the color for object of the given type\n");
   fprintf (where, "  --binding-color <none|#xxyyzz>\n"
                   "                        Disable or change binding PU and NUMA nodes color\n");
   fprintf (where, "  --disallowed-color <none|#xxyyzz>\n"
@@ -1218,9 +1220,20 @@ main (int argc, char *argv[])
         lstopo_palette_select(&loutput, argv[0]+2);
 
       else if (!strcmp (argv[0], "--palette")) {
+        char *equal;
 	if (argc < 2)
 	  goto out_usagefailure;
-        lstopo_palette_select(&loutput, argv[1]);
+        equal = strchr(argv[1], '=');
+        if (equal) {
+          if (equal[1] != '#')
+            fprintf(stderr, "Unsupported palette color modification `%s' passed to %s, ignoring.\n", argv[1], argv[0]);
+          else {
+            *equal = '\0';
+            lstopo_palette_set_color_by_name(&loutput, argv[1], strtoul(equal+2, NULL, 16));
+          }
+        } else {
+          lstopo_palette_select(&loutput, argv[1]);
+        }
 	opt = 1;
       }
       else if (!strcmp (argv[0], "--binding-color")) {

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -878,6 +878,8 @@ main (int argc, char *argv[])
   loutput.show_disallowed = 1;
   loutput.show_cpukinds = 1;
 
+  lstopo_palette_init(&loutput);
+
   /* show all error messages */
   if (!getenv("HWLOC_HIDE_ERRORS"))
     putenv((char *) "HWLOC_HIDE_ERRORS=0");
@@ -1222,6 +1224,7 @@ main (int argc, char *argv[])
 	else
 	  fprintf(stderr, "Unsupported color `%s' passed to %s, ignoring.\n", argv[1], argv[0]);
 	opt = 1;
+        /* FIXME could set custom colors in the palette */
       }
       else if (!strcmp (argv[0], "--disallowed-color")) {
 	if (argc < 2)
@@ -1231,6 +1234,7 @@ main (int argc, char *argv[])
 	else
 	  fprintf(stderr, "Unsupported color `%s' passed to %s, ignoring.\n", argv[1], argv[0]);
 	opt = 1;
+        /* FIXME could set custom colors in the palette */
       }
       else if (!strcmp (argv[0], "--top-color")) {
 	if (argc < 2)

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -557,6 +557,7 @@ void usage(const char *name, FILE *where)
   fprintf (where, "  --no-legend           Remove all text legend lines at the bottom\n");
   fprintf (where, "  --no-default-legend   Remove default text legend lines at the bottom\n");
   fprintf (where, "  --append-legend <s>   Append a new line of text at the bottom of the legend\n");
+  fprintf (where, "  --grey --palette grey Use greyscale instead of colors\n");
   fprintf (where, "  --binding-color none    Do not colorize PU and NUMA nodes according to the binding\n");
   fprintf (where, "  --disallowed-color none Do not colorize disallowed PU and NUMA nodes\n");
   fprintf (where, "  --top-color <none|#xxyyzz> Change task background color for --top\n");
@@ -1216,6 +1217,15 @@ main (int argc, char *argv[])
         }
       }
 
+      else if (!strcmp (argv[0], "--grey") || !strcmp (argv[0], "--greyscale"))
+        lstopo_palette_select(&loutput, argv[0]+2);
+
+      else if (!strcmp (argv[0], "--palette")) {
+	if (argc < 2)
+	  goto out_usagefailure;
+        lstopo_palette_select(&loutput, argv[1]);
+	opt = 1;
+      }
       else if (!strcmp (argv[0], "--binding-color")) {
 	if (argc < 2)
 	  goto out_usagefailure;

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -559,8 +559,10 @@ void usage(const char *name, FILE *where)
   fprintf (where, "  --append-legend <s>   Append a new line of text at the bottom of the legend\n");
   fprintf (where, "  --grey --palette grey Use greyscale instead of colors\n");
   fprintf (where, "  --palette white       Use white instead of colors for background\n");
-  fprintf (where, "  --binding-color none    Do not colorize PU and NUMA nodes according to the binding\n");
-  fprintf (where, "  --disallowed-color none Do not colorize disallowed PU and NUMA nodes\n");
+  fprintf (where, "  --binding-color <none|#xxyyzz>\n"
+                  "                        Disable or change binding PU and NUMA nodes color\n");
+  fprintf (where, "  --disallowed-color <none|#xxyyzz>\n"
+                  "                        Disable or change disallowed PU and NUMA nodes color\n");
   fprintf (where, "  --top-color <none|#xxyyzz> Change task background color for --top\n");
   fprintf (where, "Miscellaneous options:\n");
   fprintf (where, "  --export-xml-flags <n>\n"
@@ -1232,20 +1234,22 @@ main (int argc, char *argv[])
 	  goto out_usagefailure;
 	if (!strcmp(argv[1], "none"))
 	  loutput.show_binding = 0;
+        else if (*argv[1] == '#')
+          lstopo_palette_set_color(&loutput.palette->binding, strtoul(argv[1]+1, NULL, 16));
 	else
 	  fprintf(stderr, "Unsupported color `%s' passed to %s, ignoring.\n", argv[1], argv[0]);
 	opt = 1;
-        /* FIXME could set custom colors in the palette */
       }
       else if (!strcmp (argv[0], "--disallowed-color")) {
 	if (argc < 2)
 	  goto out_usagefailure;
 	if (!strcmp(argv[1], "none"))
 	  loutput.show_disallowed = 0;
-	else
+        else if (*argv[1] == '#')
+          lstopo_palette_set_color(&loutput.palette->disallowed, strtoul(argv[1]+1, NULL, 16));
+        else
 	  fprintf(stderr, "Unsupported color `%s' passed to %s, ignoring.\n", argv[1], argv[0]);
 	opt = 1;
-        /* FIXME could set custom colors in the palette */
       }
       else if (!strcmp (argv[0], "--top-color")) {
 	if (argc < 2)

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -558,6 +558,7 @@ void usage(const char *name, FILE *where)
   fprintf (where, "  --no-default-legend   Remove default text legend lines at the bottom\n");
   fprintf (where, "  --append-legend <s>   Append a new line of text at the bottom of the legend\n");
   fprintf (where, "  --grey --palette grey Use greyscale instead of colors\n");
+  fprintf (where, "  --palette white       Use white instead of colors for background\n");
   fprintf (where, "  --binding-color none    Do not colorize PU and NUMA nodes according to the binding\n");
   fprintf (where, "  --disallowed-color none Do not colorize disallowed PU and NUMA nodes\n");
   fprintf (where, "  --top-color <none|#xxyyzz> Change task background color for --top\n");

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -192,6 +192,7 @@ struct lstopo_color_palette {
 extern void lstopo_palette_init(struct lstopo_output *loutput);
 extern void lstopo_palette_select(struct lstopo_output *loutput, const char *name);
 extern void lstopo_palette_set_color(struct lstopo_color *color, unsigned rrggbb);
+extern void lstopo_palette_set_color_by_name(struct lstopo_output *output, const char *name, unsigned rrggbb);
 
 struct lstopo_style {
   struct lstopo_color

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -188,6 +188,7 @@ struct lstopo_color_palette {
 };
 
 extern void lstopo_palette_init(struct lstopo_output *loutput);
+extern void lstopo_palette_select(struct lstopo_output *loutput, const char *name);
 
 struct lstopo_style {
   struct lstopo_color

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -260,7 +260,7 @@ struct draw_methods {
   void (*destroy_color) (struct lstopo_output *loutput, struct lstopo_color *lcolor);
   /* only called when loutput->draw_methods == LSTOPO_DRAWING_DRAW */
   void (*box) (struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsigned depth, unsigned x, unsigned width, unsigned y, unsigned height, hwloc_obj_t obj, unsigned box_id);
-  void (*line) (struct lstopo_output *loutput, const struct lstopo_color *lcolor, unsigned depth, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj, unsigned line_id);
+  void (*line) (struct lstopo_output *loutput, unsigned depth, unsigned x1, unsigned y1, unsigned x2, unsigned y2, hwloc_obj_t obj, unsigned line_id);
   void (*text) (struct lstopo_output *loutput, const struct lstopo_color *lcolor, int size, unsigned depth, unsigned x, unsigned y, const char *text, hwloc_obj_t obj, unsigned text_id);
   /* may be called when loutput->drawing == LSTOPO_DRAWING_PREPARE */
   void (*textsize) (struct lstopo_output *loutput, const char *text, unsigned textlength, unsigned fontsize, unsigned *width);

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -189,6 +189,7 @@ struct lstopo_color_palette {
 
 extern void lstopo_palette_init(struct lstopo_output *loutput);
 extern void lstopo_palette_select(struct lstopo_output *loutput, const char *name);
+extern void lstopo_palette_set_color(struct lstopo_color *color, unsigned rrggbb);
 
 struct lstopo_style {
   struct lstopo_color

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -127,6 +127,7 @@ struct lstopo_output {
 #define FACTORIZE_MIN_DISABLED UINT_MAX
   unsigned factorize_first[HWLOC_OBJ_TYPE_MAX]; /* number of first children to keep before factorizing */
   unsigned factorize_last[HWLOC_OBJ_TYPE_MAX]; /* number of last children to keep after factorizing */
+  struct lstopo_color_palette *palette;
 
   /* draw internal data */
   void *backend_data;
@@ -162,6 +163,31 @@ struct lstopo_color {
   /* list of colors */
   struct lstopo_color *next;
 };
+
+struct lstopo_color_palette {
+  struct lstopo_color
+    white, /* used for legend background, and text on dark background */
+    black, /* used for text on light background, and legend text */
+    /* all colors below are box backgrounds */
+    machine,
+    group,
+    package,
+    group_in_package,
+    die,
+    core,
+    pu,
+    numanode,
+    memories,
+    cache,
+    pcidev,
+    osdev,
+    bridge,
+    misc,
+    binding,
+    disallowed;
+};
+
+extern void lstopo_palette_init(struct lstopo_output *loutput);
 
 struct lstopo_style {
   struct lstopo_color

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -120,6 +120,7 @@ struct lstopo_output {
   int show_attrs[HWLOC_OBJ_TYPE_MAX];
   int show_binding;
   int show_disallowed;
+  int show_process_color;
   int show_cpukinds;
   int factorize_enabled; /* global toggle for interactive keyboard shortcuts */
   unsigned factorize_min[HWLOC_OBJ_TYPE_MAX]; /* minimum number of object before factorizing (parent->arity must be strictly higher) */
@@ -184,7 +185,8 @@ struct lstopo_color_palette {
     bridge,
     misc,
     binding,
-    disallowed;
+    disallowed,
+    process;
 };
 
 extern void lstopo_palette_init(struct lstopo_output *loutput);


### PR DESCRIPTION
Define "palette" structures instead of hardwiring lots of color structures.
Cleanup the actual list of colors.

Add "--grey" to switch lstopo to greyscale output.
Add "--palette white" to disable all color backgrounds.
Add "--palette core=#ff00ff" to change the color of "Core" boxes.

Adding a colorblind palette will be easy.
