### PR TITLE
Fix name scheme when building with --target

### DIFF
--- a/utils/hwloc/Makefile.am
+++ b/utils/hwloc/Makefile.am
@@ -1,6 +1,7 @@
 # Copyright © 2009-2021 Inria.  All rights reserved.
 # Copyright © 2009-2012, 2014, 2016 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright © 2023      Université de Reims Champagne-Ardenne.  All rights reserved.
 #
 # See COPYING in top-level directory.
 
@@ -160,12 +161,16 @@ endif HWLOC_HAVE_LINUX
 	@ $(SEDMAN) \
 	  > $@ < $<
 
+
+hwloc_compress_dir_name=`echo "hwloc-compress-dir" | $(SED) -e "$(transform)"`
+hwloc_gather_topology_name=`echo "hwloc-gather-topology" | $(SED) -e "$(transform)"`
+
 install-exec-hook:
-	$(SED) -e 's/HWLOC_top_builddir\/utils\/hwloc/bindir/' -e 's/HWLOC_top_builddir\/utils\/lstopo/bindir/' -e '/HWLOC_top_builddir/d' $(DESTDIR)$(bindir)/hwloc-compress-dir > $(DESTDIR)$(bindir)/hwloc-compress-dir.tmp && mv -f $(DESTDIR)$(bindir)/hwloc-compress-dir.tmp $(DESTDIR)$(bindir)/hwloc-compress-dir
-	chmod +x $(DESTDIR)$(bindir)/hwloc-compress-dir
+	$(SED) -e 's/HWLOC_top_builddir\/utils\/hwloc/bindir/' -e 's/HWLOC_top_builddir\/utils\/lstopo/bindir/' -e '/HWLOC_top_builddir/d' $(DESTDIR)$(bindir)/$(hwloc_compress_dir_name) > $(DESTDIR)$(bindir)/$(hwloc_compress_dir_name).tmp && mv -f $(DESTDIR)$(bindir)/$(hwloc_compress_dir_name).tmp $(DESTDIR)$(bindir)/$(hwloc_compress_dir_name)
+	chmod +x $(DESTDIR)$(bindir)/$(hwloc_compress_dir_name)
 if HWLOC_HAVE_LINUX
-	$(SED) -e 's/HWLOC_top_builddir\/utils\/lstopo/bindir/' -e 's/HWLOC_top_builddir\/utils\/hwloc/bindir/' -e '/HWLOC_top_builddir/d' $(DESTDIR)$(bindir)/hwloc-gather-topology > $(DESTDIR)$(bindir)/hwloc-gather-topology.tmp && mv -f $(DESTDIR)$(bindir)/hwloc-gather-topology.tmp $(DESTDIR)$(bindir)/hwloc-gather-topology
-	chmod +x $(DESTDIR)$(bindir)/hwloc-gather-topology
+	$(SED) -e 's/HWLOC_top_builddir\/utils\/lstopo/bindir/' -e 's/HWLOC_top_builddir\/utils\/hwloc/bindir/' -e '/HWLOC_top_builddir/d' $(DESTDIR)$(bindir)/$(hwloc_gather_topology_name) > $(DESTDIR)$(bindir)/$(hwloc_gather_topology_name).tmp && mv -f $(DESTDIR)$(bindir)/$(hwloc_gather_topology_name).tmp $(DESTDIR)$(bindir)/$(hwloc_gather_topology_name)
+	chmod +x $(DESTDIR)$(bindir)/$(hwloc_gather_topology_name)
 endif HWLOC_HAVE_LINUX
 
 distclean-local:

--- a/utils/lstopo/Makefile.am
+++ b/utils/lstopo/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright © 2009-2012, 2014 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
+# Copyright © 2023      Université de Reims Champagne-Ardenne.  All rights reserved.
 #
 # See COPYING in top-level directory.
 
@@ -89,30 +90,34 @@ SEDMAN = $(SED) -e 's/%PACKAGE_NAME%/@PACKAGE_NAME@/g' \
 	@ $(SEDMAN) \
 	  > $@ < $<
 
+hwloc_ls_name=`echo "hwloc-ls" | $(SED) -e "$(transform)"`
+lstopo_name=`echo "lstopo" | $(SED) -e "$(transform)"`
+lstopo_no_graphics_name=`echo "lstopo-no-graphics" | $(SED) -e "$(transform)"`
+
 install-exec-hook:
-	rm -f $(DESTDIR)$(bindir)/hwloc-ls$(EXEEXT)
-	cd $(DESTDIR)$(bindir) && $(LN_S) lstopo-no-graphics$(EXEEXT) hwloc-ls$(EXEEXT)
+	rm -f $(DESTDIR)$(bindir)/$(hwloc_ls_name)$(EXEEXT)
+	cd $(DESTDIR)$(bindir) && $(LN_S) $(lstopo_no_graphics_name)$(EXEEXT) $(hwloc_ls_name)$(EXEEXT)
 if !HWLOC_HAVE_WINDOWS
 if !HWLOC_HAVE_CAIRO
