### PR TITLE
Archivemount restore working dir

### DIFF
--- a/utils/hwloc/hwloc-calc.c
+++ b/utils/hwloc/hwloc-calc.c
@@ -3,6 +3,7 @@
  * Copyright © 2009-2023 Inria.  All rights reserved.
  * Copyright © 2009-2011 Université Bordeaux
  * Copyright © 2009-2010 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2023 Université de Reims Champagne-Ardenne.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -316,7 +317,7 @@ int main(int argc, char *argv[])
   unsigned long flags = HWLOC_TOPOLOGY_FLAG_IMPORT_SUPPORT;
   unsigned long restrict_flags = 0;
   char *input = NULL;
-  enum hwloc_utils_input_format input_format = HWLOC_UTILS_INPUT_DEFAULT;
+  struct hwloc_utils_input_format_s input_format = HWLOC_UTILS_INPUT_FORMAT_DEFAULT;
   int depth = 0;
   hwloc_bitmap_t set;
   int cmdline_args = 0;
@@ -462,6 +463,9 @@ int main(int argc, char *argv[])
       fprintf(stderr, "Couldn't find any CPU kind matching %s=%s, keeping no PU.\n", cpukind_infoname, cpukind_infovalue);
       /* FALLTHRU */
     }
+  }
+  if (input) {
+    hwloc_utils_disable_input_format(&input_format);
   }
 
   while (argc >= 1) {

--- a/utils/hwloc/hwloc-distrib.c
+++ b/utils/hwloc/hwloc-distrib.c
@@ -3,6 +3,7 @@
  * Copyright © 2009-2022 Inria.  All rights reserved.
  * Copyright © 2009-2010 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2023 Université de Reims Champagne-Ardenne.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -43,7 +44,7 @@ int main(int argc, char *argv[])
   long n = -1;
   char *callname;
   char *input = NULL;
-  enum hwloc_utils_input_format input_format = HWLOC_UTILS_INPUT_DEFAULT;
+  struct hwloc_utils_input_format_s input_format = HWLOC_UTILS_INPUT_FORMAT_DEFAULT;
   int taskset = 0;
   int singlify = 0;
   int verbose = 0;
@@ -229,7 +230,11 @@ int main(int argc, char *argv[])
     err = hwloc_topology_load(topology);
     if (err < 0) {
       free(cpuset);
+      if (input) hwloc_utils_disable_input_format(&input_format);
       return EXIT_FAILURE;
+    }
+    if (input) {
+      hwloc_utils_disable_input_format(&input_format);
     }
 
     if (restrictstring) {

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -3,6 +3,7 @@
  * Copyright © 2009-2022 Inria.  All rights reserved.
  * Copyright © 2009-2012 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2023 Université de Reims Champagne-Ardenne.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -495,7 +496,7 @@ main (int argc, char *argv[])
   unsigned long restrict_flags = 0;
   char * callname;
   char * input = NULL;
-  enum hwloc_utils_input_format input_format = HWLOC_UTILS_INPUT_DEFAULT;
+  struct hwloc_utils_input_format_s input_format = HWLOC_UTILS_INPUT_FORMAT_DEFAULT;
   const char *show_ancestor_type = NULL;
   const char *show_descendants_type = NULL;
   const char *best_memattr_str = NULL;
@@ -721,6 +722,7 @@ main (int argc, char *argv[])
     if (hwloc_pid_from_number(&pid, pid_number, 0, 1 /* verbose */) < 0
 	|| hwloc_topology_set_pid(topology, pid)) {
       perror("Setting target pid");
+      if (input) hwloc_utils_disable_input_format(&input_format);
       return EXIT_FAILURE;
     }
   }
@@ -728,7 +730,12 @@ main (int argc, char *argv[])
   err = hwloc_topology_load (topology);
   if (err) {
     perror("hwloc_topology_load");
+    if (input) hwloc_utils_disable_input_format(&input_format);
     return EXIT_FAILURE;
+  }
+
+  if (input) {
+    hwloc_utils_disable_input_format(&input_format);
   }
 
   topodepth = hwloc_topology_get_depth(topology);

--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -3,6 +3,7 @@
  * Copyright © 2009-2023 Inria.  All rights reserved.
  * Copyright © 2009-2012 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2023 Université de Reims Champagne-Ardenne.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -26,6 +27,7 @@
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
 #endif
+#include <fcntl.h>
 #include <assert.h>
 
 extern void usage(const char *name, FILE *where);
@@ -80,15 +82,19 @@ hwloc_utils_input_format_usage(FILE *where, int addspaces)
 	   addspaces, " ");
 }
 
