### PR TITLE
CXLDevice attributes in DAX and NUMA nodes

### DIFF
--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -2127,6 +2127,11 @@ and GID #1 of port #3.
 These info attributes are attached to objects specified in parentheses.
 
 <dl>
+<dt>CXLDevice (NUMA Nodes or DAX Memory OS devices)</dt>
+<dd>The PCI/CXL bus ID of a device whose CXL Type-3 memory is exposed here.
+There may be multiple instances of this attributes if multiple device memories
+are interleaved.
+</dd>
 <dt>DAXDevice (NUMA Nodes)</dt>
 <dd>The name of the Linux DAX device that was used to expose a non-volatile
 memory region as a volatile NUMA node.


### PR DESCRIPTION
Don't merge before candidate CXL patches (volatile region, etc) are merged Linux 6.3.

Things that don't work well yet in Linux:
* CXL PMEM DAX numa_node is always 0 ?
* CXL RAM DAX numa_node is always -1 ?
* How to specify this nodes' distance on the Qemu cmdline

Refs #554