### PR TITLE
tests/backends.c: fix a failure when /sys isn't available on Linux on non-x86

### DIFF
--- a/tests/hwloc/hwloc_backends.c
+++ b/tests/hwloc/hwloc_backends.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2022 Inria.  All rights reserved.
+ * Copyright © 2012-2023 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -46,10 +46,14 @@ static const char *get_backend_name(hwloc_topology_t topo)
 static void assert_backend_name(hwloc_topology_t topo, const char *wanted)
 {
   const char *found = get_backend_name(topo);
-  int diff;
-  assert(found);
-  diff = strcmp(found, wanted);
-  assert(!diff);
+  if (!wanted) {
+    assert(!found);
+  } else {
+    int diff;
+    assert(found);
+    diff = strcmp(found, wanted);
+    assert(!diff);
+  }
 }
 
 static void assert_foo_bar(hwloc_topology_t topo, int setornot)


### PR DESCRIPTION
Since 2.9, Linux discovery aborts if /sys isn't available. Usually it will fallback to the x86 backend... except on non-x86 platforms obviously where it would fallback to "noos" instead.

The hwloc_backends.c test verified that the "Backend" info attribute was the same in the XML-loaded topology and the original topology, but it did not handle the case where that info attribute did not exist at all, which is the case when only "noos" is used.

This is first reported by Simon South on https://issues.guix.gnu.org/61493
Thanks to Ludovic Courtes for forwarding to me.