### PR TITLE
Strengthen the NVML check by adding a runtime check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ AH_TOP([/* -*- c -*-
  *
  * Copyright © 2009, 2011, 2012 CNRS, inria., Université Bordeaux  All rights reserved.
  * Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2022 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -255,12 +256,36 @@ fi
 test "x$hwloc_linuxio_happy" = "xyes" && hwloc_probeio_list="$hwloc_probeio_list LinuxIO"
 test "x$hwloc_opencl_happy" = "xyes" && hwloc_probeio_list="$hwloc_probeio_list OpenCL"
 test "x$hwloc_have_cudart" = "xyes" && hwloc_probeio_list="$hwloc_probeio_list CUDA"
-test "x$hwloc_nvml_happy" = "xyes" && hwloc_probeio_list="$hwloc_probeio_list NVML"
+if test "x$hwloc_nvml_happy" = "xyes" ; then
+    hwloc_probeio_list="$hwloc_probeio_list NVML"
+    hwloc_nvml_status="yes"
+else
+    hwloc_nvml_status="no"
+fi
 test "x$hwloc_rsmi_happy" = "xyes" && hwloc_probeio_list="$hwloc_probeio_list RSMI"
 test "x$hwloc_levelzero_happy" = "xyes" && hwloc_probeio_list="$hwloc_probeio_list LevelZero"
 test "x$hwloc_gl_happy" = "xyes" && hwloc_probeio_list="$hwloc_probeio_list GL"
 # if nothing, say "no"
 test "x$hwloc_probeio_list" = "x" && hwloc_probeio_list=" no"
+
+if test "x$hwloc_nvml_happy" = "xyes" -a "x$hwloc_nvml_warning" = "xyes"; then
+    hwloc_nvml_status="yes, but not functional on this machine (see warning above)"
+    cat <<EOF
+
+************************************************************************
+WARNING: NVIDIA Management Library (NVML) was detected, but programs
+linked against it cannot run on this machine. This situation often
+indicates that this machine does not have the hardware necessary to run
+the library.
+
+Sometimes, the machine building hwloc differs from the machine where
+hwloc will be running. As such, this warning can be ignored if you know
+that the library is functional where you intend to run hwloc.
+However, if that is not the situation, you may want to disable NVML
+support in hwloc with the --disable-nvml option in configure.
+************************************************************************
+EOF
+fi
 
 # Beginning of generic support
 cat <<EOF
@@ -269,6 +294,7 @@ cat <<EOF
 Hwloc optional build support status (more details can be found above):
 
 Probe / display I/O devices:$hwloc_probeio_list
+NVML support:                $hwloc_nvml_status
 Graphical output:            $hwloc_graphical_lstopo_status
 XML input / output:          $hwloc_xml_status
 Netloc functionality:        $netloc_status


### PR DESCRIPTION
 * The Nvidia ML library is provided by a stub which can fool
   the linker into thinking that the actual library is on the system
   even when it is not. This can cause a runtime failure on such
   systems.
   - Strengthen the `nvidia-ml` library check by adding a runtime
     check that the resulting program will run not just compile
     and link.