### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to brice.goglin@inria.fr; and/or
+- send us a [private vulnerability report](https://github.com/open-mpi/hwloc/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+Security fixes will only be applied to active stable branches (usually the last two
+stable branches, e.g. v2.9 and v2.8). Older branches might be considered if there is a
+strong reason not to upgrade.


### PR DESCRIPTION
Fixes #582.

As described in the issue, this PR adds a security policy to hwloc so researchers can more easily understand how to report possible vulnerabilities.

The policy currently uses an email listed in the codemeta.json file and which I believe belongs to the project's maintainer. It also allows reporting via GitHub's private reporting feature (needs to be enabled in the [project settings]((https://github.com/open-mpi/hwloc/settings/security_analysis))). Let me know if you'd rather use another email or just one of these reporting means (or another entirely!).

I've also added a 90-day remediation timeline, which is pretty standard. But just let me know if you'd rather change that (or anything else!).