### PR TITLE
levelzero: only use Sysman queries instead of similar Core API queries

### DIFF
--- a/hwloc/topology-levelzero.c
+++ b/hwloc/topology-levelzero.c
@@ -63,16 +63,21 @@ hwloc__levelzero_osdev_array_find(struct hwloc_osdev_array *array,
 
 static void
 hwloc__levelzero_properties_get(ze_device_handle_t zeh, zes_device_handle_t zesh,
-                                hwloc_obj_t osdev)
+                                hwloc_obj_t osdev, ze_device_properties_t *prop)
 {
   ze_result_t res;
-  ze_device_properties_t prop;
+  ze_device_properties_t _prop;
   zes_device_properties_t prop2;
   int is_subdevice = 0;
 
-  memset(&prop, 0, sizeof(prop));
-  res = zeDeviceGetProperties(zeh, &prop);
-  if (res == ZE_RESULT_SUCCESS) {
+  if (!prop) {
+    /* no properties were given, get ours */
+    memset(&_prop, 0, sizeof(_prop));
+    res = zeDeviceGetProperties(zeh, &_prop);
+    if (res == ZE_RESULT_SUCCESS)
+      prop = &_prop;
+  }
+  if (prop) {
     /* name is the model name followed by the deviceID
      * flags 1<<0 means integrated (vs discrete).
      */
@@ -81,7 +86,7 @@ hwloc__levelzero_properties_get(ze_device_handle_t zeh, zes_device_handle_t zesh
     unsigned i;
     const char *type;
 
-    switch (prop.type) {
+    switch (prop->type) {
     case ZE_DEVICE_TYPE_GPU: type = "GPU"; break;
     case ZE_DEVICE_TYPE_CPU: type = "CPU"; break;
     case ZE_DEVICE_TYPE_FPGA: type = "FPGA"; break;
@@ -89,24 +94,24 @@ hwloc__levelzero_properties_get(ze_device_handle_t zeh, zes_device_handle_t zesh
     case ZE_DEVICE_TYPE_VPU: type = "VPU"; break;
     default:
       if (HWLOC_SHOW_ALL_ERRORS())
-        fprintf(stderr, "hwloc/levelzero: unexpected device type %u\n", (unsigned) prop.type);
+        fprintf(stderr, "hwloc/levelzero: unexpected device type %u\n", (unsigned) prop->type);
       type = "Unknown";
     }
     hwloc_obj_add_info(osdev, "LevelZeroDeviceType", type);
-    snprintf(tmp, sizeof(tmp), "%u", prop.numSlices);
+    snprintf(tmp, sizeof(tmp), "%u", prop->numSlices);
     hwloc_obj_add_info(osdev, "LevelZeroNumSlices", tmp);
-    snprintf(tmp, sizeof(tmp), "%u", prop.numSubslicesPerSlice);
+    snprintf(tmp, sizeof(tmp), "%u", prop->numSubslicesPerSlice);
     hwloc_obj_add_info(osdev, "LevelZeroNumSubslicesPerSlice", tmp);
-    snprintf(tmp, sizeof(tmp), "%u", prop.numEUsPerSubslice);
+    snprintf(tmp, sizeof(tmp), "%u", prop->numEUsPerSubslice);
     hwloc_obj_add_info(osdev, "LevelZeroNumEUsPerSubslice", tmp);
-    snprintf(tmp, sizeof(tmp), "%u", prop.numThreadsPerEU);
+    snprintf(tmp, sizeof(tmp), "%u", prop->numThreadsPerEU);
     hwloc_obj_add_info(osdev, "LevelZeroNumThreadsPerEU", tmp);
 
     for(i=0; i<ZE_MAX_DEVICE_UUID_SIZE; i++)
-      snprintf(uuid+2*i, 3, "%02x", prop.uuid.id[i]);
+      snprintf(uuid+2*i, 3, "%02x", prop->uuid.id[i]);
     hwloc_obj_add_info(osdev, "LevelZeroUUID", uuid);
 
-    if (prop.flags & ZE_DEVICE_PROPERTY_FLAG_SUBDEVICE)
+    if (prop->flags & ZE_DEVICE_PROPERTY_FLAG_SUBDEVICE)
       is_subdevice = 1;
   }
 
@@ -485,7 +490,7 @@ hwloc__levelzero_devices_get(struct hwloc_topology *topology,
       snprintf(buffer, sizeof(buffer), "%u", j);
       hwloc_obj_add_info(osdev, "LevelZeroDriverDeviceIndex", buffer);
 
-      hwloc__levelzero_properties_get(zeh, zesh, osdev);
+      hwloc__levelzero_properties_get(zeh, zesh, osdev, &props);
 
       hwloc__levelzero_cqprops_get(zeh, osdev);
 
@@ -529,7 +534,7 @@ hwloc__levelzero_devices_get(struct hwloc_topology *topology,
             snprintf(tmp, sizeof(tmp), "%u", k);
             hwloc_obj_add_info(subosdevs[k], "LevelZeroSubdeviceID", tmp);
 
-            hwloc__levelzero_properties_get(subzeh, subzesh, subosdevs[k]);
+            hwloc__levelzero_properties_get(subzeh, subzesh, subosdevs[k], NULL);
 
             hwloc__levelzero_cqprops_get(subzeh, subosdevs[k]);
           }

--- a/hwloc/topology-levelzero.c
+++ b/hwloc/topology-levelzero.c
@@ -63,14 +63,12 @@ hwloc__levelzero_osdev_array_find(struct hwloc_osdev_array *array,
 
 static void
 hwloc__levelzero_properties_get(ze_device_handle_t zeh, zes_device_handle_t zesh,
-                                hwloc_obj_t osdev,
-                                int *is_integrated_p)
+                                hwloc_obj_t osdev)
 {
   ze_result_t res;
   ze_device_properties_t prop;
   zes_device_properties_t prop2;
   int is_subdevice = 0;
-  int is_integrated = 0;
 
   memset(&prop, 0, sizeof(prop));
   res = zeDeviceGetProperties(zeh, &prop);
@@ -110,13 +108,7 @@ hwloc__levelzero_properties_get(ze_device_handle_t zeh, zes_device_handle_t zesh
 
     if (prop.flags & ZE_DEVICE_PROPERTY_FLAG_SUBDEVICE)
       is_subdevice = 1;
-
-    if (prop.flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED)
-      is_integrated = 1;
   }
-
-  if (is_integrated_p)
-    *is_integrated_p = is_integrated;
 
   if (is_subdevice)
     /* sysman API on subdevice returns the same as root device, and we don't need those duplicate attributes */
@@ -462,7 +454,6 @@ hwloc__levelzero_devices_get(struct hwloc_topology *topology,
       hwloc_obj_t osdev, parent, *subosdevs = NULL;
       ze_device_properties_t props;
       zes_uuid_t uuid;
-      int is_integrated = 0;
       ze_bool_t onSubdevice = 0;
       uint32_t subdeviceId = 0;
 
@@ -494,7 +485,7 @@ hwloc__levelzero_devices_get(struct hwloc_topology *topology,
       snprintf(buffer, sizeof(buffer), "%u", j);
       hwloc_obj_add_info(osdev, "LevelZeroDriverDeviceIndex", buffer);
 
-      hwloc__levelzero_properties_get(zeh, zesh, osdev, &is_integrated);
+      hwloc__levelzero_properties_get(zeh, zesh, osdev);
 
       hwloc__levelzero_cqprops_get(zeh, osdev);
 
@@ -538,7 +529,7 @@ hwloc__levelzero_devices_get(struct hwloc_topology *topology,
             snprintf(tmp, sizeof(tmp), "%u", k);
             hwloc_obj_add_info(subosdevs[k], "LevelZeroSubdeviceID", tmp);
 
-            hwloc__levelzero_properties_get(subzeh, subzesh, subosdevs[k], NULL);
+            hwloc__levelzero_properties_get(subzeh, subzesh, subosdevs[k]);
 
             hwloc__levelzero_cqprops_get(subzeh, subosdevs[k]);
           }

--- a/include/hwloc/levelzero.h
+++ b/include/hwloc/levelzero.h
@@ -166,6 +166,10 @@ hwloc_levelzero_get_sysman_device_cpuset(hwloc_topology_t topology __hwloc_attri
  * topology. If not, the locality of the object may still be found using
  * hwloc_levelzero_get_device_cpuset().
  *
+ * \note If the input ZE device is actually a subdevice, then its parent
+ * (root device) is actually translated, i.e. the main hwloc OS device
+ * is returned instead of one of its children.
+ *
  * \note The corresponding hwloc PCI device may be found by looking
  * at the result parent pointer (unless PCI devices are filtered out).
  *
@@ -230,6 +234,10 @@ hwloc_levelzero_get_device_osdev(hwloc_topology_t topology, ze_device_handle_t d
  * I/O devices detection and the Level Zero component must be enabled in the
  * topology. If not, the locality of the object may still be found using
  * hwloc_levelzero_get_device_cpuset().
+ *
+ * \note If the input ZES device is actually a subdevice, then its parent
+ * (root device) is actually translated, i.e. the main hwloc OS device
+ * is returned instead of one of its children.
  *
  * \note The corresponding hwloc PCI device may be found by looking
  * at the result parent pointer (unless PCI devices are filtered out).

--- a/tests/hwloc/levelzero.c
+++ b/tests/hwloc/levelzero.c
@@ -185,18 +185,17 @@ int main(void)
       printf("found OSDev %s\n", osdev->name);
       err = strncmp(osdev->name, "ze", 2);
       assert(!err);
-      assert(atoi(osdev->name+2) == (int) k);
+      /* don't check the index,
+       * ZE and ZES device orders may be different inside a single driver.
+       */
 
       assert(osdev->attr->osdev.types == (HWLOC_OBJ_OSDEV_COPROC|HWLOC_OBJ_OSDEV_GPU));
 
       assert(has_levelzero_backend);
 
-      value = hwloc_obj_get_info_by_name(osdev, "LevelZeroDriverIndex");
-      assert(value);
-      assert(atoi(value) == (int) i);
-      value = hwloc_obj_get_info_by_name(osdev, "LevelZeroDriverDeviceIndex");
-      assert(value);
-      assert(atoi(value) == (int) j);
+      /* don't check LevelZeroDriverIndex and LevelZeroDriverDeviceIndex,
+       * ZE and ZES device orders may be different inside a single driver.
+       */
 
       set = hwloc_bitmap_alloc();
       err = hwloc_levelzero_get_sysman_device_cpuset(topology, sdvh[j], set);

--- a/tests/hwloc/levelzero.c
+++ b/tests/hwloc/levelzero.c
@@ -164,7 +164,7 @@ int main(void)
     sdvh = malloc(nbdevices * sizeof(*sdvh));
     if (!sdvh)
       continue;
-    res = zeDeviceGet(sdrh[i], &nbdevices, sdvh);
+    res = zesDeviceGet(sdrh[i], &nbdevices, sdvh);
     if (res != ZE_RESULT_SUCCESS) {
       free(sdvh);
       continue;

--- a/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
+++ b/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
@@ -28,7 +28,6 @@ typedef enum _ze_device_type {
   ZE_DEVICE_TYPE_VPU = 5
 } ze_device_type_t;
 
-#define ZE_DEVICE_PROPERTY_FLAG_INTEGRATED (1<<0)
 #define ZE_DEVICE_PROPERTY_FLAG_SUBDEVICE (1<<1)
 
 #define ZE_MAX_DEVICE_UUID_SIZE 16

--- a/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
+++ b/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
@@ -58,13 +58,6 @@ extern ze_result_t zeDeviceGetCommandQueueGroupProperties(ze_driver_handle_t, ui
 
 extern ze_result_t zeDeviceGetSubDevices(ze_device_handle_t, uint32_t *, ze_device_handle_t*);
 
-typedef struct ze_device_memory_properties {
-  uint64_t totalSize;
-  char *name;
-} ze_device_memory_properties_t;
-
-extern ze_result_t zeDeviceGetMemoryProperties(ze_device_handle_t, uint32_t *, ze_device_memory_properties_t*);
-
 typedef struct ze_pci_address_ext {
   uint32_t domain, bus, device, function;
 } ze_pci_address_ext_t;


### PR DESCRIPTION
~~This goes on top of #594 which might be merged once a compute-runtime release brings a working zesInit(). This PR requires zesInit() to be more widely available, especially the last commit which completely remove the old setting of ZES_ENABLE_SYSMAN=1 in the env.~~
Now that we require zesInit(), just use ZES queries instead of switching from/to the Core API depending on ZES being available or not.