### PR TITLE
[WIP DNM] levelzero: use zesInit() when available

### DIFF
--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -54,9 +54,10 @@
 #endif
 
 
-#ifdef HWLOC_HAVE_LEVELZERO
+#if (defined HWLOC_HAVE_LEVELZERO) && !(defined HWLOC_HAVE_ZESINIT)
 /*
  * Define ZES_ENABLE_SYSMAN=1 early so that the LevelZero backend gets Sysman enabled.
+ * This is only for old releases (<1.5) without zesInit().
  *
  * Only if the levelzero was enabled in this build so that we don't enable sysman
  * for external levelzero users when hwloc doesn't need it. If somebody ever loads
@@ -101,7 +102,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved)
   return TRUE;
 }
 #endif
-#endif /* HWLOC_HAVE_LEVELZERO */
+#endif /* HWLOC_HAVE_LEVELZERO && !HWLOC_HAVE_ZESINIT */
 
 
 unsigned hwloc_get_api_version(void)

--- a/tests/hwloc/levelzero.c
+++ b/tests/hwloc/levelzero.c
@@ -26,19 +26,19 @@ int main(void)
 #ifdef HWLOC_HAVE_ZESINIT
   res = zesInit(0);
   if (res != ZE_RESULT_SUCCESS) {
-    fprintf(stderr, "Failed to initialize LevelZero Sysman in zesInit(): %d\n", (int)res);
-    /* continuing, assuming ZES_ENABLE_SYSMAN=1 will be enough */
+    fprintf(stderr, "Failed to initialize LevelZero in zesInit(): %d\n", (int)res);
+    return 0;
   }
-#endif
-
+#else
   putenv((char *) "ZES_ENABLE_SYSMAN=1");
+#endif
 
   res = zeInit(0);
   if (res != ZE_RESULT_SUCCESS) {
     fprintf(stderr, "Failed to initialize LevelZero in zeInit(): %d\n", (int)res);
     return 0;
   }
-  
+
   hwloc_topology_init(&topology);
   hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
   hwloc_topology_load(topology);

--- a/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
+++ b/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
@@ -8,6 +8,7 @@
 
 typedef int ze_result_t;
 #define ZE_RESULT_SUCCESS 0
+#define ZE_RESULT_ERROR_UNSUPPORTED_FEATURE 0x78000003
 
 #define ZE_MAX_DEVICE_NAME 64
 


### PR DESCRIPTION
Don't merge until a compute-runtime release supports zesInit(). Blacklist the releases with unsupported zesInit() in the error messages before merging this PR.

Refs #687

TODO just drop releases without zesInit() and abort if the backend if zesInit() fails
TODO check whether zesInit() must be called in a constructor before any other zeInit() or just in the hwloc backend as usual.
TODO requires oneapi-src/level-zero#153