### PR TITLE
Leak in hwloc__xml_import_cpukind

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -1853,6 +1853,7 @@ hwloc__xml_import_cpukind(hwloc_topology_t topology,
     hwloc_bitmap_free(cpuset);
   } else {
     hwloc_internal_cpukinds_register(topology, cpuset, forced_efficiency, infos, nr_infos, HWLOC_CPUKINDS_REGISTER_FLAG_OVERWRITE_FORCED_EFFICIENCY);
+    hwloc__free_infos(infos, nr_infos);
   }
 
   return state->global->close_tag(state);


### PR DESCRIPTION
We are seeing the leak using valgrind:
```
[0] ==698650== Memcheck, a memory error detector
[0] ==698650== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
[0] ==698650== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
[0] ==698650== Command: ./cpi
[0] ==698650==
[1] ==698651== Memcheck, a memory error detector
[1] ==698651== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
[1] ==698651== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
[1] ==698651== Command: ./cpi
[1] ==698651==
[1] Process 1 of 2 is on tiger
[0] Process 0 of 2 is on tiger
[0] pi is approximately 3.1415926544231318, Error is 0.0000000008333387
[0] wall clock time = 0.023639
[1] ==698651==
[1] ==698651== HEAP SUMMARY:
[1] ==698651==     in use at exit: 967 bytes in 20 blocks
[1] ==698651==   total heap usage: 9,682 allocs, 9,662 frees, 11,469,601 bytes allocated
[1] ==698651==
[1] ==698651== 342 (256 direct, 86 indirect) bytes in 2 blocks are definitely lost in loss record 13 of 13
[1] ==698651==    at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
[1] ==698651==    by 0x4C483F6: hwloc__add_info (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[1] ==698651==    by 0x4C76A6E: hwloc__xml_import_cpukind (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[1] ==698651==    by 0x4C7777C: hwloc_look_xml (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[1] ==698651==    by 0x4C4F23E: hwloc_discover (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[1] ==698651==    by 0x4C5098D: hwloc_topology_load (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[1] ==698651==    by 0x4C3B25E: MPII_hwtopo_init (mpir_hwtopo.c:216)
[1] ==698651==    by 0x4B0647B: MPII_Init_thread (mpir_init.c:169)
[1] ==698651==    by 0x4B070C9: MPIR_Init_impl (mpir_init.c:102)
[1] ==698651==    by 0x4997831: internal_Init (c_binding.c:45877)
[1] ==698651==    by 0x4997831: PMPI_Init (c_binding.c:45929)
[1] ==698651==    by 0x10933C: main (in /home/hzhou/work/pull_requests/2210_hydra_pg/cpi)
[1] ==698651==
[1] ==698651== LEAK SUMMARY:
[1] ==698651==    definitely lost: 256 bytes in 2 blocks
[1] ==698651==    indirectly lost: 86 bytes in 8 blocks
[1] ==698651==      possibly lost: 0 bytes in 0 blocks
[1] ==698651==    still reachable: 625 bytes in 10 blocks
[1] ==698651==         suppressed: 0 bytes in 0 blocks
[1] ==698651== Reachable blocks (those to which a pointer was found) are not shown.
[1] ==698651== To see them, rerun with: --leak-check=full --show-leak-kinds=all
[1] ==698651==
[1] ==698651== For lists of detected and suppressed errors, rerun with: -s
[1] ==698651== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
[0] ==698650==
[0] ==698650== HEAP SUMMARY:
[0] ==698650==     in use at exit: 967 bytes in 20 blocks
[0] ==698650==   total heap usage: 9,686 allocs, 9,666 frees, 11,470,063 bytes allocated
[0] ==698650==
[0] ==698650== 342 (256 direct, 86 indirect) bytes in 2 blocks are definitely lost in loss record 13 of 13
[0] ==698650==    at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
[0] ==698650==    by 0x4C483F6: hwloc__add_info (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[0] ==698650==    by 0x4C76A6E: hwloc__xml_import_cpukind (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[0] ==698650==    by 0x4C7777C: hwloc_look_xml (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[0] ==698650==    by 0x4C4F23E: hwloc_discover (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[0] ==698650==    by 0x4C5098D: hwloc_topology_load (in /home/hzhou/work/pull_requests/2210_hydra_pg/lib/.libs/libmpi.so.0.0.0)
[0] ==698650==    by 0x4C3B25E: MPII_hwtopo_init (mpir_hwtopo.c:216)
[0] ==698650==    by 0x4B0647B: MPII_Init_thread (mpir_init.c:169)
[0] ==698650==    by 0x4B070C9: MPIR_Init_impl (mpir_init.c:102)
[0] ==698650==    by 0x4997831: internal_Init (c_binding.c:45877)
[0] ==698650==    by 0x4997831: PMPI_Init (c_binding.c:45929)
[0] ==698650==    by 0x10933C: main (in /home/hzhou/work/pull_requests/2210_hydra_pg/cpi)
[0] ==698650==
[0] ==698650== LEAK SUMMARY:
[0] ==698650==    definitely lost: 256 bytes in 2 blocks
[0] ==698650==    indirectly lost: 86 bytes in 8 blocks
[0] ==698650==      possibly lost: 0 bytes in 0 blocks
[0] ==698650==    still reachable: 625 bytes in 10 blocks
[0] ==698650==         suppressed: 0 bytes in 0 blocks
[0] ==698650== Reachable blocks (those to which a pointer was found) are not shown.
[0] ==698650== To see them, rerun with: --leak-check=full --show-leak-kinds=all
[0] ==698650==
[0] ==698650== For lists of detected and suppressed errors, rerun with: -s
[0] ==698650== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```
Looks like `hwloc_internal_cpukinds_register` copies the infos so we always need free the locally allocated infos.