-enum hwloc_utils_input_format {
-  HWLOC_UTILS_INPUT_DEFAULT,
-  HWLOC_UTILS_INPUT_XML,
-  HWLOC_UTILS_INPUT_FSROOT,
-  HWLOC_UTILS_INPUT_SYNTHETIC,
-  HWLOC_UTILS_INPUT_CPUID,
-  HWLOC_UTILS_INPUT_SHMEM,
-  HWLOC_UTILS_INPUT_ARCHIVE
+struct hwloc_utils_input_format_s {
+  enum hwloc_utils_input_format {
+    HWLOC_UTILS_INPUT_DEFAULT,
+    HWLOC_UTILS_INPUT_XML,
+    HWLOC_UTILS_INPUT_FSROOT,
+    HWLOC_UTILS_INPUT_SYNTHETIC,
+    HWLOC_UTILS_INPUT_CPUID,
+    HWLOC_UTILS_INPUT_SHMEM,
+    HWLOC_UTILS_INPUT_ARCHIVE
+  } format;
+  int oldworkdir;
 };
+#define HWLOC_UTILS_INPUT_FORMAT_DEFAULT (struct hwloc_utils_input_format_s) { HWLOC_UTILS_INPUT_DEFAULT, -1 }
 
 static __hwloc_inline enum hwloc_utils_input_format
 hwloc_utils_parse_input_format(const char *name, const char *callname)
@@ -115,7 +121,7 @@ hwloc_utils_parse_input_format(const char *name, const char *callname)
 
 static __hwloc_inline int
 hwloc_utils_lookup_input_option(char *argv[], int argc, int *consumed_opts,
-				char **inputp, enum hwloc_utils_input_format *input_formatp,
+				char **inputp, struct hwloc_utils_input_format_s *input_formatp,
 				const char *callname)
 {
   if (!strcmp (argv[0], "--input")
@@ -137,7 +143,8 @@ hwloc_utils_lookup_input_option(char *argv[], int argc, int *consumed_opts,
       usage (callname, stderr);
       exit(EXIT_FAILURE);
     }
-    *input_formatp = hwloc_utils_parse_input_format (argv[1], callname);
+    *input_formatp = HWLOC_UTILS_INPUT_FORMAT_DEFAULT;
+    input_formatp->format = hwloc_utils_parse_input_format (argv[1], callname);
     *consumed_opts = 1;
     return 1;
   }
@@ -202,9 +209,10 @@ hwloc_utils_autodetect_input_format(const char *input, int verbose)
 static __hwloc_inline int
 hwloc_utils_enable_input_format(struct hwloc_topology *topology, unsigned long flags,
 				const char *input,
-				enum hwloc_utils_input_format *input_format,
+				struct hwloc_utils_input_format_s *input_formatp,
 				int verbose, const char *callname)
 {
+  enum hwloc_utils_input_format *input_format = &input_formatp->format;
   if (*input_format == HWLOC_UTILS_INPUT_DEFAULT && !strcmp(input, "-.xml")) {
     *input_format = HWLOC_UTILS_INPUT_XML;
     input = "-";
@@ -283,12 +291,23 @@ hwloc_utils_enable_input_format(struct hwloc_topology *topology, unsigned long f
     char umntcmd[512];
     DIR *dir;
     struct dirent *dirent;
-    enum hwloc_utils_input_format sub_input_format;
+    /* oldworkdir == -1 -> close would fail if !defined(O_PATH), but we don't care */
+    struct hwloc_utils_input_format_s sub_input_format = HWLOC_UTILS_INPUT_FORMAT_DEFAULT;
     char *subdir = NULL;
     int err;
 
+#ifdef O_PATH
+    if (-1 == input_formatp->oldworkdir) { /* if archivemount'ed recursively, only keep the first oldworkdir */
+        sub_input_format.oldworkdir = open(".", O_DIRECTORY|O_PATH); /* more efficient than getcwd(3) */
+        if (sub_input_format.oldworkdir < 0) {
+            perror("Saving current working directory");
+            return EXIT_FAILURE;
+        }
+    }
+#endif
     if (!mkdtemp(mntpath)) {
       perror("Creating archivemount directory");
+      close(sub_input_format.oldworkdir);
       return EXIT_FAILURE;
     }
     snprintf(mntcmd, sizeof(mntcmd), "archivemount -o ro %s %s", input, mntpath);
@@ -296,6 +315,7 @@ hwloc_utils_enable_input_format(struct hwloc_topology *topology, unsigned long f
     if (err) {
       perror("Archivemount'ing the archive");
       rmdir(mntpath);
+      close(sub_input_format.oldworkdir);
       return EXIT_FAILURE;
     }
     snprintf(umntcmd, sizeof(umntcmd), "umount -l %s", mntpath);
@@ -317,16 +337,18 @@ hwloc_utils_enable_input_format(struct hwloc_topology *topology, unsigned long f
 
     if (!subdir) {
       perror("No subdirectory in archivemount directory");
+      close(sub_input_format.oldworkdir);
       return EXIT_FAILURE;
     }
 
     /* call ourself recursively on subdir, it should be either a fsroot or a cpuid directory */
-    sub_input_format = HWLOC_UTILS_INPUT_DEFAULT;
     err = hwloc_utils_enable_input_format(topology, flags, subdir, &sub_input_format, verbose, callname);
     if (!err)
-      *input_format = sub_input_format;
-    else
+      *input_formatp = sub_input_format;
+    else {
+      close(sub_input_format.oldworkdir);
       return err;
+    }
 #else
     fprintf(stderr, "This installation of hwloc does not support loading from an archive, sorry.\n");
     exit(EXIT_FAILURE);
@@ -349,6 +371,28 @@ hwloc_utils_enable_input_format(struct hwloc_topology *topology, unsigned long f
   }
 
   return 0;
+}
+
+static __hwloc_inline void
+hwloc_utils_disable_input_format(struct hwloc_utils_input_format_s *input_format)
+{
+  if (-1 < input_format->oldworkdir) {
+#ifdef HWLOC_LINUX_SYS
+#ifdef O_PATH
+    int err = fchdir(input_format->oldworkdir);
+    if (err) {
+      perror("Restoring current working directory");
+    }
+#else
+    fprintf(stderr, "Couldn't restore working directory. Errors may arise.\n");
+#endif
+    close(input_format->oldworkdir);
+    input_format->oldworkdir = -1;
+#else
+    fprintf(stderr, "oldworkdir should not have been changed. You should not have reached this execution branch.\n");
+    exit(EXIT_FAILURE);
+#endif
+  }
 }
 
 static __hwloc_inline void

--- a/utils/lstopo/lstopo.c
+++ b/utils/lstopo/lstopo.c
@@ -4,6 +4,7 @@
  * Copyright © 2009-2012, 2015, 2017 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright © 2020 Hewlett Packard Enterprise.  All rights reserved.
+ * Copyright © 2023 Université de Reims Champagne-Ardenne.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -804,7 +805,7 @@ main (int argc, char *argv[])
   hwloc_bitmap_t allow_cpuset = NULL, allow_nodeset = NULL;
   char * callname;
   char * input = NULL;
-  enum hwloc_utils_input_format input_format = HWLOC_UTILS_INPUT_DEFAULT;
+  struct hwloc_utils_input_format_s input_format = HWLOC_UTILS_INPUT_FORMAT_DEFAULT;
   enum output_format output_format = LSTOPO_OUTPUT_DEFAULT;
   struct lstopo_type_filter type_filter[HWLOC_OBJ_TYPE_MAX];
   char *restrictstring = NULL;
@@ -1671,7 +1672,7 @@ main (int argc, char *argv[])
     if (err)
       goto out_with_topology;
 
-    if (input_format != HWLOC_UTILS_INPUT_DEFAULT) {
+    if (input_format.format != HWLOC_UTILS_INPUT_DEFAULT) {
       /* add the input path to the window title */
       snprintf(loutput.title, sizeof(loutput.title), "lstopo - %s", input);
 
@@ -1704,7 +1705,7 @@ main (int argc, char *argv[])
     }
   }
 
-  if (input_format == HWLOC_UTILS_INPUT_XML
+  if (input_format.format == HWLOC_UTILS_INPUT_XML
       && output_format == LSTOPO_OUTPUT_XML) {
     /* must be after parsing output format and before loading the topology */
     putenv((char *) "HWLOC_XML_USERDATA_NOT_DECODED=1");
@@ -1723,7 +1724,7 @@ main (int argc, char *argv[])
     clock_gettime(CLOCK_MONOTONIC, &ts1);
 #endif
 
-  if (input_format == HWLOC_UTILS_INPUT_SHMEM) {
+  if (input_format.format == HWLOC_UTILS_INPUT_SHMEM) {
 #ifdef HWLOC_WIN_SYS
     fprintf(stderr, "shmem topology not supported\n"); /* this line must match the grep line in test-lstopo-shmem */
     goto out_with_topology;
@@ -1752,6 +1753,14 @@ main (int argc, char *argv[])
     printf("hwloc_topology_load() took %lu ms\n", ms);
   }
 #endif
+
+  /********************************
+   * Clean input format's internal variables
+   */
+
+  if (input) {
+    hwloc_utils_disable_input_format(&input_format);
+  }
 
   /********************************
    * Tweak the topology and output
@@ -1867,6 +1876,7 @@ main (int argc, char *argv[])
   lstopo_destroy_userdata(hwloc_get_root_obj(topology));
   hwloc_topology_destroy(topology);
  out:
+  if (input) hwloc_utils_disable_input_format(&input_format);
   hwloc_bitmap_free(allow_cpuset);
   hwloc_bitmap_free(allow_nodeset);
   hwloc_bitmap_free(loutput.cpubind_set);


### PR DESCRIPTION
This PR saves the current working directory and restores it after the topology has been loaded.

Solves #577 by ensuring the current directory does not change (at least not from a side effect of loading a topology).