### PR TITLE
utils/archivemount: propagate error when visiting subdirs

### DIFF
--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -325,6 +325,8 @@ hwloc_utils_enable_input_format(struct hwloc_topology *topology, unsigned long f
     err = hwloc_utils_enable_input_format(topology, flags, subdir, &sub_input_format, verbose, callname);
     if (!err)
       *input_format = sub_input_format;
+    else
+      return err;
 #else
     fprintf(stderr, "This installation of hwloc does not support loading from an archive, sorry.\n");
     exit(EXIT_FAILURE);


### PR DESCRIPTION
When using archivemount to load a topology, the directory hierarchy is traversed until a topology can be loaded. However, if an error occurs, it was silently ignored as the corresponding case reached the `break` and the `return 0` statements.

This commit adds the propagation of the error code (if it is not `0`).