### PR TITLE
Set ZES_ENABLE_SYSMAN via setenv instead of putenv

### DIFF
--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -3,6 +3,7 @@
  * Copyright © 2009-2022 Inria.  All rights reserved.
  * Copyright © 2009-2012, 2020 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2022 IBM Corporation.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -74,13 +75,14 @@ static void hwloc_constructor(void) __attribute__((constructor));
 static void hwloc_constructor(void)
 {
   if (!getenv("ZES_ENABLE_SYSMAN"))
-    putenv((char *) "ZES_ENABLE_SYSMAN=1");
+    setenv("ZES_ENABLE_SYSMAN", "1", 1);
 }
 #endif
 #ifdef HWLOC_WIN_SYS
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved)
 {
   if (fdwReason == DLL_PROCESS_ATTACH) {
+    // Windows does not have a setenv, so use putenv
     if (!getenv("ZES_ENABLE_SYSMAN"))
       putenv((char *) "ZES_ENABLE_SYSMAN=1");
   }


### PR DESCRIPTION
 * Setting `ZES_ENABLE_SYSMAN` via `putenv` placed a constant string
   in the environ array which cannot be touched. If the user is
   manipulating that environ array then touching this envar will
   result in a segv.
   - Instead of using `putenv` use `setenv` which will put a copy
     of the constant string in the `environ` array allowing the
     end user to manipulate that array as needed.
   - Note that I could not find a `setenv` function for windows
     so I left a comment and did not touch that code.
