### PR TITLE
pci: rework locality quirks and add one for Cray/HPE EX235a

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,7 @@ Version 2.8.0
     but they may be slightly adjusted to avoid reporting hybrid CPUs
     because of features such as Intel Turbo Boost Max 3.0.
     - See the documentation of environment variable HWLOC_CPUKINDS_MAXFREQ.
+  + Hardwire the PCI locality of HPE Cray EX235a nodes.
 * Tools
   + lstopo and other tools may now load Linux and x86 cpuid topology files
     from a tarball.

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -3536,6 +3536,8 @@ hwloc_discover(struct hwloc_topology *topology,
   /*
    * Additional discovery
    */
+  hwloc_pci_discovery_prepare(topology);
+
   if (topology->backend_phases & HWLOC_DISC_PHASE_PCI) {
     dstatus->phase = HWLOC_DISC_PHASE_PCI;
     hwloc_discover_by_phase(topology, dstatus, "PCI");
@@ -3552,6 +3554,8 @@ hwloc_discover(struct hwloc_topology *topology,
     dstatus->phase = HWLOC_DISC_PHASE_ANNOTATE;
     hwloc_discover_by_phase(topology, dstatus, "ANNOTATE");
   }
+
+  hwloc_pci_discovery_exit(topology); /* pci needed up to annotate */
 
   if (getenv("HWLOC_DEBUG_SORT_CHILDREN"))
     hwloc_debug_sort_children(topology->levels[0][0]);
@@ -4085,14 +4089,10 @@ hwloc_topology_load (struct hwloc_topology *topology)
    */
   hwloc_set_binding_hooks(topology);
 
-  hwloc_pci_discovery_prepare(topology);
-
   /* actual topology discovery */
   err = hwloc_discover(topology, &dstatus);
   if (err < 0)
     goto out;
-
-  hwloc_pci_discovery_exit(topology);
 
 #ifndef HWLOC_DEBUG
   if (getenv("HWLOC_DEBUG_CHECK"))

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009      CNRS
- * Copyright © 2009-2021 Inria.  All rights reserved.
+ * Copyright © 2009-2022 Inria.  All rights reserved.
  * Copyright © 2009-2012, 2020 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
  *
@@ -259,6 +259,7 @@ struct hwloc_topology {
     unsigned bus_first, bus_last;
     hwloc_bitmap_t cpuset;
   } * pci_forced_locality;
+  hwloc_uint64_t pci_locality_quirks;
 
   /* component blacklisting */
   unsigned nr_blacklisted_components;


### PR DESCRIPTION
Add a PCI locality quirk for the HPE Cray EX235a server used in the Frontier supercomputer. This requires to rework the old PCI locality quirk interface. By the way, we also add a debugging fake quirk.