-	rm -f $(DESTDIR)$(bindir)/lstopo
-	cd $(DESTDIR)$(bindir) && $(LN_S) lstopo-no-graphics$(EXEEXT) lstopo$(EXEEXT) || true
+	rm -f $(DESTDIR)$(bindir)/$(lstopo_name)$(EXEEXT)
+	cd $(DESTDIR)$(bindir) && $(LN_S) $(lstopo_no_graphics_name)$(EXEEXT) $(lstopo_name)$(EXEEXT) || true
 endif
 endif
 
 install-data-hook:
-	rm -f $(DESTDIR)$(man1dir)/hwloc-ls.1
-	cd $(DESTDIR)$(man1dir) && $(LN_S) lstopo-no-graphics.1 hwloc-ls.1
-	rm -f $(DESTDIR)$(man1dir)/lstopo.1
-	cd $(DESTDIR)$(man1dir) && $(LN_S) lstopo-no-graphics.1 lstopo.1
+	rm -f $(DESTDIR)$(man1dir)/$(hwloc_ls_name).1
+	cd $(DESTDIR)$(man1dir) && $(LN_S) $(lstopo_no_graphics_name).1 $(hwloc_ls_name).1
+	rm -f $(DESTDIR)$(man1dir)/$(lstopo_name).1
+	cd $(DESTDIR)$(man1dir) && $(LN_S) $(lstopo_no_graphics_name).1 $(lstopo_name).1
 
 uninstall-local:
-	rm -f $(DESTDIR)$(bindir)/hwloc-ls$(EXEEXT)
+	rm -f $(DESTDIR)$(bindir)/$(hwloc_ls_name)$(EXEEXT)
 if !HWLOC_HAVE_WINDOWS
 if !HWLOC_HAVE_CAIRO
-	rm -f $(DESTDIR)$(bindir)/lstopo$(EXEEXT)
+	rm -f $(DESTDIR)$(bindir)/$(lstopo_name)$(EXEEXT)
 endif
 endif
-	rm -f $(DESTDIR)$(man1dir)/hwloc-ls.1 $(DESTDIR)$(man1dir)/lstopo.1
+	rm -f $(DESTDIR)$(man1dir)/$(hwloc_ls_name).1 $(DESTDIR)$(man1dir)/$(lstopo_name).1
 
 distclean-local:
 	rm -f $(nodist_man_MANS)

--- a/utils/netloc/infiniband/Makefile.am
+++ b/utils/netloc/infiniband/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright © 2013      University of Wisconsin-La Crosse.
 #                         All rights reserved.
 # Copyright © 2015-2018 Inria.  All rights reserved.
+# Copyright © 2023      Université de Reims Champagne-Ardenne.  All rights reserved.
 #
 # See COPYING in top-level directory.
 #
@@ -11,9 +12,11 @@ bin_SCRIPTS = \
         netloc_ib_gather_raw
 CLEANFILES = $(bin_SCRIPTS)
 
+netloc_ib_gather_raw_name=`echo "netloc_ib_gather_raw" | $(SED) -e "$(transform)"`
+
 install-exec-hook:
-	$(SED) -e 's/HWLOC_top_builddir\/utils\/lstopo/bindir/' -e '/HWLOC_top_builddir/d' $(DESTDIR)$(bindir)/netloc_ib_gather_raw > $(DESTDIR)$(bindir)/netloc_ib_gather_raw.tmp && mv -f $(DESTDIR)$(bindir)/netloc_ib_gather_raw.tmp $(DESTDIR)$(bindir)/netloc_ib_gather_raw
-	chmod +x $(DESTDIR)$(bindir)/netloc_ib_gather_raw
+	$(SED) -e 's/HWLOC_top_builddir\/utils\/lstopo/bindir/' -e '/HWLOC_top_builddir/d' $(DESTDIR)$(bindir)/$(netloc_ib_gather_raw_name) > $(DESTDIR)$(bindir)/$(netloc_ib_gather_raw_name).tmp && mv -f $(DESTDIR)$(bindir)/$(netloc_ib_gather_raw_name).tmp $(DESTDIR)$(bindir)/$(netloc_ib_gather_raw_name)
+	chmod +x $(DESTDIR)$(bindir)/$(netloc_ib_gather_raw_name)
 
 AM_CPPFLAGS = \
         -I$(top_builddir)/include \


### PR DESCRIPTION
Building with --target may add an unexpected prefix to the binary names. This commit uses the same mecanism to take this prefix in account.

Resolves #560