### PR TITLE
Update .gitignore to include cross-compile libtool artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ test-suite.log
 /autom4te.cache
 /aclocal.m4
 /tags
-/libtool
+/*libtool
 
 /hwloc.pc
 


### PR DESCRIPTION
When configured with a non-native --host value, the libtool file will be prefixed by the host, which the current .gitignore misses.