### PR TITLE
autogen: exit on first error

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Exit on error, useful if autoconf is missing, the script will stop instead of
+# trying to continue.
+set -e
+
 srcdir=$(dirname "$0")
 if test "x$srcdir" != x; then
    # in case we ever autogen on a platform without dirname


### PR DESCRIPTION
Currently, if autoreconf is missing on the building system, the autogen.sh script will continue, in a buggy way:
```
$ ./autogen.sh 
./autogen.sh: line 9: autoreconf: command not found
Checking whether configure needs patching for MacOS Big Sur libtool.m4 bug... grep: configure: No such file or directory
grep: configure: No such file or directory
yes
Trying to patch configure...
can't find file to patch at input line 9
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|Updated from libtool.m4 patch:
|
|[PATCH] Improve macOS version detection to support macOS 11 and simplify legacy logic
|
|Signed-off-by: Jeremy Huddleston Sequoia <jeremyhu@apple.com>
|
|--- hwloc/configure.old	2020-11-25 16:03:04.225097149 +0100
|+++ hwloc/configure	2020-11-25 16:02:29.368995613 +0100
--------------------------
File to patch: ^C
```

This PR fixes this problem:
```
$ ./autogen.sh 
./autogen.sh: line 11: autoreconf: command not found
```