### PR TITLE
levelzero: use the core PCI prop extension if available

### DIFF
--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -1408,13 +1408,18 @@ return clGetDeviceIDs(0, 0, 0, NULL, NULL);
       HWLOC_PKG_CHECK_MODULES([LEVELZERO], [libze_loader], [zesDevicePciGetProperties], [level_zero/zes_api.h],
                               [hwloc_levelzero_happy=yes
                                HWLOC_LEVELZERO_REQUIRES=libze_loader
+			       AC_CHECK_LIB([ze_loader], [zeDevicePciGetPropertiesExt], [AC_DEFINE(HWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT, 1, [Define to 1 if zeDevicePciGetPropertiesExt is available])])
                               ], [hwloc_levelzero_happy=no])
       if test x$hwloc_levelzero_happy = xno; then
         hwloc_levelzero_happy=yes
         AC_CHECK_HEADERS([level_zero/ze_api.h], [
           AC_CHECK_LIB([ze_loader], [zeInit], [
             AC_CHECK_HEADERS([level_zero/zes_api.h], [
-              AC_CHECK_LIB([ze_loader], [zesDevicePciGetProperties], [HWLOC_LEVELZERO_LIBS="-lze_loader"], [hwloc_levelzero_happy=no])
+              AC_CHECK_LIB([ze_loader],
+	                   [zesDevicePciGetProperties],
+	                   [HWLOC_LEVELZERO_LIBS="-lze_loader"
+			    AC_CHECK_LIB([ze_loader], [zeDevicePciGetPropertiesExt], [AC_DEFINE(HWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT, 1, [Define to 1 if zeDevicePciGetPropertiesExt is available])])
+                           ], [hwloc_levelzero_happy=no])
             ], [hwloc_levelzero_happy=no])
           ], [hwloc_levelzero_happy=no])
         ], [hwloc_levelzero_happy=no])

--- a/hwloc/topology-levelzero.c
+++ b/hwloc/topology-levelzero.c
@@ -416,7 +416,6 @@ hwloc_levelzero_discover(struct hwloc_backend *backend, struct hwloc_disc_status
     }
 
     for(j=0; j<nbdevices; j++) {
-      zes_pci_properties_t pci;
       zes_device_handle_t sdvh = dvh[j];
       zes_device_handle_t *subh = NULL;
       uint32_t nr_subdevices;
@@ -478,16 +477,39 @@ hwloc_levelzero_discover(struct hwloc_backend *backend, struct hwloc_disc_status
       hwloc__levelzero_memory_get(dvh[j], osdev, is_integrated, nr_subdevices, subh, subosdevs);
 
       parent = NULL;
-      res = zesDevicePciGetProperties(sdvh, &pci);
-      if (res == ZE_RESULT_SUCCESS) {
-        parent = hwloc_pci_find_parent_by_busid(topology,
-                                                pci.address.domain,
-                                                pci.address.bus,
-                                                pci.address.device,
-                                                pci.address.function);
-        if (parent && parent->type == HWLOC_OBJ_PCI_DEVICE) {
-          if (pci.maxSpeed.maxBandwidth > 0)
-            parent->attr->pcidev.linkspeed = ((float)pci.maxSpeed.maxBandwidth)/1000/1000/1000;
+#ifdef HWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT
+      { /* try getting PCI BDF+speed from core extension */
+        ze_pci_ext_properties_t ext_pci;
+        ext_pci.stype =  ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES;
+        ext_pci.pNext = NULL;
+        res = zeDevicePciGetPropertiesExt(dvh[j], &ext_pci);
+        if (res == ZE_RESULT_SUCCESS) {
+          parent = hwloc_pci_find_parent_by_busid(topology,
+                                                  ext_pci.address.domain,
+                                                  ext_pci.address.bus,
+                                                  ext_pci.address.device,
+                                                  ext_pci.address.function);
+          if (parent && parent->type == HWLOC_OBJ_PCI_DEVICE) {
+            if (ext_pci.maxSpeed.maxBandwidth > 0)
+              parent->attr->pcidev.linkspeed = ((float)ext_pci.maxSpeed.maxBandwidth)/1000/1000/1000;
+          }
+        }
+      }
+#endif /* HWLOC_HAVE_LEVELZERO_CORE_PCI_EXT */
+      if (!parent) {
+        /* try getting PCI BDF+speed from sysman */
+        zes_pci_properties_t pci;
+        res = zesDevicePciGetProperties(sdvh, &pci);
+        if (res == ZE_RESULT_SUCCESS) {
+          parent = hwloc_pci_find_parent_by_busid(topology,
+                                                  pci.address.domain,
+                                                  pci.address.bus,
+                                                  pci.address.device,
+                                                  pci.address.function);
+          if (parent && parent->type == HWLOC_OBJ_PCI_DEVICE) {
+            if (pci.maxSpeed.maxBandwidth > 0)
+              parent->attr->pcidev.linkspeed = ((float)pci.maxSpeed.maxBandwidth)/1000/1000/1000;
+          }
         }
       }
       if (!parent)

--- a/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
+++ b/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
@@ -63,4 +63,25 @@ typedef struct ze_device_memory_properties {
 
 extern ze_result_t zeDeviceGetMemoryProperties(ze_device_handle_t, uint32_t *, ze_device_memory_properties_t*);
 
+typedef struct ze_pci_address_ext {
+  uint32_t domain, bus, device, function;
+} ze_pci_address_ext_t;
+
+typedef struct ze_pci_speed_ext {
+  int64_t maxBandwidth;
+} ze_pci_speed_ext_t;
+
+typedef int ze_structure_type_t;
+
+#define ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES 0x10008
+
+typedef struct ze_pci_ext_properties {
+  ze_structure_type_t stype;
+  void* pNext;
+  ze_pci_address_ext_t address;
+  ze_pci_speed_ext_t maxSpeed;
+} ze_pci_ext_properties_t;
+
+extern ze_result_t zeDevicePciGetPropertiesExt(ze_device_handle_t, ze_pci_ext_properties_t *);
+
 #endif /* HWLOC_PORT_L0_ZE_API_H */


### PR DESCRIPTION
When available, it gives the PCI locality without requiring Sysman.
If not, we fallback to Sysman as usual.

This is marked as a "standard" extension in the specs (as opposed to "experimental" extensions) hence it shouldn't break anytime soon.