### PR TITLE
Clean utils args

### DIFF
--- a/utils/hwloc/common-ps.c
+++ b/utils/hwloc/common-ps.c
@@ -23,8 +23,8 @@
 #include "misc.h"
 
 int hwloc_ps_read_process(hwloc_topology_t topology, hwloc_const_bitmap_t topocpuset,
-			  struct hwloc_ps_process *proc,
-			  unsigned long flags)
+                          struct hwloc_ps_process *proc,
+                          unsigned long flags)
 {
 #ifdef HAVE_DIRENT_H
   hwloc_pid_t realpid;
@@ -68,9 +68,9 @@ int hwloc_ps_read_process(hwloc_topology_t topology, hwloc_const_bitmap_t topocp
       n = read(fd, comm, sizeof(comm) - 1);
       close(fd);
       if (n > 0) {
-	comm[n] = '\0';
-	if (n > 1 && comm[n-1] == '\n')
-	  comm[n-1] = '\0';
+        comm[n] = '\0';
+        if (n > 1 && comm[n-1] == '\n')
+          comm[n-1] = '\0';
       }
 
     } else {
@@ -81,19 +81,19 @@ int hwloc_ps_read_process(hwloc_topology_t topology, hwloc_const_bitmap_t topocp
       snprintf(path, pathlen, "/proc/%ld/stat", proc->pid);
       fd = open(path, O_RDONLY);
       if (fd >= 0) {
-	/* "pid (comm) ..." */
-	n = read(fd, stats, sizeof(stats) - 1);
-	close(fd);
-	if (n > 0) {
-	  stats[n] = '\0';
-	  parenl = strchr(stats, '(');
-	  parenr = strchr(stats, ')');
-	  if (!parenr)
-	    parenr = &stats[sizeof(stats)-1];
-	  *parenr = '\0';
-	  if (parenl)
-	    snprintf(comm, sizeof(comm), "%s", parenl+1);
-	}
+        /* "pid (comm) ..." */
+        n = read(fd, stats, sizeof(stats) - 1);
+        close(fd);
+        if (n > 0) {
+          stats[n] = '\0';
+          parenl = strchr(stats, '(');
+          parenr = strchr(stats, ')');
+          if (!parenr)
+            parenr = &stats[sizeof(stats)-1];
+          *parenr = '\0';
+          if (parenl)
+            snprintf(comm, sizeof(comm), "%s", parenl+1);
+        }
       }
     }
 
@@ -147,78 +147,78 @@ int hwloc_ps_read_process(hwloc_topology_t topology, hwloc_const_bitmap_t topocp
       unsigned nbth = 0;
       /* count threads */
       while ((taskdirent = readdir(taskdir))) {
-	tid = strtol(taskdirent->d_name, &end, 10);
-	if (*end)
-	  /* Not a number */
-	  continue;
-	nbth++;
+        tid = strtol(taskdirent->d_name, &end, 10);
+        if (*end)
+          /* Not a number */
+          continue;
+        nbth++;
       }
       if (nbth > 1) {
-	/* if there's more than one thread, see if some are bound */
-	proc->threads = calloc(nbth, sizeof(*proc->threads));
-	if (proc->threads) {
-	  /* reread the directory but gather info now */
-	  rewinddir(taskdir);
-	  unsigned i = 0;
-	  while ((taskdirent = readdir(taskdir))) {
-	    char *path2;
-	    unsigned path2len;
+        /* if there's more than one thread, see if some are bound */
+        proc->threads = calloc(nbth, sizeof(*proc->threads));
+        if (proc->threads) {
+          /* reread the directory but gather info now */
+          rewinddir(taskdir);
+          unsigned i = 0;
+          while ((taskdirent = readdir(taskdir))) {
+            char *path2;
+            unsigned path2len;
 
-	    tid = strtol(taskdirent->d_name, &end, 10);
-	    if (*end)
-	      /* Not a number */
-	      continue;
+            tid = strtol(taskdirent->d_name, &end, 10);
+            if (*end)
+              /* Not a number */
+              continue;
 
-	    proc->threads[i].tid = tid;
+            proc->threads[i].tid = tid;
 
-	    path2len = pathlen + 1 + 21 + 1 + 4 + 1;
-	    path2 = malloc(path2len);
-	    if (path2) {
-	      int commfd;
-	      snprintf(path2, path2len, "%s/%ld/comm", path, tid);
-	      commfd = open(path2, O_RDWR);
-	      if (commfd >= 0) {
-		n = read(commfd, proc->threads[i].name, sizeof(proc->threads[i].name));
-		close(commfd);
-		if (n <= 0)
-		  proc->threads[i].name[0] = '\0';
-		else if ((size_t)n < sizeof(proc->threads[i].name))
-		  proc->threads[i].name[n] = '\0';
-		proc->threads[i].name[sizeof(proc->threads[i].name)-1] = '\0';
-		end = strchr(proc->threads[i].name, '\n');
-		if (end)
-		  *end = '\0';
-	      }
-	      free(path2);
-	    }
+            path2len = pathlen + 1 + 21 + 1 + 4 + 1;
+            path2 = malloc(path2len);
+            if (path2) {
+              int commfd;
+              snprintf(path2, path2len, "%s/%ld/comm", path, tid);
+              commfd = open(path2, O_RDWR);
+              if (commfd >= 0) {
+                n = read(commfd, proc->threads[i].name, sizeof(proc->threads[i].name));
+                close(commfd);
+                if (n <= 0)
+                  proc->threads[i].name[0] = '\0';
+                else if ((size_t)n < sizeof(proc->threads[i].name))
+                  proc->threads[i].name[n] = '\0';
+                proc->threads[i].name[sizeof(proc->threads[i].name)-1] = '\0';
+                end = strchr(proc->threads[i].name, '\n');
+                if (end)
+                  *end = '\0';
+              }
+              free(path2);
+            }
 
-	    if (flags & HWLOC_PS_FLAG_LASTCPULOCATION) {
-	      if (hwloc_linux_get_tid_last_cpu_location(topology, tid, cpuset))
-		goto next;
-	    } else {
-	      if (hwloc_linux_get_tid_cpubind(topology, tid, cpuset))
-		goto next;
-	    }
-	    hwloc_bitmap_and(cpuset, cpuset, topocpuset);
-	    if (hwloc_bitmap_iszero(cpuset))
-	      goto next;
+            if (flags & HWLOC_PS_FLAG_LASTCPULOCATION) {
+              if (hwloc_linux_get_tid_last_cpu_location(topology, tid, cpuset))
+                goto next;
+            } else {
+              if (hwloc_linux_get_tid_cpubind(topology, tid, cpuset))
+                goto next;
+            }
+            hwloc_bitmap_and(cpuset, cpuset, topocpuset);
+            if (hwloc_bitmap_iszero(cpuset))
+              goto next;
 
-	    proc->threads[i].cpuset = hwloc_bitmap_dup(cpuset);
-	    if (!hwloc_bitmap_isequal(cpuset, topocpuset)) {
-	      proc->threads[i].bound = 1;
-	      proc->nboundthreads++;
-	    }
+            proc->threads[i].cpuset = hwloc_bitmap_dup(cpuset);
+            if (!hwloc_bitmap_isequal(cpuset, topocpuset)) {
+              proc->threads[i].bound = 1;
+              proc->nboundthreads++;
+            }
 
-	  next:
-	    i++;
-	    proc->nthreads++;
-	    if (i == nbth)
-	      /* ignore the lastly created threads, I'm too lazy to reallocate */
-	      break;
-	  }
-	} else {
-	  /* failed to alloc, behave as if there were no threads */
-	}
+          next:
+            i++;
+            proc->nthreads++;
+            if (i == nbth)
+              /* ignore the lastly created threads, I'm too lazy to reallocate */
+              break;
+          }
+        } else {
+          /* failed to alloc, behave as if there were no threads */
+        }
       }
       closedir(taskdir);
     }
@@ -342,16 +342,16 @@ void hwloc_ps_free_process(struct hwloc_ps_process *proc)
   if (proc->nthreads)
     for(i=0; i<proc->nthreads; i++)
       if (proc->threads[i].cpuset)
-	hwloc_bitmap_free(proc->threads[i].cpuset);
+        hwloc_bitmap_free(proc->threads[i].cpuset);
   free(proc->threads);
 
   hwloc_bitmap_free(proc->cpuset);
 }
 
 int hwloc_ps_foreach_process(hwloc_topology_t topology, hwloc_const_bitmap_t topocpuset,
-			     void (*callback)(hwloc_topology_t topology, struct hwloc_ps_process *proc, void *cbdata),
-			     void *cbdata,
-			     unsigned long flags, const char *only_name, long uid)
+                             void (*callback)(hwloc_topology_t topology, struct hwloc_ps_process *proc, void *cbdata),
+                             void *cbdata,
+                             unsigned long flags, const char *only_name, long uid)
 {
 #ifdef HAVE_DIRENT_H
   DIR *dir;

--- a/utils/hwloc/common-ps.h
+++ b/utils/hwloc/common-ps.h
@@ -37,13 +37,13 @@ struct hwloc_ps_process {
 #define HWLOC_PS_FLAG_UID (1UL<<3)
 
 int hwloc_ps_read_process(hwloc_topology_t topology, hwloc_const_bitmap_t topocpuset,
-			  struct hwloc_ps_process *proc,
-			  unsigned long flags);
+                          struct hwloc_ps_process *proc,
+                          unsigned long flags);
 
 int hwloc_ps_foreach_process(hwloc_topology_t topology, hwloc_const_bitmap_t topocpuset,
-			     void (*callback)(hwloc_topology_t topology, struct hwloc_ps_process *proc, void *cbdata),
-			     void *cbdata,
-			     unsigned long flags, const char *only_name, long only_uid);
+                             void (*callback)(hwloc_topology_t topology, struct hwloc_ps_process *proc, void *cbdata),
+                             void *cbdata,
+                             unsigned long flags, const char *only_name, long only_uid);
 
 int hwloc_ps_foreach_child(hwloc_topology_t topology, hwloc_const_bitmap_t topocpuset,
                            long pid,

--- a/utils/hwloc/hwloc-annotate.c
+++ b/utils/hwloc/hwloc-annotate.c
@@ -14,32 +14,32 @@
 
 void usage(const char *callname __hwloc_attribute_unused, FILE *where)
 {
-	fprintf(where, "Usage: hwloc-annotate [options] <input.xml> <output.xml> -- <location1> <location2> ... -- <annotation>\n");
-	fprintf(where, "Usage: hwloc-annotate [options] <input.xml> <output.xml> <location> <annotation>\n");
-	fprintf(where, "  <location> may be:\n");
-	fprintf(where, "    all, root, <type>:<logicalindex>, <type>:all\n");
-	fprintf(where, "  <annotation> may be:\n");
-	fprintf(where, "    info <name> <value>\n");
-	fprintf(where, "    subtype <subtype>\n");
-	fprintf(where, "    size <memory or cache size>\n");
-	fprintf(where, "    misc <name>\n");
-	fprintf(where, "    distances <filename> [<flags>]\n");
-	fprintf(where, "    memattr <name> <flags>\n");
-	fprintf(where, "    memattr <name> <initiator> <value>\n");
-        fprintf(where, "    cpukind <cpuset> <efficiency> <flags> [<infoname> <infovalue>]\n");
-        fprintf(where, "    distances-transform <name> links\n");
-        fprintf(where, "    distances-transform <name> merge-switch-ports\n");
-        fprintf(where, "    distances-transform <name> transitive-closure\n");
-        fprintf(where, "    distances-transform <name> remove-obj <obj>\n");
-        fprintf(where, "    distances-transform <name> replace-objs <oldtype> <newtype>\n");
-	fprintf(where, "    none\n");
-        fprintf(where, "Options:\n");
-	fprintf(where, "  --ci\tClear existing infos\n");
-	fprintf(where, "  --ri\tReplace or remove existing infos with same name (annotation must be info)\n");
-	fprintf(where, "  --cu\tClear existing userdata\n");
-	fprintf(where, "  --cd\tClear existing distances\n");
-        fprintf(where, "  --version\tReport version and exit\n");
-        fprintf(where, "  -h --help\tShow this usage\n");
+  fprintf(where, "Usage: hwloc-annotate [options] <input.xml> <output.xml> -- <location1> <location2> ... -- <annotation>\n");
+  fprintf(where, "Usage: hwloc-annotate [options] <input.xml> <output.xml> <location> <annotation>\n");
+  fprintf(where, "  <location> may be:\n");
+  fprintf(where, "    all, root, <type>:<logicalindex>, <type>:all\n");
+  fprintf(where, "  <annotation> may be:\n");
+  fprintf(where, "    info <name> <value>\n");
+  fprintf(where, "    subtype <subtype>\n");
+  fprintf(where, "    size <memory or cache size>\n");
+  fprintf(where, "    misc <name>\n");
+  fprintf(where, "    distances <filename> [<flags>]\n");
+  fprintf(where, "    memattr <name> <flags>\n");
+  fprintf(where, "    memattr <name> <initiator> <value>\n");
+  fprintf(where, "    cpukind <cpuset> <efficiency> <flags> [<infoname> <infovalue>]\n");
+  fprintf(where, "    distances-transform <name> links\n");
+  fprintf(where, "    distances-transform <name> merge-switch-ports\n");
+  fprintf(where, "    distances-transform <name> transitive-closure\n");
+  fprintf(where, "    distances-transform <name> remove-obj <obj>\n");
+  fprintf(where, "    distances-transform <name> replace-objs <oldtype> <newtype>\n");
+  fprintf(where, "    none\n");
+  fprintf(where, "Options:\n");
+  fprintf(where, "  --ci\tClear existing infos\n");
+  fprintf(where, "  --ri\tReplace or remove existing infos with same name (annotation must be info)\n");
+  fprintf(where, "  --cu\tClear existing userdata\n");
+  fprintf(where, "  --cd\tClear existing distances\n");
+  fprintf(where, "  --version\tReport version and exit\n");
+  fprintf(where, "  -h --help\tShow this usage\n");
 }
 
 static char *infoname = NULL, *infovalue = NULL;
@@ -110,29 +110,29 @@ static void apply(hwloc_topology_t topology, hwloc_obj_t obj)
 		else
 			obj->subtype = strdup(subtype);
 	}
-        if (sizevalue != ~0ULL) {
-          if (obj->type == HWLOC_OBJ_NUMANODE)
-            obj->attr->numanode.local_memory = sizevalue;
-          else if (hwloc_obj_type_is_cache(obj->type) || obj->type == HWLOC_OBJ_MEMCACHE)
-            obj->attr->cache.size = sizevalue;
-        }
+	if (sizevalue != ~0ULL) {
+		if (obj->type == HWLOC_OBJ_NUMANODE)
+			obj->attr->numanode.local_memory = sizevalue;
+		else if (hwloc_obj_type_is_cache(obj->type) || obj->type == HWLOC_OBJ_MEMCACHE)
+			obj->attr->cache.size = sizevalue;
+	}
 	if (miscname)
 		hwloc_topology_insert_misc_object(topology, obj, miscname);
-        if (mavname) {
-          struct hwloc_location loc, *locp = NULL;
-          if (maviobj) {
-            loc.type = HWLOC_LOCATION_TYPE_OBJECT;
-            loc.location.object = maviobj;
-            locp = &loc;
-          } else if (mavicpuset) {
-            loc.type = HWLOC_LOCATION_TYPE_CPUSET;
-            loc.location.cpuset = mavicpuset;
-            locp = &loc;
-          }
-          if (hwloc_memattr_set_value(topology, mavid, obj, locp, 0, mavvalue) < 0) {
-            fprintf(stderr, "Failed to add memattr value (%s)\n", strerror(errno));
-          }
-        }
+	if (mavname) {
+		struct hwloc_location loc, *locp = NULL;
+		if (maviobj) {
+			loc.type = HWLOC_LOCATION_TYPE_OBJECT;
+			loc.location.object = maviobj;
+			locp = &loc;
+		} else if (mavicpuset) {
+			loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+			loc.location.cpuset = mavicpuset;
+			locp = &loc;
+		}
+		if (hwloc_memattr_set_value(topology, mavid, obj, locp, 0, mavvalue) < 0) {
+			fprintf(stderr, "Failed to add memattr value (%s)\n", strerror(errno));
+		}
+	}
 }
 
 static void apply_recursive(hwloc_topology_t topology, hwloc_obj_t obj)
@@ -198,7 +198,7 @@ get_unique_obj(hwloc_topology_t topology, int topodepth, char *str,
 static void
 add_distances(hwloc_topology_t topology, int topodepth)
 {
-        char *name = NULL;
+	char *name = NULL;
 	unsigned long kind = 0;
 	unsigned nbobjs = 0;
 	hwloc_obj_t *objs = NULL;
@@ -206,7 +206,7 @@ add_distances(hwloc_topology_t topology, int topodepth)
 	FILE *file;
 	char line[64], *end;
 	unsigned i, x, y, z;
-        hwloc_distances_add_handle_t handle;
+	hwloc_distances_add_handle_t handle;
 	int err;
 
 	file = fopen(distancesfilename, "r");
@@ -219,19 +219,19 @@ add_distances(hwloc_topology_t topology, int topodepth)
 		fprintf(stderr, "Failed to read header line\n");
 		goto out;
 	}
-        if (!strncmp(line, "name=", 5)) {
-          end = strchr(line, '\n');
-          if (end) {
-            *end = '\0';
-            name = strdup(line+5);
-          }
-          if (!fgets(line, sizeof(line), file)) {
-            fprintf(stderr, "Failed to read kind line\n");
-            goto out;
-          }
-        }
+	if (!strncmp(line, "name=", 5)) {
+		end = strchr(line, '\n');
+		if (end) {
+			*end = '\0';
+			name = strdup(line+5);
+		}
+		if (!fgets(line, sizeof(line), file)) {
+			fprintf(stderr, "Failed to read kind line\n");
+			goto out;
+		}
+	}
 
-        kind = strtoul(line, NULL, 0);
+	kind = strtoul(line, NULL, 0);
 
 	if (!fgets(line, sizeof(line), file)) {
 		fprintf(stderr, "Failed to read nbobjs line\n");
@@ -253,21 +253,21 @@ add_distances(hwloc_topology_t topology, int topodepth)
 		int ignored_multiple;
 
 		if (!fgets(line, sizeof(line), file)) {
-		  fprintf(stderr, "Failed to read object line #%u.\n", i);
-		  goto out;
+			fprintf(stderr, "Failed to read object line #%u.\n", i);
+			goto out;
 		}
-                end = strchr(line, '\n');
-                if (end)
-                  *end = '\0';
+		end = strchr(line, '\n');
+		if (end)
+			*end = '\0';
 
 		obj = get_unique_obj(topology, topodepth, line, &ignored_multiple);
 		if (!obj) {
-		  fprintf(stderr, "Couldn't parse object line #%u.\n", i);
-		  goto out;
+			fprintf(stderr, "Couldn't parse object line #%u.\n", i);
+			goto out;
 		}
 
 		if (ignored_multiple) {
-		  fprintf(stderr, "Only the first object specified on line #%u was used.\n", i);
+			fprintf(stderr, "Only the first object specified on line #%u was used.\n", i);
 		}
 
 		objs[i] = obj;
@@ -299,7 +299,7 @@ add_distances(hwloc_topology_t topology, int topodepth)
 					values[i*nbobjs+j] = 80;
 	} else {
 		/* read all other values */
-	  values[0] = strtoull(line, NULL, 10);
+		values[0] = strtoull(line, NULL, 10);
 
 		for(i=1; i<nbobjs*nbobjs; i++) {
 			if (!fgets(line, sizeof(line), file)) {
@@ -310,21 +310,21 @@ add_distances(hwloc_topology_t topology, int topodepth)
 		}
 	}
 
-        err = -1;
-        handle = hwloc_distances_add_create(topology, name, kind, 0);
-        if (handle) {
-          err = hwloc_distances_add_values(topology, handle, nbobjs, objs, values, 0);
-          if (!err) {
-            err = hwloc_distances_add_commit(topology, handle, distancesflags);
-          }
-        }
-        if (err < 0 || !handle) {
-          fprintf(stderr, "Failed to add distances\n");
-          goto out;
+	err = -1;
+	handle = hwloc_distances_add_create(topology, name, kind, 0);
+	if (handle) {
+		err = hwloc_distances_add_values(topology, handle, nbobjs, objs, values, 0);
+		if (!err) {
+			err = hwloc_distances_add_commit(topology, handle, distancesflags);
+		}
+	}
+	if (err < 0 || !handle) {
+		fprintf(stderr, "Failed to add distances\n");
+		goto out;
 	}
 
 out:
-        free(name);
+	free(name);
 	free(objs);
 	free(values);
 	fclose(file);
@@ -478,11 +478,11 @@ int main(int argc, char *argv[])
 	int topodepth;
 	int err;
 
-        callname = strrchr(argv[0], '/');
-        if (!callname)
-          callname = argv[0];
-        else
-          callname++;
+	callname = strrchr(argv[0], '/');
+	if (!callname)
+		callname = argv[0];
+	else
+		callname++;
 
 	/* skip argv[0], handle options */
 	argc--;
@@ -532,27 +532,27 @@ int main(int argc, char *argv[])
 	argv += 2;
 
 	if (!strcmp(argv[0], "--")) {
-	  /* modern syntax with locations between "--" */
-	  argc--;
-	  argv++;
-	  locations = &argv[0];
-	  nr_locations = 0;
-	  while (nr_locations < argc && strcmp(argv[nr_locations], "--"))
-	    nr_locations++;
-	  /* check we have an ending "--" */
-	  if (nr_locations == argc || strcmp(argv[nr_locations], "--")) {
-	    usage(callname, stderr);
-	    exit(EXIT_FAILURE);
-	  }
-	  /* skip those locations and the ending "--" */
-	  argc -= nr_locations+1;
-	  argv += nr_locations+1;
+		/* modern syntax with locations between "--" */
+		argc--;
+		argv++;
+		locations = &argv[0];
+		nr_locations = 0;
+		while (nr_locations < argc && strcmp(argv[nr_locations], "--"))
+			nr_locations++;
+		/* check we have an ending "--" */
+		if (nr_locations == argc || strcmp(argv[nr_locations], "--")) {
+			usage(callname, stderr);
+			exit(EXIT_FAILURE);
+		}
+		/* skip those locations and the ending "--" */
+		argc -= nr_locations+1;
+		argv += nr_locations+1;
 	} else {
-	  /* old syntax with a single location without "--" before and after */
-	  locations = &argv[0];
-	  nr_locations = 1;
-	  argc--;
-	  argv++;
+		/* old syntax with a single location without "--" before and after */
+		locations = &argv[0];
+		nr_locations = 1;
+		argc--;
+		argv++;
 	}
 
 	if (argc < 1) {
@@ -581,24 +581,24 @@ int main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 		sizevalue = strtoull(argv[1], &end, 0);
-                if (end) {
-                  if (!strcasecmp(end, "kB"))
-                    sizevalue *= 1000ULL;
-                  else if (!strcasecmp(end, "kiB"))
-                    sizevalue <<= 10;
-                  else if (!strcasecmp(end, "MB"))
-                    sizevalue *= 1000ULL*1000ULL;
-                  else if (!strcasecmp(end, "MiB"))
-                    sizevalue <<= 20;
-                  else if (!strcasecmp(end, "GB"))
-                    sizevalue *= 1000ULL*1000ULL*1000ULL;
-                  else if (!strcasecmp(end, "GiB"))
-                    sizevalue <<= 30;
-                  else if (!strcasecmp(end, "TB"))
-                    sizevalue *= 1000ULL*1000ULL*1000ULL*1000ULL;
-                  else if (!strcasecmp(end, "TiB"))
-                    sizevalue <<= 40;
-                }
+		if (end) {
+			if (!strcasecmp(end, "kB"))
+				sizevalue *= 1000ULL;
+			else if (!strcasecmp(end, "kiB"))
+				sizevalue <<= 10;
+			else if (!strcasecmp(end, "MB"))
+				sizevalue *= 1000ULL*1000ULL;
+			else if (!strcasecmp(end, "MiB"))
+				sizevalue <<= 20;
+			else if (!strcasecmp(end, "GB"))
+				sizevalue *= 1000ULL*1000ULL*1000ULL;
+			else if (!strcasecmp(end, "GiB"))
+				sizevalue <<= 30;
+			else if (!strcasecmp(end, "TB"))
+				sizevalue *= 1000ULL*1000ULL*1000ULL*1000ULL;
+			else if (!strcasecmp(end, "TiB"))
+				sizevalue <<= 40;
+		}
 
 	} else if (!strcmp(argv[0], "misc")) {
 		if (argc < 2) {
@@ -615,89 +615,89 @@ int main(int argc, char *argv[])
 		distancesfilename = argv[1];
 		if (argc >= 3) {
 			distancesflags = hwloc_utils_parse_distances_add_flags(argv[2]);
-                        if(distancesflags == (unsigned long)-1)
-                                goto out;
-                }
+			if(distancesflags == (unsigned long)-1)
+				goto out;
+		}
 
-        } else if (!strcmp(argv[0], "distances-transform")) {
-          if (argc < 3) {
-            usage(callname, stderr);
-            exit(EXIT_FAILURE);
-          }
-          distances_transform_name = argv[1];
-          if (!strcmp(argv[2], "links")) {
-            distances_transform_links = 1;
-          } else if (!strcmp(argv[2], "merge-switch-ports")) {
-            distances_transform_merge_switch_ports = 1;
-          } else if (!strcmp(argv[2], "transitive-closure")) {
-            distances_transform_closure = 1;
-          } else if (!strcmp(argv[2], "remove-obj")) {
-            if (argc < 4) {
-              usage(callname, stderr);
-              exit(EXIT_FAILURE);
-            }
-            distances_transform_removeobj = argv[3];
-          } else if (!strcmp(argv[2], "replace-objs")) {
-            if (argc < 5) {
-              usage(callname, stderr);
-              exit(EXIT_FAILURE);
-            }
-            distances_transform_replace_oldtype = argv[3];
-            distances_transform_replace_newtype = argv[4];
-          } else {
-	    fprintf(stderr, "Unrecognized distances-transform operation `%s'\n", argv[2]);
-            usage(callname, stderr);
-            exit(EXIT_FAILURE);
-          }
+	} else if (!strcmp(argv[0], "distances-transform")) {
+		if (argc < 3) {
+			usage(callname, stderr);
+			exit(EXIT_FAILURE);
+		}
+		distances_transform_name = argv[1];
+		if (!strcmp(argv[2], "links")) {
+			distances_transform_links = 1;
+		} else if (!strcmp(argv[2], "merge-switch-ports")) {
+			distances_transform_merge_switch_ports = 1;
+		} else if (!strcmp(argv[2], "transitive-closure")) {
+			distances_transform_closure = 1;
+		} else if (!strcmp(argv[2], "remove-obj")) {
+			if (argc < 4) {
+				usage(callname, stderr);
+				exit(EXIT_FAILURE);
+			}
+			distances_transform_removeobj = argv[3];
+		} else if (!strcmp(argv[2], "replace-objs")) {
+			if (argc < 5) {
+				usage(callname, stderr);
+				exit(EXIT_FAILURE);
+			}
+			distances_transform_replace_oldtype = argv[3];
+			distances_transform_replace_newtype = argv[4];
+		} else {
+			fprintf(stderr, "Unrecognized distances-transform operation `%s'\n", argv[2]);
+			usage(callname, stderr);
+			exit(EXIT_FAILURE);
+		}
 
-        } else if (!strcmp(argv[0], "memattr")) {
-                if (argc < 3) {
-                        usage(callname, stderr);
-                        exit(EXIT_FAILURE);
-                }
-                if (argc == 3) {
-                        maname = argv[1];
-                        maflags = hwloc_utils_parse_memattr_flags(argv[2]);
-                } else {
-                        mavname = argv[1];
-                        mavvalue = strtoull(argv[3], NULL, 0);
-                        if (strcmp(argv[2], "none")) {
-                          if (!strncmp(argv[2], "0x", 2)) {
-                            /* parse a cpuset */
-                            mavicpuset = hwloc_bitmap_alloc();
-                            if (!mavicpuset) {
-                              fprintf(stderr, "Failed to allocate cpuset for memattr initiator\n");
-                              goto out;
-                            }
-                            hwloc_bitmap_sscanf(mavicpuset, argv[2]);
-                          } else {
-                            /* parse an object */
-                            maviobjstr = argv[2];
-                          }
-                        }
-                }
+	} else if (!strcmp(argv[0], "memattr")) {
+		if (argc < 3) {
+			usage(callname, stderr);
+			exit(EXIT_FAILURE);
+		}
+		if (argc == 3) {
+			maname = argv[1];
+			maflags = hwloc_utils_parse_memattr_flags(argv[2]);
+		} else {
+			mavname = argv[1];
+			mavvalue = strtoull(argv[3], NULL, 0);
+			if (strcmp(argv[2], "none")) {
+				if (!strncmp(argv[2], "0x", 2)) {
+					/* parse a cpuset */
+					mavicpuset = hwloc_bitmap_alloc();
+					if (!mavicpuset) {
+						fprintf(stderr, "Failed to allocate cpuset for memattr initiator\n");
+						goto out;
+					}
+					hwloc_bitmap_sscanf(mavicpuset, argv[2]);
+				} else {
+					/* parse an object */
+					maviobjstr = argv[2];
+				}
+			}
+		}
 
-        } else if (!strcmp(argv[0], "cpukind")) {
-          if (argc < 4) {
-            usage(callname, stderr);
-            exit(EXIT_FAILURE);
-          }
-          ckcpuset = hwloc_bitmap_alloc();
-          if (!ckcpuset) {
-            fprintf(stderr, "Failed to allocate cpuset for cpukind\n");
-            goto out;
-          }
-          hwloc_bitmap_sscanf(ckcpuset, argv[1]);
-          ckefficiency = atoi(argv[2]);
-          ckflags = atoi(argv[3]);
-          if (argc == 5) {
-            fprintf(stderr, "cpukind with info name without info value\n");
-            goto out;
-          }
-          if (argc >= 6 && *argv[4] && *argv[5]) {
-            ckiname = argv[4];
-            ckivalue = argv[5];
-          }
+	} else if (!strcmp(argv[0], "cpukind")) {
+		if (argc < 4) {
+			usage(callname, stderr);
+			exit(EXIT_FAILURE);
+		}
+		ckcpuset = hwloc_bitmap_alloc();
+		if (!ckcpuset) {
+			fprintf(stderr, "Failed to allocate cpuset for cpukind\n");
+			goto out;
+		}
+		hwloc_bitmap_sscanf(ckcpuset, argv[1]);
+		ckefficiency = atoi(argv[2]);
+		ckflags = atoi(argv[3]);
+		if (argc == 5) {
+			fprintf(stderr, "cpukind with info name without info value\n");
+			goto out;
+		}
+		if (argc >= 6 && *argv[4] && *argv[5]) {
+			ckiname = argv[4];
+			ckivalue = argv[5];
+		}
 
 	} else if (!strcmp(argv[0], "none")) {
 		/* do nothing (maybe clear) */
@@ -735,97 +735,97 @@ int main(int argc, char *argv[])
 	}
 
 	if (distancesfilename) {
-	  /* ignore locations */
-	  add_distances(topology, topodepth);
+		/* ignore locations */
+		add_distances(topology, topodepth);
 
-        } else if (distances_transform_name) {
-          transform_distances(topology, topodepth);
+	} else if (distances_transform_name) {
+		transform_distances(topology, topodepth);
 
-        } else if (maname) {
-          hwloc_memattr_id_t id;
-          err = hwloc_memattr_register(topology, maname, maflags, &id);
-          if (err < 0) {
-            fprintf(stderr, "Failed to register new memattr (%s)\n", strerror(errno));
-            goto out_with_topology;
-          }
+	} else if (maname) {
+		hwloc_memattr_id_t id;
+		err = hwloc_memattr_register(topology, maname, maflags, &id);
+		if (err < 0) {
+			fprintf(stderr, "Failed to register new memattr (%s)\n", strerror(errno));
+			goto out_with_topology;
+		}
 
-        } else if (ckcpuset) {
-          struct hwloc_infos_s infos;
-          struct hwloc_info_s info;
-          info.name = ckiname;
-          info.value = ckivalue;
-          infos.count = 1;
-          infos.array = &info;
-          infos.allocated = 0;
-          if (hwloc_cpukinds_register(topology, ckcpuset, ckefficiency,
-                                      ckiname ? &infos : NULL,
-                                      ckflags) < 0) {
-            fprintf(stderr, "Failed to register CPU kind (%s)\n", strerror(errno));
-          }
+	} else if (ckcpuset) {
+		struct hwloc_infos_s infos;
+		struct hwloc_info_s info;
+		info.name = ckiname;
+		info.value = ckivalue;
+		infos.count = 1;
+		infos.array = &info;
+		infos.allocated = 0;
+		if (hwloc_cpukinds_register(topology, ckcpuset, ckefficiency,
+					ckiname ? &infos : NULL,
+					ckflags) < 0) {
+			fprintf(stderr, "Failed to register CPU kind (%s)\n", strerror(errno));
+		}
 
 	} else {
-	  int i;
-          unsigned long mavflags = 0;
+		int i;
+		unsigned long mavflags = 0;
 
-          if (mavname) {
-            mavid = hwloc_utils_parse_memattr_name(topology, mavname);
-            if (mavid == (hwloc_memattr_id_t) -1) {
-              fprintf(stderr, "Failed to find memattr by name %s\n", mavname);
-              goto out_with_topology;
-            }
-            hwloc_memattr_get_flags(topology, mavid, &mavflags);
-          }
-
-          if (maviobjstr && (mavflags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR)) {
-            int ignored_multiple;
-            maviobj = get_unique_obj(topology, topodepth, maviobjstr, &ignored_multiple);
-            if (!maviobj) {
-              fprintf(stderr, "Failed to find memattr initiator object %s\n", maviobjstr);
-              goto out_with_topology;
-            }
-            if (ignored_multiple) {
-              fprintf(stderr, "Only the first object specified is used as a memattr initiator.\n");
-            }
-          }
-
-	  for(i=0; i<nr_locations; i++) {
-	    char *location = locations[i];
-            if (!strncmp(location, "cpukind#", 8) && (infoname || clearinfos)) {
-              struct hwloc_infos_s *infos;
-              int num;
-              if (location[8] < '0' || location[8] > '9') {
-                fprintf(stderr, "Failed to recognize number after cpukind# in location %s\n", location);
-                goto out_with_topology;
-              }
-              num = atoi(location+8);
-              err = hwloc_cpukinds_get_info(topology, num, NULL, NULL, &infos, 0);
-              if (err < 0) {
-                fprintf(stderr, "Failed to find cpukind#%d\n", num);
-                goto out_with_topology;
-              } else {
-                apply_infos(infos);
-              }
-            } else if (!strcmp(location, "topology") && (infoname || clearinfos)) {
-              apply_infos(hwloc_topology_get_infos(topology));
-            } else if (!strcmp(location, "all")) {
-	      apply_recursive(topology, hwloc_get_root_obj(topology));
-	    } else if (!strcmp(location, "root")) {
-	      apply(topology, hwloc_get_root_obj(topology));
-	    } else {
-		size_t typelen;
-		typelen = strspn(location, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
-		if (typelen && (location[typelen] == ':' || location[typelen] == '=' || location[typelen] == '[')) {
-			struct hwloc_calc_location_context_s lcontext;
-			lcontext.topology = topology;
-			lcontext.topodepth = topodepth;
-			lcontext.only_hbm = -1;
-			lcontext.logical = 1;
-			lcontext.verbose = 0;
-			err = hwloc_calc_process_location(&lcontext, location, typelen,
-							  hwloc_calc_process_location_annotate_cb, NULL);
+		if (mavname) {
+			mavid = hwloc_utils_parse_memattr_name(topology, mavname);
+			if (mavid == (hwloc_memattr_id_t) -1) {
+				fprintf(stderr, "Failed to find memattr by name %s\n", mavname);
+				goto out_with_topology;
+			}
+			hwloc_memattr_get_flags(topology, mavid, &mavflags);
 		}
-	    }
-	  }
+
+		if (maviobjstr && (mavflags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR)) {
+			int ignored_multiple;
+			maviobj = get_unique_obj(topology, topodepth, maviobjstr, &ignored_multiple);
+			if (!maviobj) {
+				fprintf(stderr, "Failed to find memattr initiator object %s\n", maviobjstr);
+				goto out_with_topology;
+			}
+			if (ignored_multiple) {
+				fprintf(stderr, "Only the first object specified is used as a memattr initiator.\n");
+			}
+		}
+
+		for(i=0; i<nr_locations; i++) {
+			char *location = locations[i];
+			if (!strncmp(location, "cpukind#", 8) && (infoname || clearinfos)) {
+				struct hwloc_infos_s *infos;
+				int num;
+				if (location[8] < '0' || location[8] > '9') {
+					fprintf(stderr, "Failed to recognize number after cpukind# in location %s\n", location);
+					goto out_with_topology;
+				}
+				num = atoi(location+8);
+				err = hwloc_cpukinds_get_info(topology, num, NULL, NULL, &infos, 0);
+				if (err < 0) {
+					fprintf(stderr, "Failed to find cpukind#%d\n", num);
+					goto out_with_topology;
+				} else {
+					apply_infos(infos);
+				}
+			} else if (!strcmp(location, "topology") && (infoname || clearinfos)) {
+				apply_infos(hwloc_topology_get_infos(topology));
+			} else if (!strcmp(location, "all")) {
+				apply_recursive(topology, hwloc_get_root_obj(topology));
+			} else if (!strcmp(location, "root")) {
+				apply(topology, hwloc_get_root_obj(topology));
+			} else {
+				size_t typelen;
+				typelen = strspn(location, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+				if (typelen && (location[typelen] == ':' || location[typelen] == '=' || location[typelen] == '[')) {
+					struct hwloc_calc_location_context_s lcontext;
+					lcontext.topology = topology;
+					lcontext.topodepth = topodepth;
+					lcontext.only_hbm = -1;
+					lcontext.logical = 1;
+					lcontext.verbose = 0;
+					err = hwloc_calc_process_location(&lcontext, location, typelen,
+							hwloc_calc_process_location_annotate_cb, NULL);
+				}
+			}
+		}
 	}
 
 	err = hwloc_topology_export_xml(topology, output, 0);
@@ -841,6 +841,6 @@ out_with_topology:
 	hwloc_topology_destroy(topology);
 out:
 	hwloc_bitmap_free(mavicpuset);
-        hwloc_bitmap_free(ckcpuset);
+	hwloc_bitmap_free(ckcpuset);
 	exit(EXIT_FAILURE);
 }

--- a/utils/hwloc/hwloc-annotate.c
+++ b/utils/hwloc/hwloc-annotate.c
@@ -494,6 +494,7 @@ int main(int argc, char *argv[])
 		putenv((char *) "HWLOC_XML_VERBOSE=1");
 
 	while (argc && *argv[0] == '-') {
+		/* Options */
 		if (!strcmp(argv[0], "--ci"))
 			clearinfos = 1;
 		else if (!strcmp(argv[0], "--ri"))
@@ -502,14 +503,17 @@ int main(int argc, char *argv[])
 			clearuserdata = 1;
 		else if (!strcmp(argv[0], "--cd"))
 			cleardistances = 1;
-                else if (!strcmp (argv[0], "--version")) {
-                  printf("%s %s\n", callname, HWLOC_VERSION);
-                  exit(EXIT_SUCCESS);
-                }
+		/* Misc */
+		else if (!strcmp (argv[0], "--version")) {
+			printf("%s %s\n", callname, HWLOC_VERSION);
+			exit(EXIT_SUCCESS);
+		}
 		else if (!strcmp(argv[0], "-h") || !strcmp(argv[0], "--help")) {
 			usage(callname, stdout);
 			exit(EXIT_SUCCESS);
-		} else {
+		}
+		/* Errors */
+		else {
 			fprintf(stderr, "Unrecognized options: %s\n", argv[0]);
 			usage(callname, stderr);
 			exit(EXIT_FAILURE);

--- a/utils/hwloc/hwloc-bind.c
+++ b/utils/hwloc/hwloc-bind.c
@@ -343,7 +343,7 @@ int main(int argc, char *argv[])
     ret = hwloc_calc_process_location_as_set(&lcontext, &scontext, location);
     if (ret < 0) {
       if (verbose > 0)
-	fprintf(stderr, "assuming the command starts at %s\n", argv[0]);
+        fprintf(stderr, "assuming the command starts at %s\n", argv[0]);
       break;
     }
     if (working_on_cpubind)
@@ -387,76 +387,76 @@ int main(int argc, char *argv[])
     int err;
     if (working_on_cpubind) {
       if (get_last_cpu_location) {
-	if (pid_number > 0)
-	  err = hwloc_get_proc_last_cpu_location(topology, pid, cpubind_set, 0);
+        if (pid_number > 0)
+          err = hwloc_get_proc_last_cpu_location(topology, pid, cpubind_set, 0);
 #ifdef HWLOC_LINUX_SYS
-	else if (tid_number > 0)
-	  err = hwloc_linux_get_tid_last_cpu_location(topology, tid_number, cpubind_set);
+        else if (tid_number > 0)
+          err = hwloc_linux_get_tid_last_cpu_location(topology, tid_number, cpubind_set);
 #endif
-	else
-	  err = hwloc_get_last_cpu_location(topology, cpubind_set, 0);
+        else
+          err = hwloc_get_last_cpu_location(topology, cpubind_set, 0);
       } else {
-	if (pid_number > 0)
-	  err = hwloc_get_proc_cpubind(topology, pid, cpubind_set, 0);
+        if (pid_number > 0)
+          err = hwloc_get_proc_cpubind(topology, pid, cpubind_set, 0);
 #ifdef HWLOC_LINUX_SYS
-	else if (tid_number > 0)
-	  err = hwloc_linux_get_tid_cpubind(topology, tid_number, cpubind_set);
+        else if (tid_number > 0)
+          err = hwloc_linux_get_tid_cpubind(topology, tid_number, cpubind_set);
 #endif
-	else
-	  err = hwloc_get_cpubind(topology, cpubind_set, 0);
+        else
+          err = hwloc_get_cpubind(topology, cpubind_set, 0);
       }
       if (err) {
-	const char *errmsg = strerror(errno);
-	if (pid_number > 0)
-	  fprintf(stderr, "hwloc_get_proc_%s %d failed (errno %d %s)\n", get_last_cpu_location ? "last_cpu_location" : "cpubind", pid_number, errno, errmsg);
-	else if (tid_number > 0)
-	  fprintf(stderr, "hwloc_get_tid_%s %d failed (errno %d %s)\n", get_last_cpu_location ? "last_cpu_location" : "cpubind", tid_number, errno, errmsg);
-	else
-	  fprintf(stderr, "hwloc_get_%s failed (errno %d %s)\n", get_last_cpu_location ? "last_cpu_location" : "cpubind", errno, errmsg);
-	return EXIT_FAILURE;
+        const char *errmsg = strerror(errno);
+        if (pid_number > 0)
+          fprintf(stderr, "hwloc_get_proc_%s %d failed (errno %d %s)\n", get_last_cpu_location ? "last_cpu_location" : "cpubind", pid_number, errno, errmsg);
+        else if (tid_number > 0)
+          fprintf(stderr, "hwloc_get_tid_%s %d failed (errno %d %s)\n", get_last_cpu_location ? "last_cpu_location" : "cpubind", tid_number, errno, errmsg);
+        else
+          fprintf(stderr, "hwloc_get_%s failed (errno %d %s)\n", get_last_cpu_location ? "last_cpu_location" : "cpubind", errno, errmsg);
+        return EXIT_FAILURE;
       }
       if (use_nodeset) {
-	hwloc_bitmap_t nset = hwloc_bitmap_alloc();
-	hwloc_cpuset_to_nodeset(topology, cpubind_set, nset);
-	if (taskset)
-	  hwloc_bitmap_taskset_asprintf(&s, nset);
-	else
-	  hwloc_bitmap_asprintf(&s, nset);
-	hwloc_bitmap_free(nset);
+        hwloc_bitmap_t nset = hwloc_bitmap_alloc();
+        hwloc_cpuset_to_nodeset(topology, cpubind_set, nset);
+        if (taskset)
+          hwloc_bitmap_taskset_asprintf(&s, nset);
+        else
+          hwloc_bitmap_asprintf(&s, nset);
+        hwloc_bitmap_free(nset);
       } else {
-	if (taskset)
-	  hwloc_bitmap_taskset_asprintf(&s, cpubind_set);
-	else
-	  hwloc_bitmap_asprintf(&s, cpubind_set);
+        if (taskset)
+          hwloc_bitmap_taskset_asprintf(&s, cpubind_set);
+        else
+          hwloc_bitmap_asprintf(&s, cpubind_set);
       }
 
-      } else {
+    } else {
       hwloc_membind_policy_t policy;
       if (pid_number > 0) {
-	err = hwloc_get_proc_membind(topology, pid, membind_set, &policy, use_nodeset ? HWLOC_MEMBIND_BYNODESET : 0);
+        err = hwloc_get_proc_membind(topology, pid, membind_set, &policy, use_nodeset ? HWLOC_MEMBIND_BYNODESET : 0);
       } else if (tid_number > 0) {
-	err = -1; errno = ENOSYS;
+        err = -1; errno = ENOSYS;
       } else {
-	err = hwloc_get_membind(topology, membind_set, &policy, use_nodeset ? HWLOC_MEMBIND_BYNODESET : 0);
+        err = hwloc_get_membind(topology, membind_set, &policy, use_nodeset ? HWLOC_MEMBIND_BYNODESET : 0);
       }
       if (err) {
-	const char *errmsg = strerror(errno);
+        const char *errmsg = strerror(errno);
         if (pid_number > 0)
           fprintf(stderr, "hwloc_get_proc_membind %d failed (errno %d %s)\n", pid_number, errno, errmsg);
         else
-	  fprintf(stderr, "hwloc_get_membind failed (errno %d %s)\n", errno, errmsg);
-	return EXIT_FAILURE;
+          fprintf(stderr, "hwloc_get_membind failed (errno %d %s)\n", errno, errmsg);
+        return EXIT_FAILURE;
       }
       if (taskset)
-	hwloc_bitmap_taskset_asprintf(&s, membind_set);
+        hwloc_bitmap_taskset_asprintf(&s, membind_set);
       else
-	hwloc_bitmap_asprintf(&s, membind_set);
+        hwloc_bitmap_asprintf(&s, membind_set);
       switch (policy) {
-      case HWLOC_MEMBIND_FIRSTTOUCH: policystr = "firsttouch"; break;
-      case HWLOC_MEMBIND_BIND: policystr = "bind"; break;
-      case HWLOC_MEMBIND_INTERLEAVE: policystr = "interleave"; break;
-      case HWLOC_MEMBIND_NEXTTOUCH: policystr = "nexttouch"; break;
-      default: fprintf(stderr, "unknown memory policy %d\n", policy); assert(0); break;
+        case HWLOC_MEMBIND_FIRSTTOUCH: policystr = "firsttouch"; break;
+        case HWLOC_MEMBIND_BIND: policystr = "bind"; break;
+        case HWLOC_MEMBIND_INTERLEAVE: policystr = "interleave"; break;
+        case HWLOC_MEMBIND_NEXTTOUCH: policystr = "nexttouch"; break;
+        default: fprintf(stderr, "unknown memory policy %d\n", policy); assert(0); break;
       }
     }
     if (policystr)
@@ -469,9 +469,9 @@ int main(int argc, char *argv[])
   if (got_membind) {
     if (hwloc_bitmap_iszero(membind_set)) {
       if (verbose >= 0)
-	fprintf(stderr, "cannot membind to empty set\n");
+        fprintf(stderr, "cannot membind to empty set\n");
       if (!force)
-	goto failed_binding;
+        goto failed_binding;
     }
 
     if (best_memattr_str) {
@@ -545,9 +545,9 @@ int main(int argc, char *argv[])
   if (got_cpubind) {
     if (hwloc_bitmap_iszero(cpubind_set)) {
       if (verbose >= 0)
-	fprintf(stderr, "cannot cpubind to empty set\n");
+        fprintf(stderr, "cannot cpubind to empty set\n");
       if (!force)
-	goto failed_binding;
+        goto failed_binding;
     }
     if (verbose > 0) {
       char *s;
@@ -557,14 +557,14 @@ int main(int argc, char *argv[])
     }
     if (got_membind && !hwloc_bitmap_isequal(membind_set, cpubind_set)) {
       if (verbose)
-	fprintf(stderr, "Conflicting CPU and memory binding requested, adding HWLOC_CPUBIND_NOMEMBIND flag.\n");
+        fprintf(stderr, "Conflicting CPU and memory binding requested, adding HWLOC_CPUBIND_NOMEMBIND flag.\n");
       cpubind_flags |= HWLOC_CPUBIND_NOMEMBIND;
     }
     if (no_smt != -1) {
       if (hwloc_get_type_depth(topology, HWLOC_OBJ_CORE) == HWLOC_TYPE_DEPTH_UNKNOWN) {
-	fprintf(stderr, "Topology has no Core object, ignoring --no-smt\n");
+        fprintf(stderr, "Topology has no Core object, ignoring --no-smt\n");
       } else {
-	hwloc_bitmap_singlify_per_core(topology, cpubind_set, no_smt);
+        hwloc_bitmap_singlify_per_core(topology, cpubind_set, no_smt);
       }
     }
     if (single)

--- a/utils/hwloc/hwloc-calc.c
+++ b/utils/hwloc/hwloc-calc.c
@@ -211,7 +211,7 @@ hwloc_calc_output(hwloc_topology_t topology, const char *sep, hwloc_bitmap_t set
           && intersectattr.osdev.type != obj->attr->osdev.type)
         continue;
       if (!first)
-	printf("%s", sep);
+        printf("%s", sep);
       idx = logicalo ? obj->logical_index : obj->os_index;
       if (idx == (unsigned)-1)
         printf("-1");
@@ -665,7 +665,7 @@ int main(int argc, char *argv[])
     while (1) {
       tmp = strchr(tmp, '.');
       if (!tmp)
-	break;
+        break;
       tmp++;
       hiernblevels++;
     }
@@ -674,12 +674,12 @@ int main(int argc, char *argv[])
     for(i=0; i<hiernblevels; i++) {
       next = strchr(tmp, '.');
       if (next)
-	*next = '\0';
+        *next = '\0';
       if (hwloc_calc_type_depth(topology, tmp, &hierdepth[i], NULL, "--hierarchical") < 0)
-	goto out;
+        goto out;
       if (hierdepth[i] < 0 && hierdepth[i] != HWLOC_TYPE_DEPTH_NUMANODE) {
-	fprintf(stderr, "unsupported (non-normal) --hierarchical type %s\n", tmp);
-	goto out;
+        fprintf(stderr, "unsupported (non-normal) --hierarchical type %s\n", tmp);
+        goto out;
       }
       tmp = next+1;
     }
@@ -713,38 +713,38 @@ int main(int argc, char *argv[])
       /* keep reading until we get EOL */
       tmpline = line;
       while (!strchr(tmpline, '\n')) {
-	char *tmp;
-	tmp = realloc(line, len*2);
-	if (!tmp) {
-	  /* failed to allocate, ignore that line */
-	  fprintf(stderr, "Failed to allocate line buffer, line ignored.\n");
-	  free(line);
-	  goto out;
-	}
-	line = tmp;
-	tmpline = line + len-1;
-	if (!fgets(tmpline, (int)(len+1), stdin))
-	  break;
-	len *= 2;
+        char *tmp;
+        tmp = realloc(line, len*2);
+        if (!tmp) {
+          /* failed to allocate, ignore that line */
+          fprintf(stderr, "Failed to allocate line buffer, line ignored.\n");
+          free(line);
+          goto out;
+        }
+        line = tmp;
+        tmpline = line + len-1;
+        if (!fgets(tmpline, (int)(len+1), stdin))
+          break;
+        len *= 2;
       }
       /* parse now that we got everything */
       current = line;
       hwloc_bitmap_zero(set);
       while (1) {
-	char *token = strtok(current, " \n");
-	if (!token)
-	  break;
-	current = NULL;
-	lcontext.topology = topology;
-	lcontext.topodepth = depth;
-	lcontext.only_hbm = -1;
-	lcontext.logical = logicali;
-	lcontext.verbose = verbose;
-	scontext.output_set = set;
-	scontext.nodeset_input = nodeseti;
-	scontext.nodeset_output = nodeseto;
-	if (hwloc_calc_process_location_as_set(&lcontext, &scontext, token) < 0)
-	  fprintf(stderr, "ignored unrecognized argument %s\n", token);
+        char *token = strtok(current, " \n");
+        if (!token)
+          break;
+        current = NULL;
+        lcontext.topology = topology;
+        lcontext.topodepth = depth;
+        lcontext.only_hbm = -1;
+        lcontext.logical = logicali;
+        lcontext.verbose = verbose;
+        scontext.output_set = set;
+        scontext.nodeset_input = nodeseti;
+        scontext.nodeset_output = nodeseto;
+        if (hwloc_calc_process_location_as_set(&lcontext, &scontext, token) < 0)
+          fprintf(stderr, "ignored unrecognized argument %s\n", token);
       }
       hwloc_calc_output(topology, outsep, set);
     }

--- a/utils/hwloc/hwloc-calc.c
+++ b/utils/hwloc/hwloc-calc.c
@@ -33,14 +33,14 @@ void usage(const char *callname __hwloc_attribute_unused, FILE *where)
   hwloc_utils_input_format_usage(where, 10);
   fprintf(where, "Conversion options:\n");
   fprintf(where, "  [default]                 Report the combined input locations as a CPU set\n");
-  fprintf(where, "  --number-of <type|depth>\n"
-                 "  -N <type|depth>           Report the number of objects intersecting the CPU set\n");
-  fprintf(where, "  --intersect <type|depth>\n"
-		 "  -I <type|depth>           Report the indexes of object intersecting the CPU set\n");
-  fprintf(where, "  --hierarchical <type1>.<type2>...\n"
-		 "  -H <type1>.<type2>...     Find the list of objects intersecting the CPU set and\n"
-		 "                            display them as hierarchical combinations such as\n"
-		 "                            type1:index1.type2:index2...\n");
+  fprintf(where, "  --number-of <type|depth>\n");
+  fprintf(where, "  -N <type|depth>           Report the number of objects intersecting the CPU set\n");
+  fprintf(where, "  --intersect <type|depth>\n");
+  fprintf(where, "  -I <type|depth>           Report the indexes of object intersecting the CPU set\n");
+  fprintf(where, "  --hierarchical <type1>.<type2>...\n");
+  fprintf(where, "  -H <type1>.<type2>...     Find the list of objects intersecting the CPU set and\n");
+  fprintf(where, "                            display them as hierarchical combinations such as\n");
+  fprintf(where, "                            type1:index1.type2:index2...\n");
   fprintf(where, "  --largest                 Report the list of largest objects in the CPU set\n");
   fprintf(where, "  --local-memory            Report the memory nodes that are local to the CPU set\n");
   fprintf(where, "  --local-memory flags <x>  Change flags for selecting local memory nodes\n");
@@ -361,31 +361,13 @@ int main(int argc, char *argv[])
   while (argc >= 1) {
     opt = 0;
 
-    if (!strcmp (argv[0], "--disallowed") || !strcmp (argv[0], "--whole-system")) {
-      flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
+    /* Topology */
+    if (!strcmp (argv[0], "--no-smt")) {
+      no_smt = 0;
       goto next_config;
     }
-    if (!strcmp (argv[0], "--restrict")) {
-      if (argc < 2) {
-	usage (callname, stderr);
-	exit(EXIT_FAILURE);
-      }
-      if(strncmp(argv[1], "nodeset=", 7))
-        restrictstring = strdup(argv[1]);
-      else {
-        restrictstring = strdup(argv[1]+8);
-        restrict_flags |= HWLOC_RESTRICT_FLAG_BYNODESET;
-      }
-      opt = 1;
-      goto next_config;
-    }
-    if (!strcmp (argv[0], "--restrict-flags")) {
-      if (argc < 2) {
-	usage (callname, stderr);
-	exit(EXIT_FAILURE);
-      }
-      restrict_flags = hwloc_utils_parse_restrict_flags(argv[1]);
-      opt = 1;
+    if (!strncmp(argv[0], "--no-smt=", 9)) {
+      no_smt = atoi(argv[0] + 9);
       goto next_config;
     }
     if (!strcmp(argv[0], "--cpukind")) {
@@ -406,6 +388,33 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
       }
       opt = 1;
+      goto next_config;
+    }
+    if (!strcmp (argv[0], "--restrict")) {
+      if (argc < 2) {
+        usage (callname, stderr);
+        exit(EXIT_FAILURE);
+      }
+      if(strncmp(argv[1], "nodeset=", 7))
+        restrictstring = strdup(argv[1]);
+      else {
+        restrictstring = strdup(argv[1]+8);
+        restrict_flags |= HWLOC_RESTRICT_FLAG_BYNODESET;
+      }
+      opt = 1;
+      goto next_config;
+    }
+    if (!strcmp (argv[0], "--restrict-flags")) {
+      if (argc < 2) {
+        usage (callname, stderr);
+        exit(EXIT_FAILURE);
+      }
+      restrict_flags = hwloc_utils_parse_restrict_flags(argv[1]);
+      opt = 1;
+      goto next_config;
+    }
+    if (!strcmp (argv[0], "--disallowed") || !strcmp (argv[0], "--whole-system")) {
+      flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
       goto next_config;
     }
     if (hwloc_utils_lookup_input_option(argv, argc, &opt,
@@ -479,56 +488,37 @@ int main(int argc, char *argv[])
     opt = 0;
 
     if (*argv[0] == '-') {
-      if (!strcmp (argv[0], "-h") || !strcmp (argv[0], "--help")) {
-        usage(callname, stdout);
-        exit(EXIT_SUCCESS);
-      }
-      if (!strcmp(argv[0], "-v") || !strcmp(argv[0], "--verbose")) {
-        verbose++;
-        goto next;
-      }
-      if (!strcmp(argv[0], "-q") || !strcmp(argv[0], "--quiet")) {
-        verbose--;
-        goto next;
-      }
-      if (!strcmp (argv[0], "--disallowed") || !strcmp (argv[0], "--whole-system")) {
-        fprintf(stderr, "Input option %s disallowed after options using the topology\n", argv[0]);
-	exit(EXIT_FAILURE);
-      }
-      if (!strcmp (argv[0], "--no-smt")) {
-	no_smt = 0;
-	goto next;
-      }
-      if (!strncmp(argv[0], "--no-smt=", 9)) {
-	no_smt = atoi(argv[0] + 9);
-	goto next;
-      }
+      /* Conversion options */
       if (!strcmp(argv[0], "--number-of") || !strcmp(argv[0], "-N")) {
-	if (argc < 2) {
-	  usage(callname, stderr);
-	  return EXIT_FAILURE;
-	}
-	numberoftype = argv[1];
-	opt = 1;
-	goto next;
+        if (argc < 2) {
+          usage(callname, stderr);
+          return EXIT_FAILURE;
+        }
+        numberoftype = argv[1];
+        opt = 1;
+        goto next;
       }
       if (!strcmp(argv[0], "--intersect") || !strcmp(argv[0], "-I")) {
-	if (argc < 2) {
-	  usage(callname, stderr);
-	  return EXIT_FAILURE;
-	}
-	intersecttype = argv[1];
-	opt = 1;
-	goto next;
+        if (argc < 2) {
+          usage(callname, stderr);
+          return EXIT_FAILURE;
+        }
+        intersecttype = argv[1];
+        opt = 1;
+        goto next;
       }
       if (!strcmp(argv[0], "--hierarchical") || !strcmp(argv[0], "-H")) {
-	if (argc < 2) {
-	  usage(callname, stderr);
-	  return EXIT_FAILURE;
-	}
-	hiertype = argv[1];
-	opt = 1;
-	goto next;
+        if (argc < 2) {
+          usage(callname, stderr);
+          return EXIT_FAILURE;
+        }
+        hiertype = argv[1];
+        opt = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--largest")) {
+        showobjs = 1;
+        goto next;
       }
       if (!strcmp(argv[0], "--local-memory")) {
         local_numanodes = 1;
@@ -554,71 +544,86 @@ int main(int argc, char *argv[])
         opt = 1;
         goto next;
       }
-      if (!strcmp(argv[0], "--largest")) {
-	showobjs = 1;
+      /* Formatting options */
+      if (!strcmp(argv[0], "-l") || !strcmp(argv[0], "--logical")) {
+        logicali = 1;
+        logicalo = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--li") || !strcmp(argv[0], "--logical-input")) {
+        logicali = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--lo") || !strcmp(argv[0], "--logical-output")) {
+        logicalo = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "-p") || !strcmp(argv[0], "--physical")) {
+        logicali = 0;
+        logicalo = 0;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--pi") || !strcmp(argv[0], "--physical-input")) {
+        logicali = 0;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--po") || !strcmp(argv[0], "--physical-output")) {
+        logicalo = 0;
+        goto next;
+      }
+      if (!strcmp(argv[0], "-n") || !strcmp(argv[0], "--nodeset")) {
+        nodeseti = 1;
+        nodeseto = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--ni") || !strcmp(argv[0], "--nodeset-input")) {
+        nodeseti = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--no") || !strcmp(argv[0], "--nodeset-output")) {
+        nodeseto = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--sep")) {
+        if (argc < 2) {
+          usage (callname, stderr);
+          exit(EXIT_FAILURE);
+        }
+        outsep = argv[1];
+        opt = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--taskset")) {
+        taskset = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--single")) {
+        singlify = 1;
+        goto next;
+      }
+      /* Misc */
+      if (!strcmp(argv[0], "-q") || !strcmp(argv[0], "--quiet")) {
+        verbose--;
+        goto next;
+      }
+      if (!strcmp(argv[0], "-v") || !strcmp(argv[0], "--verbose")) {
+        verbose++;
         goto next;
       }
       if (!strcmp(argv[0], "--version")) {
         printf("%s %s\n", callname, HWLOC_VERSION);
         exit(EXIT_SUCCESS);
       }
-      if (!strcmp(argv[0], "-l") || !strcmp(argv[0], "--logical")) {
-	logicali = 1;
-	logicalo = 1;
-	goto next;
-      }
-      if (!strcmp(argv[0], "--li") || !strcmp(argv[0], "--logical-input")) {
-	logicali = 1;
-	goto next;
-      }
-      if (!strcmp(argv[0], "--lo") || !strcmp(argv[0], "--logical-output")) {
-	logicalo = 1;
-	goto next;
-      }
-      if (!strcmp(argv[0], "-p") || !strcmp(argv[0], "--physical")) {
-	logicali = 0;
-	logicalo = 0;
-	goto next;
-      }
-      if (!strcmp(argv[0], "--pi") || !strcmp(argv[0], "--physical-input")) {
-	logicali = 0;
-	goto next;
-      }
-      if (!strcmp(argv[0], "--po") || !strcmp(argv[0], "--physical-output")) {
-	logicalo = 0;
-	goto next;
-      }
-      if (!strcmp(argv[0], "-n") || !strcmp(argv[0], "--nodeset")) {
-	nodeseti = 1;
-	nodeseto = 1;
-	goto next;
-      }
-      if (!strcmp(argv[0], "--ni") || !strcmp(argv[0], "--nodeset-input")) {
-	nodeseti = 1;
-	goto next;
-      }
-      if (!strcmp(argv[0], "--no") || !strcmp(argv[0], "--nodeset-output")) {
-	nodeseto = 1;
-	goto next;
-      }
-      if (!strcmp(argv[0], "--sep")) {
-	if (argc < 2) {
-	  usage (callname, stderr);
-	  exit(EXIT_FAILURE);
-	}
-	outsep = argv[1];
-	opt = 1;
-	goto next;
-      }
-      if (!strcmp(argv[0], "--single")) {
-	singlify = 1;
-	goto next;
-      }
-      if (!strcmp(argv[0], "--taskset")) {
-	taskset = 1;
-	goto next;
+      if (!strcmp (argv[0], "-h") || !strcmp (argv[0], "--help")) {
+        usage(callname, stdout);
+        exit(EXIT_SUCCESS);
       }
 
+      /* Errors */
+      if (!strcmp (argv[0], "--disallowed") || !strcmp (argv[0], "--whole-system")) {
+        fprintf(stderr, "Input option %s disallowed after options using the topology\n", argv[0]);
+        exit(EXIT_FAILURE);
+      }
       fprintf (stderr, "Unrecognized option: %s\n", argv[0]);
       usage(callname, stderr);
       return EXIT_FAILURE;

--- a/utils/hwloc/hwloc-calc.h
+++ b/utils/hwloc/hwloc-calc.h
@@ -785,7 +785,7 @@ hwloc_calc_process_location_as_set(struct hwloc_calc_location_context_s *lcontex
 static __hwloc_inline void
 hwloc_calc_locations_usage(FILE *where)
 {
-  fprintf (where, "    core:2-3        for the third and fourth cores\n");
+  fprintf (where, "    core:2-3          for the third and fourth cores\n");
   fprintf (where, "    node:1.pu:2       the third PU of the second NUMA node\n");
   fprintf (where, "    0x12345678        a CPU set given a bitmask string\n");
   fprintf (where, "    os=eth0           the operating system device named eth0\n");

--- a/utils/hwloc/hwloc-calc.h
+++ b/utils/hwloc/hwloc-calc.h
@@ -38,7 +38,7 @@ typedef enum hwloc_calc_append_mode_e {
 
 static __hwloc_inline int
 hwloc_calc_append_set(hwloc_bitmap_t set, hwloc_const_bitmap_t newset,
-		      hwloc_calc_append_mode_t mode, int verbose)
+                      hwloc_calc_append_mode_t mode, int verbose)
 {
   char *s1, *s2;
   hwloc_bitmap_asprintf(&s1, newset);
@@ -47,25 +47,25 @@ hwloc_calc_append_set(hwloc_bitmap_t set, hwloc_const_bitmap_t newset,
   case HWLOC_CALC_APPEND_ADD:
     if (verbose > 0)
       fprintf(stderr, "adding %s to %s\n",
-          s1, s2);
+              s1, s2);
     hwloc_bitmap_or(set, set, newset);
     break;
   case HWLOC_CALC_APPEND_CLR:
     if (verbose > 0)
       fprintf(stderr, "clearing %s from %s\n",
-          s1, s2);
+              s1, s2);
     hwloc_bitmap_andnot(set, set, newset);
     break;
   case HWLOC_CALC_APPEND_AND:
     if (verbose > 0)
       fprintf(stderr, "and'ing %s from %s\n",
-          s1, s2);
+              s1, s2);
     hwloc_bitmap_and(set, set, newset);
     break;
   case HWLOC_CALC_APPEND_XOR:
     if (verbose > 0)
       fprintf(stderr, "xor'ing %s from %s\n",
-          s1, s2);
+              s1, s2);
     hwloc_bitmap_xor(set, set, newset);
     break;
   default:
@@ -78,8 +78,8 @@ hwloc_calc_append_set(hwloc_bitmap_t set, hwloc_const_bitmap_t newset,
 
 static __hwloc_inline unsigned
 hwloc_calc_get_nbobjs_inside_sets_by_depth(struct hwloc_calc_location_context_s *lcontext,
-					   hwloc_const_bitmap_t cpuset, hwloc_const_bitmap_t nodeset,
-					   int depth)
+                                           hwloc_const_bitmap_t cpuset, hwloc_const_bitmap_t nodeset,
+                                           int depth)
 {
   hwloc_topology_t topology = lcontext->topology;
   int only_hbm = lcontext->only_hbm;
@@ -97,7 +97,7 @@ hwloc_calc_get_nbobjs_inside_sets_by_depth(struct hwloc_calc_location_context_s 
       /* filter on hbm */
       int obj_is_hbm = obj->subtype && !strcmp(obj->subtype, "MCDRAM");
       if (only_hbm != obj_is_hbm)
-	continue;
+        continue;
     }
     n++;
   }
@@ -106,8 +106,8 @@ hwloc_calc_get_nbobjs_inside_sets_by_depth(struct hwloc_calc_location_context_s 
 
 static __hwloc_inline hwloc_obj_t
 hwloc_calc_get_obj_inside_sets_by_depth(struct hwloc_calc_location_context_s *lcontext,
-					hwloc_const_bitmap_t cpuset, hwloc_const_bitmap_t nodeset,
-					int depth, unsigned ind)
+                                        hwloc_const_bitmap_t cpuset, hwloc_const_bitmap_t nodeset,
+                                        int depth, unsigned ind)
 {
   hwloc_topology_t topology = lcontext->topology;
   int only_hbm = lcontext->only_hbm;
@@ -126,15 +126,15 @@ hwloc_calc_get_obj_inside_sets_by_depth(struct hwloc_calc_location_context_s *lc
       /* filter on hbm */
       int obj_is_hbm = obj->subtype && !strcmp(obj->subtype, "MCDRAM");
       if (only_hbm != obj_is_hbm)
-	continue;
+        continue;
     }
     if (logical) {
       if (i == ind)
-	return obj;
+        return obj;
       i++;
     } else {
       if (obj->os_index == ind)
-	return obj;
+        return obj;
     }
   }
   return NULL;
@@ -142,8 +142,8 @@ hwloc_calc_get_obj_inside_sets_by_depth(struct hwloc_calc_location_context_s *lc
 
 static __hwloc_inline int
 hwloc_calc_parse_depth_prefix(struct hwloc_calc_location_context_s *lcontext,
-			      const char *string, size_t typelen,
-			      hwloc_obj_type_t *typep)
+                              const char *string, size_t typelen,
+                              hwloc_obj_type_t *typep)
 {
   hwloc_topology_t topology = lcontext->topology;
   int topodepth = lcontext->topodepth;
@@ -196,9 +196,9 @@ hwloc_calc_parse_depth_prefix(struct hwloc_calc_location_context_s *lcontext,
 
 static __hwloc_inline int
 hwloc_calc_parse_range(const char *_string,
-		       int *firstp, int *amountp, int *stepp, int *wrapp,
-		       const char **dotp,
-		       int verbose)
+                       int *firstp, int *amountp, int *stepp, int *wrapp,
+                       const char **dotp,
+                       int verbose)
 {
   char string[65];
   size_t len;
@@ -242,7 +242,7 @@ hwloc_calc_parse_range(const char *_string,
       return 0;
     } else {
       if (verbose >= 0)
-	fprintf(stderr, "unrecognized range keyword `%s'\n", string);
+        fprintf(stderr, "unrecognized range keyword `%s'\n", string);
       return -1;
     }
   }
@@ -255,7 +255,7 @@ hwloc_calc_parse_range(const char *_string,
     last = strtol(end+1, &end2, 10);
     if (*end2) {
       if (verbose >= 0)
-	fprintf(stderr, "invalid character at `%s' after range at `%s'\n", end2, string);
+        fprintf(stderr, "invalid character at `%s' after range at `%s'\n", end2, string);
       return -1;
     } else if (end2 == end+1) {
       /* X- */
@@ -271,11 +271,11 @@ hwloc_calc_parse_range(const char *_string,
     amount = strtol(end+1, &end2, 10);
     if (*end2) {
       if (verbose >= 0)
-	fprintf(stderr, "invalid character at `%s' after range at `%s'\n", end2, string);
+        fprintf(stderr, "invalid character at `%s' after range at `%s'\n", end2, string);
       return -1;
     } else if (end2 == end+1) {
       if (verbose >= 0)
-	fprintf(stderr, "missing width at `%s' in range at `%s'\n", end2, string);
+        fprintf(stderr, "missing width at `%s' in range at `%s'\n", end2, string);
       return -1;
     }
 
@@ -294,9 +294,9 @@ hwloc_calc_parse_range(const char *_string,
 
 static __hwloc_inline int
 hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
-			       hwloc_const_bitmap_t rootcpuset, hwloc_const_bitmap_t rootnodeset, int depth,
-			       const char *string, /* starts with indexes following the colon */
-			       void (*cbfunc)(struct hwloc_calc_location_context_s *, void *, hwloc_obj_t), void *cbdata)
+                               hwloc_const_bitmap_t rootcpuset, hwloc_const_bitmap_t rootnodeset, int depth,
+                               const char *string, /* starts with indexes following the colon */
+                               void (*cbfunc)(struct hwloc_calc_location_context_s *, void *, hwloc_obj_t), void *cbdata)
 {
   int verbose = lcontext->verbose;
   hwloc_obj_t obj;
@@ -309,9 +309,9 @@ hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
   int err;
 
   err = hwloc_calc_parse_range(string,
-			       &first, &amount, &step, &wrap,
-			       &dot,
-			       verbose);
+                               &first, &amount, &step, &wrap,
+                               &dot,
+                               verbose);
   if (err < 0) {
     if (verbose >= 0)
       fprintf(stderr, "Failed to parse object index range %s\n", string);
@@ -327,28 +327,28 @@ hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
     typelen = strspn(nextstring, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
     if (!typelen || nextstring[typelen] != ':') {
       if (verbose >= 0)
-	fprintf(stderr, "hierarchical sublocation %s contains types not followed by colon and index range\n", nextstring);
+        fprintf(stderr, "hierarchical sublocation %s contains types not followed by colon and index range\n", nextstring);
       return -1;
     }
     nextsep = &nextstring[typelen];
 
     nextdepth = hwloc_calc_parse_depth_prefix(lcontext,
-					      nextstring, typelen,
-					      &type);
+                                              nextstring, typelen,
+                                              &type);
     if (nextdepth == HWLOC_TYPE_DEPTH_UNKNOWN) {
       if (verbose >= 0)
-	fprintf(stderr, "could not find level specified by location %s\n", nextstring);
+        fprintf(stderr, "could not find level specified by location %s\n", nextstring);
       return -1;
     }
     if (nextdepth == HWLOC_TYPE_DEPTH_MULTIPLE) {
       if (verbose >= 0)
-	fprintf(stderr, "found multiple levels for location %s\n", nextstring);
+        fprintf(stderr, "found multiple levels for location %s\n", nextstring);
       return -1;
     }
     /* we need an object with a cpuset, that's depth>=0 or memory */
     if (nextdepth < 0 && nextdepth != HWLOC_TYPE_DEPTH_NUMANODE) {
       if (verbose >= 0)
-	fprintf(stderr, "hierarchical location %s only supported with normal object types\n", string);
+        fprintf(stderr, "hierarchical location %s only supported with normal object types\n", string);
       return -1;
     }
   }
@@ -367,22 +367,22 @@ hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
       hwloc_bitmap_asprintf(&sc, rootcpuset);
       hwloc_bitmap_asprintf(&sn, rootnodeset);
       if (obj)
-	printf("using object #%u depth %d below cpuset %s nodeset %s\n",
-	       i, depth, sc, sn);
+        printf("using object #%u depth %d below cpuset %s nodeset %s\n",
+               i, depth, sc, sn);
       else
-	fprintf(stderr, "object #%u depth %d below cpuset %s nodeset %s does not exist\n",
-		i, depth, sc, sn);
+        fprintf(stderr, "object #%u depth %d below cpuset %s nodeset %s does not exist\n",
+                i, depth, sc, sn);
       free(sc);
       free(sn);
     }
     if (obj) {
       found++;
       if (dot) {
-	hwloc_calc_append_object_range(lcontext, obj->cpuset, obj->nodeset, nextdepth, nextsep+1, cbfunc, cbdata);
+        hwloc_calc_append_object_range(lcontext, obj->cpuset, obj->nodeset, nextdepth, nextsep+1, cbfunc, cbdata);
       } else {
-	/* add to the temporary cpuset
-	 * and let the caller add/clear/and/xor for the actual final cpuset depending on cmdline options
-	 */
+        /* add to the temporary cpuset
+         * and let the caller add/clear/and/xor for the actual final cpuset depending on cmdline options
+         */
         cbfunc(lcontext, cbdata, obj);
       }
     }
@@ -395,8 +395,8 @@ hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
 
 static __hwloc_inline int
 hwloc_calc_append_iodev(struct hwloc_calc_location_context_s *lcontext,
-			void (*cbfunc)(struct hwloc_calc_location_context_s *, void *, hwloc_obj_t), void *cbdata,
-			hwloc_obj_t obj)
+                        void (*cbfunc)(struct hwloc_calc_location_context_s *, void *, hwloc_obj_t), void *cbdata,
+                        hwloc_obj_t obj)
 {
   cbfunc(lcontext, cbdata, obj);
   return 0;
@@ -404,8 +404,8 @@ hwloc_calc_append_iodev(struct hwloc_calc_location_context_s *lcontext,
 
 static __hwloc_inline int
 hwloc_calc_append_iodev_by_index(struct hwloc_calc_location_context_s *lcontext,
-				 hwloc_obj_type_t type, int depth, const char *string,
-				 void (*cbfunc)(struct hwloc_calc_location_context_s *, void *, hwloc_obj_t), void *cbdata)
+                                 hwloc_obj_type_t type, int depth, const char *string,
+                                 void (*cbfunc)(struct hwloc_calc_location_context_s *, void *, hwloc_obj_t), void *cbdata)
 {
   hwloc_topology_t topology = lcontext->topology;
   int verbose = lcontext->verbose;
@@ -425,28 +425,28 @@ hwloc_calc_append_iodev_by_index(struct hwloc_calc_location_context_s *lcontext,
       /* try to match by [vendor:device] */
       pcivendor = strtoul(current, &endp, 16);
       if (*endp != ':') {
-	if (verbose >= 0)
-	  fprintf(stderr, "invalid PCI vendor:device matching specification %s\n", string);
-	return -1;
+        if (verbose >= 0)
+          fprintf(stderr, "invalid PCI vendor:device matching specification %s\n", string);
+        return -1;
       }
       if (endp == current)
-	pcivendor = -1;
+        pcivendor = -1;
       current = endp+1;
 
       pcidevice = strtoul(current, &endp, 16);
       if (*endp != ']') {
-	if (verbose >= 0)
-	  fprintf(stderr, "invalid PCI vendor:device matching specification %s\n", string);
-      	return -1;
+        if (verbose >= 0)
+          fprintf(stderr, "invalid PCI vendor:device matching specification %s\n", string);
+        return -1;
       }
       if (endp == current)
-	pcidevice = -1;
+        pcidevice = -1;
       current = endp+1;
 
       if (*current != ':' && *current != '\0') {
-	if (verbose >= 0)
-	  fprintf(stderr, "invalid PCI vendor:device matching specification %s\n", string);
-      	return -1;
+        if (verbose >= 0)
+          fprintf(stderr, "invalid PCI vendor:device matching specification %s\n", string);
+        return -1;
       }
 
     } else if (type == HWLOC_OBJ_OS_DEVICE) {
@@ -456,32 +456,32 @@ hwloc_calc_append_iodev_by_index(struct hwloc_calc_location_context_s *lcontext,
 
       endp = strchr(current, ']');
       if (!endp) {
-	if (verbose >= 0)
-	  fprintf(stderr, "invalid OS device subtype specification %s\n", string);
-	return -1;
+        if (verbose >= 0)
+          fprintf(stderr, "invalid OS device subtype specification %s\n", string);
+        return -1;
       }
       *endp = 0;
 
       err = hwloc_type_sscanf(current, &type2, &attr, sizeof(attr));
       *endp = ']';
       if (err < 0 || type2 != HWLOC_OBJ_OS_DEVICE) {
-	if (verbose >= 0)
-	  fprintf(stderr, "invalid OS device subtype specification %s\n", string);
-	return -1;
+        if (verbose >= 0)
+          fprintf(stderr, "invalid OS device subtype specification %s\n", string);
+        return -1;
       }
       osdevtype = attr.osdev.type;
 
       current = endp+1;
       if (*current != ':' && *current != '\0') {
-	if (verbose >= 0)
-	  fprintf(stderr, "invalid OS device subtype specification %s\n", string);
+        if (verbose >= 0)
+          fprintf(stderr, "invalid OS device subtype specification %s\n", string);
         return -1;
       }
 
     } else {
       /* no matching for non-PCI devices */
       if (verbose >= 0)
-	fprintf(stderr, "invalid matching specification %s\n", string);
+        fprintf(stderr, "invalid matching specification %s\n", string);
       return -1;
     }
 
@@ -493,16 +493,16 @@ hwloc_calc_append_iodev_by_index(struct hwloc_calc_location_context_s *lcontext,
   if (*current != '\0') {
     current++;
     err = hwloc_calc_parse_range(current,
-				 &first, &amount, &step, &wrap,
-				 &dot,
-				 verbose);
+                                 &first, &amount, &step, &wrap,
+                                 &dot,
+                                 verbose);
     if (dot) {
       fprintf(stderr, "hierarchical location %s only supported with normal object types\n", string);
       return -1;
     }
     if (err < 0) {
       if (verbose >= 0)
-	fprintf(stderr, "Failed to parse object index range %s\n", current);
+        fprintf(stderr, "Failed to parse object index range %s\n", current);
       return -1;
     }
   }
@@ -523,14 +523,14 @@ hwloc_calc_append_iodev_by_index(struct hwloc_calc_location_context_s *lcontext,
 
     if (type == HWLOC_OBJ_PCI_DEVICE) {
       if (pcivendor != -1 && (int) obj->attr->pcidev.vendor_id != pcivendor)
-	continue;
+        continue;
       if (pcidevice != -1 && (int) obj->attr->pcidev.device_id != pcidevice)
-	continue;
+        continue;
     }
 
     if (type == HWLOC_OBJ_OS_DEVICE) {
       if (osdevtype != -1 && (int) obj->attr->osdev.type != osdevtype)
-	continue;
+        continue;
     }
 
     if (first--)
@@ -539,7 +539,7 @@ hwloc_calc_append_iodev_by_index(struct hwloc_calc_location_context_s *lcontext,
     /* ok, got one object */
     if (verbose > 0)
       printf("using matching PCI object #%d bus id %04x:%02x:%02x.%01x\n", i,
-	     obj->attr->pcidev.domain, obj->attr->pcidev.bus, obj->attr->pcidev.dev, obj->attr->pcidev.func);
+             obj->attr->pcidev.domain, obj->attr->pcidev.bus, obj->attr->pcidev.dev, obj->attr->pcidev.func);
     hwloc_calc_append_iodev(lcontext, cbfunc, cbdata, obj);
 
     if (!prev)
@@ -557,8 +557,8 @@ hwloc_calc_append_iodev_by_index(struct hwloc_calc_location_context_s *lcontext,
 
 static __hwloc_inline int
 hwloc_calc_process_location(struct hwloc_calc_location_context_s *lcontext,
-			    const char *arg, size_t typelen,
-			    void (*cbfunc)(struct hwloc_calc_location_context_s *, void *, hwloc_obj_t), void *cbdata)
+                            const char *arg, size_t typelen,
+                            void (*cbfunc)(struct hwloc_calc_location_context_s *, void *, hwloc_obj_t), void *cbdata)
 {
   hwloc_topology_t topology = lcontext->topology;
   int verbose = lcontext->verbose;
@@ -567,8 +567,8 @@ hwloc_calc_process_location(struct hwloc_calc_location_context_s *lcontext,
   int depth;
 
   depth = hwloc_calc_parse_depth_prefix(lcontext,
-					arg, typelen,
-					&type);
+                                        arg, typelen,
+                                        &type);
   if (depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
     if (verbose >= 0)
       fprintf(stderr, "could not find level specified by location %s\n", arg);
@@ -593,31 +593,31 @@ hwloc_calc_process_location(struct hwloc_calc_location_context_s *lcontext,
       /* try to match a busid */
       obj = hwloc_get_pcidev_by_busidstring(topology, sep+1);
       if (obj)
-	return hwloc_calc_append_iodev(lcontext, cbfunc, cbdata, obj);
+        return hwloc_calc_append_iodev(lcontext, cbfunc, cbdata, obj);
       if (verbose >= 0)
-	fprintf(stderr, "invalid PCI device %s\n", sep+1);
+        fprintf(stderr, "invalid PCI device %s\n", sep+1);
       return -1;
 
     } else if (*sep == '=' && type == HWLOC_OBJ_OS_DEVICE) {
       /* try to match a OS device name */
       while ((obj = hwloc_get_next_osdev(topology, obj)) != NULL) {
-	if (!strcmp(obj->name, sep+1))
-	  return hwloc_calc_append_iodev(lcontext, cbfunc, cbdata, obj);
+        if (!strcmp(obj->name, sep+1))
+          return hwloc_calc_append_iodev(lcontext, cbfunc, cbdata, obj);
       }
       if (verbose >= 0)
-	fprintf(stderr, "invalid OS device %s\n", sep+1);
+        fprintf(stderr, "invalid OS device %s\n", sep+1);
       return -1;
 
     } else if (*sep == '=' && type == HWLOC_OBJ_MISC) {
       /* try to match a Misc device name */
       obj = hwloc_get_obj_by_type(topology, HWLOC_OBJ_MISC, 0);
       while (obj) {
-	if (!strcmp(obj->name, sep+1))
-	  return hwloc_calc_append_iodev(lcontext, cbfunc, cbdata, obj);
-	obj = obj->next_cousin;
+        if (!strcmp(obj->name, sep+1))
+          return hwloc_calc_append_iodev(lcontext, cbfunc, cbdata, obj);
+        obj = obj->next_cousin;
       }
       if (verbose >= 0)
-	fprintf(stderr, "invalid Misc object %s\n", sep+1);
+        fprintf(stderr, "invalid Misc object %s\n", sep+1);
       return -1;
 
     } else
@@ -626,9 +626,9 @@ hwloc_calc_process_location(struct hwloc_calc_location_context_s *lcontext,
 
   /* look at indexes following this type/depth */
   return hwloc_calc_append_object_range(lcontext,
-					hwloc_topology_get_complete_cpuset(topology),
-					hwloc_topology_get_complete_nodeset(topology),
-					depth, sep+1, cbfunc, cbdata);
+                                        hwloc_topology_get_complete_cpuset(topology),
+                                        hwloc_topology_get_complete_nodeset(topology),
+                                        depth, sep+1, cbfunc, cbdata);
 }
 
 struct hwloc_calc_set_context_s {
@@ -656,14 +656,14 @@ hwloc_calc_process_location_set_cb(struct hwloc_calc_location_context_s *lcontex
     /* do nothing */
     return;
   hwloc_calc_append_set(set,
-			nodeset_output ? obj->nodeset : obj->cpuset,
-			HWLOC_CALC_APPEND_ADD, verbose);
+                        nodeset_output ? obj->nodeset : obj->cpuset,
+                        HWLOC_CALC_APPEND_ADD, verbose);
 }
 
 static __hwloc_inline int
 hwloc_calc_process_location_as_set(struct hwloc_calc_location_context_s *lcontext,
-				   struct hwloc_calc_set_context_s *scontext,
-				   const char *arg)
+                                   struct hwloc_calc_set_context_s *scontext,
+                                   const char *arg)
 {
   hwloc_topology_t topology = lcontext->topology;
   int verbose = lcontext->verbose;
@@ -687,8 +687,8 @@ hwloc_calc_process_location_as_set(struct hwloc_calc_location_context_s *lcontex
 
   if (!strcmp(arg, "all") || !strcmp(arg, "root"))
     return hwloc_calc_append_set(output_set,
-				 nodeset_output ? hwloc_topology_get_topology_nodeset(topology) : hwloc_topology_get_topology_cpuset(topology),
-				 mode, verbose);
+                                 nodeset_output ? hwloc_topology_get_topology_nodeset(topology) : hwloc_topology_get_topology_cpuset(topology),
+                                 mode, verbose);
 
   /* try to match a type/depth followed by a special character */
   typelen = strspn(arg, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
@@ -698,7 +698,7 @@ hwloc_calc_process_location_as_set(struct hwloc_calc_location_context_s *lcontex
     cbdata.set = hwloc_bitmap_alloc();
     cbdata.scontext = scontext;
     err = hwloc_calc_process_location(lcontext, arg, typelen,
-				      hwloc_calc_process_location_set_cb, &cbdata);
+                                      hwloc_calc_process_location_set_cb, &cbdata);
     if (!err)
       err = hwloc_calc_append_set(output_set, cbdata.set, mode, verbose);
     hwloc_bitmap_free(cbdata.set);
@@ -737,23 +737,23 @@ hwloc_calc_process_location_as_set(struct hwloc_calc_location_context_s *lcontex
     } else {
       /* check that the remaining is a comma-separated list of hexadecimal integer with 0x as an optional prefix */
       while (1) {
-	char *next = strchr(tmp, ',');
-	size_t len;
+        char *next = strchr(tmp, ',');
+        size_t len;
         if (hwloc_strncasecmp(tmp, "0x", 2) == 0) {
-	  tmp += 2;
-	  if (',' == *tmp || 0 == *tmp) {
-	    err = -1;
-	    goto out;
-	  }
-	}
-	len = next ? (size_t) (next-tmp) : strlen(tmp);
-	if (len != strspn(tmp, "0123456789abcdefABCDEF")) {
-	  err = -1;
-	  goto out;
-	}
-	if (!next)
-	  break;
-	tmp = next+1;
+          tmp += 2;
+          if (',' == *tmp || 0 == *tmp) {
+            err = -1;
+            goto out;
+          }
+        }
+        len = next ? (size_t) (next-tmp) : strlen(tmp);
+        if (len != strspn(tmp, "0123456789abcdefABCDEF")) {
+          err = -1;
+          goto out;
+        }
+        if (!next)
+          break;
+        tmp = next+1;
       }
     }
 

--- a/utils/hwloc/hwloc-diff.c
+++ b/utils/hwloc/hwloc-diff.c
@@ -15,7 +15,7 @@ void usage(const char *callname __hwloc_attribute_unused, FILE *where)
 	fprintf(where, "  --refname <name>  Change the XML reference identifier to <name> in the output\n");
 	fprintf(where, "                    (default is the filename of the first topology\n");
 	fprintf(where, "  --version         Report version and exit\n");
-        fprintf(where, "  -h --help         Show this usage\n");
+	fprintf(where, "  -h --help         Show this usage\n");
 }
 
 int main(int argc, char *argv[])

--- a/utils/hwloc/hwloc-diff.c
+++ b/utils/hwloc/hwloc-diff.c
@@ -29,11 +29,11 @@ int main(int argc, char *argv[])
 	unsigned i, j;
 	int err;
 
-        callname = strrchr(argv[0], '/');
-        if (!callname)
-          callname = argv[0];
-        else
-          callname++;
+	callname = strrchr(argv[0], '/');
+	if (!callname)
+		callname = argv[0];
+	else
+		callname++;
 
 	/* skip argv[0], handle options */
 	argc--;

--- a/utils/hwloc/hwloc-distrib.c
+++ b/utils/hwloc/hwloc-distrib.c
@@ -227,8 +227,8 @@ int main(int argc, char *argv[])
     if (input) {
       err = hwloc_utils_enable_input_format(topology, flags, input, &input_format, verbose, callname);
       if (err) {
-	free(cpuset);
-	return EXIT_FAILURE;
+        free(cpuset);
+        return EXIT_FAILURE;
       }
     }
     hwloc_topology_set_flags(topology, flags);
@@ -247,8 +247,8 @@ int main(int argc, char *argv[])
       hwloc_bitmap_sscanf(restrictset, restrictstring);
       err = hwloc_topology_restrict (topology, restrictset, restrict_flags);
       if (err) {
-	perror("Restricting the topology");
-	/* FALLTHRU */
+        perror("Restricting the topology");
+        /* FALLTHRU */
       }
       hwloc_bitmap_free(restrictset);
       free(restrictstring);
@@ -260,8 +260,8 @@ int main(int argc, char *argv[])
       union hwloc_obj_attr_u attr;
       if (hwloc_type_sscanf(from_type, &type, &attr, sizeof(attr)) < 0
           || (from_depth = hwloc_get_type_depth_with_attr(topology, type, &attr, sizeof(attr))) < 0) {
-	fprintf(stderr, "Unsupported or unavailable type `%s' passed to --from, ignoring.\n", from_type);
-	return EXIT_FAILURE;
+        fprintf(stderr, "Unsupported or unavailable type `%s' passed to --from, ignoring.\n", from_type);
+        return EXIT_FAILURE;
       }
     }
 
@@ -271,7 +271,7 @@ int main(int argc, char *argv[])
       union hwloc_obj_attr_u attr;
       if (hwloc_type_sscanf(to_type, &type, &attr, sizeof(attr)) < 0
           || (to_depth = hwloc_get_type_depth_with_attr(topology, type, &attr, sizeof(attr))) < 0) {
-	return EXIT_FAILURE;
+        return EXIT_FAILURE;
       }
     }
 
@@ -287,22 +287,22 @@ int main(int argc, char *argv[])
       hwloc_distrib(topology, roots, chunks, cpuset, n, to_depth, dflags);
 
       for (i = 0; (long) i < n; i++) {
-	char *str = NULL;
-	if (singlify) {
-	  if (dflags & HWLOC_DISTRIB_FLAG_REVERSE) {
-	    unsigned last = hwloc_bitmap_last(cpuset[i]);
-	    hwloc_bitmap_only(cpuset[i], last);
-	  } else {
-	    hwloc_bitmap_singlify(cpuset[i]);
-	  }
-	}
-	if (taskset)
-	  hwloc_bitmap_taskset_asprintf(&str, cpuset[i]);
-	else
-	  hwloc_bitmap_asprintf(&str, cpuset[i]);
-	printf("%s\n", str);
-	free(str);
-	hwloc_bitmap_free(cpuset[i]);
+        char *str = NULL;
+        if (singlify) {
+          if (dflags & HWLOC_DISTRIB_FLAG_REVERSE) {
+            unsigned last = hwloc_bitmap_last(cpuset[i]);
+            hwloc_bitmap_only(cpuset[i], last);
+          } else {
+            hwloc_bitmap_singlify(cpuset[i]);
+          }
+        }
+        if (taskset)
+          hwloc_bitmap_taskset_asprintf(&str, cpuset[i]);
+        else
+          hwloc_bitmap_asprintf(&str, cpuset[i]);
+        printf("%s\n", str);
+        free(str);
+        hwloc_bitmap_free(cpuset[i]);
       }
 
       free(roots);

--- a/utils/hwloc/hwloc-distrib.c
+++ b/utils/hwloc/hwloc-distrib.c
@@ -87,104 +87,109 @@ int main(int argc, char *argv[])
     opt = 0;
 
     if (*argv[0] == '-') {
-      if (!strcmp(argv[0], "--single")) {
-	singlify = 1;
-	goto next;
+      /* Distribution options */
+      if (!strcmp (argv[0], "--ignore")) {
+        hwloc_obj_type_t type;
+        if (argc < 2) {
+          usage(callname, stderr);
+          exit(EXIT_FAILURE);
+        }
+        if (hwloc_type_sscanf(argv[1], &type, NULL, 0) < 0)
+          fprintf(stderr, "Unsupported type `%s' passed to --ignore, ignoring.\n", argv[1]);
+        else
+          hwloc_topology_set_type_filter(topology, type, HWLOC_TYPE_FILTER_KEEP_NONE);
+        opt = 1;
+        goto next;
       }
-      if (!strcmp(argv[0], "--taskset")) {
-	taskset = 1;
-	goto next;
+      if (!strcmp (argv[0], "--from")) {
+        if (argc < 2) {
+          usage(callname, stderr);
+          exit(EXIT_FAILURE);
+        }
+        from_type = argv[1];
+        opt = 1;
+        goto next;
       }
-      if (!strcmp(argv[0], "-v") || !strcmp(argv[0], "--verbose")) {
-	verbose = 1;
-	goto next;
+      if (!strcmp (argv[0], "--to")) {
+        if (argc < 2) {
+          usage(callname, stderr);
+          exit(EXIT_FAILURE);
+        }
+        to_type = argv[1];
+        opt = 1;
+        goto next;
       }
-      if (!strcmp (argv[0], "--disallowed") || !strcmp (argv[0], "--whole-system")) {
-	flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
-	goto next;
+      if (!strcmp (argv[0], "--at")) {
+        if (argc < 2) {
+          usage(callname, stderr);
+          exit(EXIT_FAILURE);
+        }
+        from_type = to_type = argv[1];
+        opt = 1;
+        goto next;
       }
-      if (!strcmp(argv[0], "-h") || !strcmp(argv[0], "--help")) {
-	usage(callname, stdout);
-	return EXIT_SUCCESS;
+      if (!strcmp (argv[0], "--reverse")) {
+        dflags |= HWLOC_DISTRIB_FLAG_REVERSE;
+        goto next;
       }
-      if (hwloc_utils_lookup_input_option(argv, argc, &opt,
-					  &input, &input_format,
-					  callname)) {
-	opt = 1;
-	goto next;
-      }
-      else if (!strcmp (argv[0], "--ignore")) {
-	hwloc_obj_type_t type;
-	if (argc < 2) {
-	  usage(callname, stderr);
-	  exit(EXIT_FAILURE);
-	}
-	if (hwloc_type_sscanf(argv[1], &type, NULL, 0) < 0)
-	  fprintf(stderr, "Unsupported type `%s' passed to --ignore, ignoring.\n", argv[1]);
-	else
-	  hwloc_topology_set_type_filter(topology, type, HWLOC_TYPE_FILTER_KEEP_NONE);
-	opt = 1;
-	goto next;
-      }
-      else if (!strcmp (argv[0], "--from")) {
-	if (argc < 2) {
-	  usage(callname, stderr);
-	  exit(EXIT_FAILURE);
-	}
-	from_type = argv[1];
-	opt = 1;
-	goto next;
-      }
-      else if (!strcmp (argv[0], "--to")) {
-	if (argc < 2) {
-	  usage(callname, stderr);
-	  exit(EXIT_FAILURE);
-	}
-	to_type = argv[1];
-	opt = 1;
-	goto next;
-      }
-      else if (!strcmp (argv[0], "--at")) {
-	if (argc < 2) {
-	  usage(callname, stderr);
-	  exit(EXIT_FAILURE);
-	}
-	from_type = to_type = argv[1];
-	opt = 1;
-	goto next;
-      }
-      else if (!strcmp (argv[0], "--reverse")) {
-	dflags |= HWLOC_DISTRIB_FLAG_REVERSE;
-	goto next;
-      }
-      else if (!strcmp (argv[0], "--restrict")) {
-	if (argc < 2) {
-	  usage (callname, stderr);
-	  exit(EXIT_FAILURE);
-	}
+      /* Input topology options */
+      if (!strcmp (argv[0], "--restrict")) {
+        if (argc < 2) {
+          usage (callname, stderr);
+          exit(EXIT_FAILURE);
+        }
         if(strncmp(argv[1], "nodeset=", 8)) {
           restrictstring = strdup(argv[1]);
         } else {
           restrictstring = strdup(argv[1]+8);
           restrict_flags |= HWLOC_RESTRICT_FLAG_BYNODESET;
         }
-	opt = 1;
-	goto next;
-      }
-      else if (!strcmp (argv[0], "--restrict-flags")) {
-	if (argc < 2) {
-	  usage (callname, stderr);
-	  exit(EXIT_FAILURE);
-        }
-	restrict_flags = hwloc_utils_parse_restrict_flags(argv[1]);
         opt = 1;
-	goto next;
+        goto next;
       }
-      else if (!strcmp (argv[0], "--version")) {
-          printf("%s %s\n", callname, HWLOC_VERSION);
-          exit(EXIT_SUCCESS);
+      if (!strcmp (argv[0], "--restrict-flags")) {
+        if (argc < 2) {
+          usage (callname, stderr);
+          exit(EXIT_FAILURE);
+        }
+        restrict_flags = hwloc_utils_parse_restrict_flags(argv[1]);
+        opt = 1;
+        goto next;
+      }
+      if (!strcmp (argv[0], "--disallowed") || !strcmp (argv[0], "--whole-system")) {
+        flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
+        goto next;
+      }
+      if (hwloc_utils_lookup_input_option(argv, argc, &opt,
+            &input, &input_format,
+            callname)) {
+        opt = 1;
+        goto next;
+      }
+      /* Formatting options */
+      if (!strcmp(argv[0], "--single")) {
+        singlify = 1;
+        goto next;
+      }
+      if (!strcmp(argv[0], "--taskset")) {
+        taskset = 1;
+        goto next;
+      }
+      /* Misc */
+      if (!strcmp(argv[0], "-v") || !strcmp(argv[0], "--verbose")) {
+        verbose = 1;
+        goto next;
+      }
+      if (!strcmp (argv[0], "--version")) {
+        printf("%s %s\n", callname, HWLOC_VERSION);
+        exit(EXIT_SUCCESS);
+      }
+      if (!strcmp(argv[0], "-h") || !strcmp(argv[0], "--help")) {
+        usage(callname, stdout);
+        return EXIT_SUCCESS;
       }
 
+      /* Errors */
       fprintf (stderr, "Unrecognized option: %s\n", argv[0]);
       usage(callname, stderr);
       return EXIT_FAILURE;

--- a/utils/hwloc/hwloc-dump-hwdata.c
+++ b/utils/hwloc/hwloc-dump-hwdata.c
@@ -47,13 +47,7 @@ int main(int argc, char *argv[])
 
     argv++; argc--;
     while (argc) {
-      if (!strcmp(argv[0], "-h") || !strcmp(argv[0], "--help")) {
-        usage(callname, stdout);
-        exit(EXIT_SUCCESS);
-      } else if (!strcmp (argv[0], "--version")) {
-        printf("%s %s\n", callname, HWLOC_VERSION);
-        exit(EXIT_SUCCESS);
-      } else if (!strcmp(argv[0], "-o")) {
+      if (!strcmp(argv[0], "-o")) {
         if (argc == 1) {
           fprintf(stderr, "Missing output directory name.\n");
           usage(callname, stderr);
@@ -62,7 +56,17 @@ int main(int argc, char *argv[])
         dirname = argv[1];
         argc -= 2;
         argv += 2;
-      } else {
+      }
+      /* Misc */
+      else if (!strcmp (argv[0], "--version")) {
+        printf("%s %s\n", callname, HWLOC_VERSION);
+        exit(EXIT_SUCCESS);
+      } else if (!strcmp(argv[0], "-h") || !strcmp(argv[0], "--help")) {
+        usage(callname, stdout);
+        exit(EXIT_SUCCESS);
+      }
+      /* Errors */
+      else {
         fprintf(stderr, "Unknown option: %s\n", argv[0]);
         usage(callname, stderr);
         exit(EXIT_FAILURE);

--- a/utils/hwloc/hwloc-gather-cpuid.c
+++ b/utils/hwloc/hwloc-gather-cpuid.c
@@ -594,13 +594,17 @@ int main(int argc, const char * const argv[])
       verbose--;
       argc--;
       argv++;
-    } else if (!strcmp (argv[0], "--version")) {
+    }
+    /* Misc */
+    else if (!strcmp (argv[0], "--version")) {
       printf("%s %s\n", callname, HWLOC_VERSION);
       exit(EXIT_SUCCESS);
     } else if (!strcmp(argv[0], "-h") || !strcmp(argv[0], "--help")) {
       usage(callname, stdout);
       goto out;
-    } else {
+    }
+    /* Errors */
+    else {
       usage(callname, stderr);
       ret = EXIT_FAILURE;
       goto out;

--- a/utils/hwloc/hwloc-gather-cpuid.c
+++ b/utils/hwloc/hwloc-gather-cpuid.c
@@ -650,9 +650,9 @@ int main(int argc, const char * const argv[])
     err = mkdir(basedir, S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH);
     if (err < 0) {
       if (access(basedir, X_OK|W_OK) < 0) {
-	fprintf(stderr, "Could not create/open destination directory %s\n", basedir);
-	ret = EXIT_FAILURE;
-	goto out_with_topo;
+        fprintf(stderr, "Could not create/open destination directory %s\n", basedir);
+        ret = EXIT_FAILURE;
+        goto out_with_topo;
       }
     }
     if (verbose)
@@ -668,7 +668,7 @@ int main(int argc, const char * const argv[])
     while ((pu = hwloc_get_next_obj_by_type(topo, HWLOC_OBJ_PU, pu)) != NULL) {
       idx = pu->os_index;
       if (path)
-	snprintf(path, pathlen, "%s/pu%u", basedir, idx);
+        snprintf(path, pathlen, "%s/pu%u", basedir, idx);
       dump_one_proc(topo, pu, path);
     }
 
@@ -678,7 +678,7 @@ int main(int argc, const char * const argv[])
       fprintf(file, "Architecture: x86\n");
       fclose(file);
       if (verbose)
-	printf("Summary written to %s\n", path);
+        printf("Summary written to %s\n", path);
     } else {
       fprintf(stderr, "Failed to open summary file '%s' for writing: %s\n", path, strerror(errno));
     }
@@ -697,8 +697,8 @@ int main(int argc, const char * const argv[])
 
   if (verbose)
     printf("\n"
-	   "WARNING: Do not post these files on a public list or website unless you\n"
-	   "WARNING: are sure that no information about this platform is sensitive.\n");
+           "WARNING: Do not post these files on a public list or website unless you\n"
+           "WARNING: are sure that no information about this platform is sensitive.\n");
 
  out_with_path:
   free(path);

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -178,7 +178,7 @@ hwloc_info_show_obj(hwloc_topology_t topology, hwloc_obj_t obj, const char *type
       printf("%s attr PCI id = %04x:%04x\n",
 	     prefix, obj->attr->pcidev.vendor_id, obj->attr->pcidev.device_id);
       if (obj->attr->pcidev.linkspeed)
-	printf("%s attr PCI linkspeed = %f GB/s\n", prefix, obj->attr->pcidev.linkspeed);
+        printf("%s attr PCI linkspeed = %f GB/s\n", prefix, obj->attr->pcidev.linkspeed);
       break;
     }
     switch (obj->attr->bridge.downstream_type) {
@@ -329,15 +329,15 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
     hwloc_obj_t parent = obj;
     while (parent) {
       if (show_index_prefix)
-	snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, level);
+        snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, level);
       hwloc_obj_type_snprintf(parents, sizeof(parents), parent, HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
       if (verbose < 0)
-	printf("%s%s:%u\n", prefix, parents, parent->logical_index);
+        printf("%s%s:%u\n", prefix, parents, parent->logical_index);
       else if (level)
-	printf("%s%s L#%u = parent #%u of %s L#%u\n",
+        printf("%s%s L#%u = parent #%u of %s L#%u\n",
 	       prefix, parents, parent->logical_index, level, objs, obj->logical_index);
       else
-	printf("%s%s L#%u\n", prefix, parents, parent->logical_index);
+        printf("%s%s L#%u\n", prefix, parents, parent->logical_index);
       hwloc_info_show_obj(topology, parent, parents, prefix, verbose);
       parent = parent->parent;
       level++;
@@ -347,14 +347,14 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
     hwloc_obj_t parent = obj;
     while (parent) {
       if (parent->depth == show_ancestor_depth) {
-	hwloc_obj_type_snprintf(parents, sizeof(parents), parent, HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
-	if (verbose < 0)
-	  printf("%s%s:%u\n", prefix, parents, parent->logical_index);
-	else
-	  printf("%s%s L#%u = parent of %s L#%u\n",
-		 prefix, parents, parent->logical_index, objs, obj->logical_index);
-	hwloc_info_show_obj(topology, parent, parents, prefix, verbose);
-	break;
+        hwloc_obj_type_snprintf(parents, sizeof(parents), parent, HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
+        if (verbose < 0)
+          printf("%s%s:%u\n", prefix, parents, parent->logical_index);
+        else
+          printf("%s%s L#%u = parent of %s L#%u\n",
+              prefix, parents, parent->logical_index, objs, obj->logical_index);
+        hwloc_info_show_obj(topology, parent, parents, prefix, verbose);
+        break;
       }
       parent = parent->parent;
     }
@@ -364,13 +364,13 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
     while ((child = hwloc_get_next_child(topology, obj, child)) != NULL) {
       char childs[128];
       if (show_index_prefix)
-	snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
+        snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
       hwloc_obj_type_snprintf(childs, sizeof(childs), child, HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
       if (verbose < 0)
-	printf("%s%s:%u\n", prefix, childs, child->logical_index);
+        printf("%s%s:%u\n", prefix, childs, child->logical_index);
       else
-	printf("%s%s L#%u = child #%u of %s L#%u\n",
-	       prefix, childs, child->logical_index, i, objs, obj->logical_index);
+        printf("%s%s L#%u = child #%u of %s L#%u\n",
+            prefix, childs, child->logical_index, i, objs, obj->logical_index);
       hwloc_info_show_obj(topology, child, childs, prefix, verbose);
       i++;
     }
@@ -380,49 +380,49 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
       unsigned i = 0;
       unsigned n = hwloc_calc_get_nbobjs_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, show_descendants_depth);
       for(i=0; i<n; i++) {
-	hwloc_obj_t child = hwloc_calc_get_obj_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, show_descendants_depth, i);
-	char childs[128];
-	if (show_index_prefix)
-	  snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
-	hwloc_obj_type_snprintf(childs, sizeof(childs), child, HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
-	if (verbose < 0)
-	  printf("%s%s:%u\n", prefix, childs, child->logical_index);
-	else
-	  printf("%s%s L#%u = descendant #%u of %s L#%u\n",
+        hwloc_obj_t child = hwloc_calc_get_obj_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, show_descendants_depth, i);
+        char childs[128];
+        if (show_index_prefix)
+          snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
+        hwloc_obj_type_snprintf(childs, sizeof(childs), child, HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
+        if (verbose < 0)
+          printf("%s%s:%u\n", prefix, childs, child->logical_index);
+        else
+          printf("%s%s L#%u = descendant #%u of %s L#%u\n",
 		 prefix, childs, child->logical_index, i, objs, obj->logical_index);
-	hwloc_info_show_obj(topology, child, childs, prefix, verbose);
+        hwloc_info_show_obj(topology, child, childs, prefix, verbose);
       }
     } else {
       /* custom level */
       unsigned i = 0;
       hwloc_obj_t child = NULL;
       while ((child = hwloc_get_next_obj_by_depth(topology, show_descendants_depth, child)) != NULL) {
-	char childs[128];
-	hwloc_obj_t parent = child->parent;
-	if (obj->cpuset) {
-	  while (parent && !parent->cpuset)
-	    parent = parent->parent;
-	  if (!parent)
-	    continue;
-	  if (!hwloc_bitmap_isincluded(parent->cpuset, obj->cpuset)
-	      || !hwloc_bitmap_isincluded(parent->nodeset, obj->nodeset))
-	    continue;
-	} else {
-	  while (parent && parent != obj)
-	    parent = parent->parent;
-	  if (!parent)
-	    continue;
-	}
-	if (show_index_prefix)
-	  snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
-	hwloc_obj_type_snprintf(childs, sizeof(childs), child, HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
-	if (verbose < 0)
-	  printf("%s%s:%u\n", prefix, childs, child->logical_index);
-	else
-	  printf("%s%s L#%u = descendant #%u of %s L#%u\n",
+        char childs[128];
+        hwloc_obj_t parent = child->parent;
+        if (obj->cpuset) {
+          while (parent && !parent->cpuset)
+            parent = parent->parent;
+          if (!parent)
+            continue;
+          if (!hwloc_bitmap_isincluded(parent->cpuset, obj->cpuset)
+              || !hwloc_bitmap_isincluded(parent->nodeset, obj->nodeset))
+            continue;
+        } else {
+          while (parent && parent != obj)
+            parent = parent->parent;
+          if (!parent)
+            continue;
+        }
+        if (show_index_prefix)
+          snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
+        hwloc_obj_type_snprintf(childs, sizeof(childs), child, HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
+        if (verbose < 0)
+          printf("%s%s:%u\n", prefix, childs, child->logical_index);
+        else
+          printf("%s%s L#%u = descendant #%u of %s L#%u\n",
 		 prefix, childs, child->logical_index, i, objs, obj->logical_index);
-	hwloc_info_show_obj(topology, child, childs, prefix, verbose);
-	i++;
+        hwloc_info_show_obj(topology, child, childs, prefix, verbose);
+        i++;
       }
     }
   } else if (show_local_memory) {
@@ -464,7 +464,7 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
           if (!nodes[i])
             continue;
           if (show_index_prefix)
-	    snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
+            snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
           hwloc_obj_type_snprintf(nodestr, sizeof(nodestr), nodes[i], HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
           if (verbose < 0)
             printf("%s%s:%u\n", prefix, nodestr, nodes[i]->logical_index);
@@ -722,7 +722,7 @@ main (int argc, char *argv[])
 
   if (pid_number > 0) {
     if (hwloc_pid_from_number(&pid, pid_number, 0, 1 /* verbose */) < 0
-	|| hwloc_topology_set_pid(topology, pid)) {
+        || hwloc_topology_set_pid(topology, pid)) {
       perror("Setting target pid");
       if (input) hwloc_utils_disable_input_format(&input_format);
       return EXIT_FAILURE;
@@ -785,9 +785,9 @@ main (int argc, char *argv[])
     hwloc_bitmap_t restrictset = hwloc_bitmap_alloc();
     if (!strcmp (restrictstring, "binding")) {
       if (pid_number > 0)
-	hwloc_get_proc_cpubind(topology, pid, restrictset, HWLOC_CPUBIND_PROCESS);
+        hwloc_get_proc_cpubind(topology, pid, restrictset, HWLOC_CPUBIND_PROCESS);
       else
-	hwloc_get_cpubind(topology, restrictset, HWLOC_CPUBIND_PROCESS);
+        hwloc_get_cpubind(topology, restrictset, HWLOC_CPUBIND_PROCESS);
     } else {
       hwloc_bitmap_sscanf(restrictset, restrictstring);
     }
@@ -886,17 +886,17 @@ main (int argc, char *argv[])
     current_obj = 0;
     while (argc >= 1) {
       if (!strcmp(argv[0], "all") || !strcmp(argv[0], "root")) {
-	hwloc_calc_process_location_info_cb(&lcontext, NULL, hwloc_get_root_obj(topology));
+        hwloc_calc_process_location_info_cb(&lcontext, NULL, hwloc_get_root_obj(topology));
       } else if (*argv[0] == '-') {
         fprintf(stderr, "Cannot handle command-line option %s after some locations.\n", argv[0]);
         return EXIT_FAILURE;
       } else {
-	/* try to match a type/depth followed by a special character */
-	typelen = strspn(argv[0], "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
-	if (typelen && (argv[0][typelen] == ':' || argv[0][typelen] == '=' || argv[0][typelen] == '[')) {
-	  err = hwloc_calc_process_location(&lcontext, argv[0], typelen,
+        /* try to match a type/depth followed by a special character */
+        typelen = strspn(argv[0], "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+        if (typelen && (argv[0][typelen] == ':' || argv[0][typelen] == '=' || argv[0][typelen] == '[')) {
+          err = hwloc_calc_process_location(&lcontext, argv[0], typelen,
 					    hwloc_calc_process_location_info_cb, NULL);
-	}
+        }
       }
       argc--; argv++;
     }

--- a/utils/hwloc/hwloc-patch.c
+++ b/utils/hwloc/hwloc-patch.c
@@ -14,7 +14,7 @@ void usage(const char *callname __hwloc_attribute_unused, FILE *where)
 	fprintf(where, "Options:\n");
 	fprintf(where, "  -R --reverse     Reverse the sense of the difference\n");
 	fprintf(where, "  --version        Report version and exit\n");
-        fprintf(where, "  -h --help        Show this usage\n");
+	fprintf(where, "  -h --help        Show this usage\n");
 }
 
 static int hwloc_diff_read(const char *inputdiff,
@@ -88,15 +88,20 @@ int main(int argc, char *argv[])
 		putenv((char *) "HWLOC_XML_VERBOSE=1");
 
 	while (argc && *argv[0] == '-') {
+		/* Options */
 		if (!strcmp (argv[0], "-R") || !strcmp (argv[0], "--reverse")) {
 			patchflags ^= HWLOC_TOPOLOGY_DIFF_APPLY_REVERSE;
-		} else if (!strcmp (argv[0], "--version")) {
+		}
+		/* Misc */
+		else if (!strcmp (argv[0], "--version")) {
 			printf("%s %s\n", callname, HWLOC_VERSION);
 			exit(EXIT_SUCCESS);
 		} else if (!strcmp(argv[0], "-h") || !strcmp(argv[0], "--help")) {
 			usage(callname, stdout);
 			exit(EXIT_SUCCESS);
-		} else {
+		}
+		/* Errors */
+		else {
 			fprintf(stderr, "Unrecognized options: %s\n", argv[0]);
 			usage(callname, stderr);
 			exit(EXIT_FAILURE);

--- a/utils/hwloc/hwloc-patch.c
+++ b/utils/hwloc/hwloc-patch.c
@@ -72,11 +72,11 @@ int main(int argc, char *argv[])
 	char *callname, *input, *inputdiff, *output = NULL, *refname = NULL;
 	int err;
 
-        callname = strrchr(argv[0], '/');
-        if (!callname)
-          callname = argv[0];
-        else
-          callname++;
+	callname = strrchr(argv[0], '/');
+	if (!callname)
+		callname = argv[0];
+	else
+		callname++;
 
 	/* skip argv[0], handle options */
 	argc--;

--- a/utils/hwloc/hwloc-ps.c
+++ b/utils/hwloc/hwloc-ps.c
@@ -449,28 +449,13 @@ int main(int argc, char *argv[])
 
   while (argc >= 1) {
     opt = 0;
-    if (!strcmp(argv[0], "-a"))
+    /* Options */
+    if (!strcmp(argv[0], "-a")) {
       show_all = 1;
-    else if (!strcmp(argv[0], "-l") || !strcmp(argv[0], "--logical")) {
-      logical = 1;
-    } else if (!strcmp(argv[0], "-p") || !strcmp(argv[0], "--physical")) {
-      logical = 0;
-    } else if (!strcmp(argv[0], "-c") || !strcmp(argv[0], "--cpuset")) {
-      show_cpuset = 1;
-    } else if (!strcmp(argv[0], "-e") || !strncmp(argv[0], "--get-last-cpu-location", 10)) {
-      get_last_cpu_location = 1;
-    } else if (!strcmp(argv[0], "-t") || !strcmp(argv[0], "--threads")) {
-#ifdef HWLOC_LINUX_SYS
-      show_threads = 1;
-#else
-      fprintf (stderr, "Listing threads is currently only supported on Linux\n");
-#endif
-    } else if (!strcmp(argv[0], "--single-ancestor")) {
-      single_ancestor = 1;
     } else if (!strcmp(argv[0], "--pid")) {
       if (argc < 2) {
-	usage(callname, stderr);
-	exit(EXIT_FAILURE);
+        usage(callname, stderr);
+        exit(EXIT_FAILURE);
       }
       only_pid = strtol(argv[1], NULL, 10);
       opt = 1;
@@ -483,35 +468,54 @@ int main(int argc, char *argv[])
       opt = 1;
     } else if (!strcmp(argv[0], "--name")) {
       if (argc < 2) {
-	usage(callname, stderr);
-	exit(EXIT_FAILURE);
+        usage(callname, stderr);
+        exit(EXIT_FAILURE);
       }
       only_name = argv[1];
       opt = 1;
     } else if (!strcmp(argv[0], "--uid")) {
 #ifdef HWLOC_LINUX_SYS
       if (argc < 2) {
-	usage(callname, stderr);
-	exit(EXIT_FAILURE);
+        usage(callname, stderr);
+        exit(EXIT_FAILURE);
       }
       if (!strcmp(argv[1], "all"))
-	only_uid = HWLOC_PS_ALL_UIDS;
+        only_uid = HWLOC_PS_ALL_UIDS;
       else
-	only_uid = atoi(argv[1]);
+        only_uid = atoi(argv[1]);
       opt = 1;
 #else
       fprintf (stderr, "Filtering by UID is currently only supported on Linux\n");
 #endif
-    } else if (!strcmp (argv[0], "--disallowed") || !strcmp (argv[0], "--whole-system")) {
-      flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
+    }
+    /* Output options */
+    else if (!strcmp(argv[0], "-l") || !strcmp(argv[0], "--logical")) {
+      logical = 1;
+    } else if (!strcmp(argv[0], "-p") || !strcmp(argv[0], "--physical")) {
+      logical = 0;
+    } else if (!strcmp(argv[0], "-c") || !strcmp(argv[0], "--cpuset")) {
+      show_cpuset = 1;
+    } else if (!strcmp(argv[0], "--single-ancestor")) {
+      single_ancestor = 1;
+    } else if (!strcmp(argv[0], "-t") || !strcmp(argv[0], "--threads")) {
+#ifdef HWLOC_LINUX_SYS
+      show_threads = 1;
+#else
+      fprintf (stderr, "Listing threads is currently only supported on Linux\n");
+#endif
+    } else if (!strcmp(argv[0], "-e") || !strncmp(argv[0], "--get-last-cpu-location", 10)) {
+      get_last_cpu_location = 1;
     } else if (!strcmp (argv[0], "--pid-cmd")) {
       if (argc < 2) {
-	usage(callname, stderr);
-	exit(EXIT_FAILURE);
+        usage(callname, stderr);
+        exit(EXIT_FAILURE);
       }
       pidcmd = argv[1];
       opt = 1;
-
+    } else if (!strcmp (argv[0], "--short-name")) {
+      psflags |= HWLOC_PS_FLAG_SHORTNAME;
+    } else if (!strcmp (argv[0], "--disallowed") || !strcmp (argv[0], "--whole-system")) {
+      flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
     } else if (!strcmp (argv[0], "--lstopo-misc")) {
       if (argc < 2) {
 	usage(callname, stderr);
@@ -526,27 +530,22 @@ int main(int argc, char *argv[])
         exit(EXIT_FAILURE);
       }
       opt = 1;
-
     } else if (!strcmp (argv[0], "--json-server")) {
       json_server = 1;
     } else if (!strcmp (argv[0], "--json-port")) {
       if (argc < 2) {
-	usage(callname, stderr);
-	exit(EXIT_FAILURE);
+        usage(callname, stderr);
+        exit(EXIT_FAILURE);
       }
       json_port = atoi(argv[1]);
       opt = 1;
-
-    } else if (!strcmp(argv[0], "-v") || !strcmp(argv[0], "--verbose")) {
+    }
+    /* Misc */
+    else if (!strcmp(argv[0], "-v") || !strcmp(argv[0], "--verbose")) {
       verbose++;
-
-    } else if (!strcmp (argv[0], "--short-name")) {
-      psflags |= HWLOC_PS_FLAG_SHORTNAME;
-
     } else if (!strcmp (argv[0], "--version")) {
       printf("%s %s\n", callname, HWLOC_VERSION);
       exit(EXIT_SUCCESS);
-
     } else if (!strcmp (argv[0], "-h") || !strcmp (argv[0], "--help")) {
       usage (callname, stdout);
       exit(EXIT_SUCCESS);

--- a/utils/hwloc/hwloc-ps.c
+++ b/utils/hwloc/hwloc-ps.c
@@ -134,7 +134,7 @@ static void print_process(hwloc_topology_t topology,
   if (proc->nthreads)
     for(i=0; i<proc->nthreads; i++)
       if (proc->threads[i].cpuset)
-	print_task(topology, proc->threads[i].tid, proc->threads[i].name, proc->threads[i].cpuset, NULL, 1);
+        print_task(topology, proc->threads[i].tid, proc->threads[i].name, proc->threads[i].cpuset, NULL, 1);
 }
 
 static void print_process_lstopo_misc(hwloc_topology_t topology __hwloc_attribute_unused,
@@ -160,11 +160,11 @@ static void print_process_lstopo_misc(hwloc_topology_t topology __hwloc_attribut
   if (proc->nthreads)
     for(i=0; i<proc->nthreads; i++)
       if (proc->threads[i].cpuset) {
-	char task_name[150];
-	if (*proc->threads[i].name)
-	  snprintf(task_name, sizeof(task_name), "%s %li %s", name, proc->threads[i].tid, proc->threads[i].name);
-	else
-	  snprintf(task_name, sizeof(task_name), "%s %li", name, proc->threads[i].tid);
+        char task_name[150];
+        if (*proc->threads[i].name)
+          snprintf(task_name, sizeof(task_name), "%s %li %s", name, proc->threads[i].tid, proc->threads[i].name);
+        else
+          snprintf(task_name, sizeof(task_name), "%s %li", name, proc->threads[i].tid);
         hwloc_bitmap_asprintf(&s, proc->threads[i].cpuset);
         fprintf(lstopo_misc_output,
                 "name=%s\n"
@@ -193,14 +193,14 @@ static void print_process_json(hwloc_topology_t topology,
     obj = obj->parent;
   hwloc_obj_type_snprintf(type, sizeof(type), obj, 0);
   fprintf(json_output,
-	  "{\n"
-	  "  \"PID\": %ld,\n"
-	  "  \"name\": \"%s\",\n"
-	  "  \"object\": \"%s:%u\"%s\n",
-	  proc->pid,
-	  proc->name,
-	  type, obj->logical_index,
-	  proc->nthreads ? "," : "");
+      "{\n"
+      "  \"PID\": %ld,\n"
+      "  \"name\": \"%s\",\n"
+      "  \"object\": \"%s:%u\"%s\n",
+      proc->pid,
+      proc->name,
+      type, obj->logical_index,
+      proc->nthreads ? "," : "");
 
   /* threads */
   if (proc->nthreads) {
@@ -209,21 +209,21 @@ static void print_process_json(hwloc_topology_t topology,
     for(i=0; i<proc->nthreads; i++) {
       struct hwloc_ps_thread *thread = &proc->threads[i];
       if (thread->cpuset) {
-	obj = hwloc_get_obj_covering_cpuset(topology, thread->cpuset);
-	while (obj->parent && hwloc_bitmap_isequal(obj->cpuset, obj->parent->cpuset))
-	  obj = obj->parent;
-	hwloc_obj_type_snprintf(type, sizeof(type), obj, 0);
+        obj = hwloc_get_obj_covering_cpuset(topology, thread->cpuset);
+        while (obj->parent && hwloc_bitmap_isequal(obj->cpuset, obj->parent->cpuset))
+          obj = obj->parent;
+        hwloc_obj_type_snprintf(type, sizeof(type), obj, 0);
 
-	fprintf(json_output,
-		"    {\n"
-		"      \"PID\": %ld,\n"
-		"      \"name\": \"%s\",\n"
-		"      \"object\": \"%s:%u\"\n"
-		"    }%s\n",
-		thread->tid,
-		thread->name,
-		type, obj->logical_index,
-		i < proc->nthreads-1 ? "," : "");
+        fprintf(json_output,
+            "    {\n"
+            "      \"PID\": %ld,\n"
+            "      \"name\": \"%s\",\n"
+            "      \"object\": \"%s:%u\"\n"
+            "    }%s\n",
+            thread->tid,
+            thread->name,
+            type, obj->logical_index,
+            i < proc->nthreads-1 ? "," : "");
       }
     }
     fprintf(json_output, "  ]\n");
@@ -283,11 +283,11 @@ static int run(hwloc_topology_t topology, hwloc_const_bitmap_t topocpuset,
         hwloc_ps_pidcmd(&proc, pidcmd);
 
       if (json_output)
-	print_process_json(topology, &proc);
+        print_process_json(topology, &proc);
       else if (lstopo_misc_output)
         print_process_lstopo_misc(topology, &proc);
       else
-	print_process(topology, &proc);
+        print_process(topology, &proc);
     }
     hwloc_ps_free_process(&proc);
     return ret;
@@ -357,48 +357,48 @@ run_json_server(hwloc_topology_t topology, hwloc_const_bitmap_t topocpuset)
       /* read the client request */
       ret = read(client_socket, req, sizeof(req)-1);
       if (ret <= 0)
-	break;
+        break;
       req[ret] = '\0';
       end = strchr(req, '\n');
       if (end)
-	*end = '\0';
+        *end = '\0';
 
       if (verbose > 0)
-	printf(" received request `%s'\n", req);
+        printf(" received request `%s'\n", req);
 
       only_name = NULL;
       only_pid = NO_ONLY_PID;
       children_of_pid = NO_ONLY_PID;
       current = req;
       while (*current) {
-	if (!strncmp(current, "lastcpulocation ", 16)) {
-	  psflags |= HWLOC_PS_FLAG_LASTCPULOCATION;
-	  current += 16;
-	  continue;
-	} else if (!strncmp(current, "threads ", 8)) {
-	  psflags |= HWLOC_PS_FLAG_THREADS;
-	  current += 8;
-	  continue;
-	} else if (!strcmp(current, "all")) {
-	  show_all = 1;
-	  break;
-	} else if (!strcmp(current, "bound")) {
-	  show_all = 0;
-	  break;
-	} else if (!strncmp(current, "pid=", 4)) {
-	  only_pid = atoi(current+4);
-	  psflags |= HWLOC_PS_FLAG_THREADS;
-	  show_all = 1;
-	  break;
-	} else if (!strncmp(current, "childrenofpid=", 14)) {
-	  children_of_pid = atoi(current+14);
-	  show_all = 1;
-	  break;
-	} else if (!strncmp(current, "name=", 5)) {
-	  only_name = current+5;
-	  show_all = 1;
-	  break;
-	}
+        if (!strncmp(current, "lastcpulocation ", 16)) {
+          psflags |= HWLOC_PS_FLAG_LASTCPULOCATION;
+          current += 16;
+          continue;
+        } else if (!strncmp(current, "threads ", 8)) {
+          psflags |= HWLOC_PS_FLAG_THREADS;
+          current += 8;
+          continue;
+        } else if (!strcmp(current, "all")) {
+          show_all = 1;
+          break;
+        } else if (!strcmp(current, "bound")) {
+          show_all = 0;
+          break;
+        } else if (!strncmp(current, "pid=", 4)) {
+          only_pid = atoi(current+4);
+          psflags |= HWLOC_PS_FLAG_THREADS;
+          show_all = 1;
+          break;
+        } else if (!strncmp(current, "childrenofpid=", 14)) {
+          children_of_pid = atoi(current+14);
+          show_all = 1;
+          break;
+        } else if (!strncmp(current, "name=", 5)) {
+          only_name = current+5;
+          show_all = 1;
+          break;
+        }
       }
 
       fprintf(json_output, "[ ");
@@ -461,8 +461,8 @@ int main(int argc, char *argv[])
       opt = 1;
     } else if (!strcmp(argv[0], "--children-of-pid")) {
       if (argc < 2) {
-	usage(callname, stderr);
-	exit(EXIT_FAILURE);
+        usage(callname, stderr);
+        exit(EXIT_FAILURE);
       }
       children_of_pid = strtol(argv[1], NULL, 10);
       opt = 1;
@@ -518,8 +518,8 @@ int main(int argc, char *argv[])
       flags |= HWLOC_TOPOLOGY_FLAG_INCLUDE_DISALLOWED;
     } else if (!strcmp (argv[0], "--lstopo-misc")) {
       if (argc < 2) {
-	usage(callname, stderr);
-	exit(EXIT_FAILURE);
+        usage(callname, stderr);
+        exit(EXIT_FAILURE);
       }
       if (!strcmp(argv[1], "-"))
         lstopo_misc_output = stdout;

--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -38,10 +38,10 @@ hwloc_utils_check_api_version(const char *callname)
   unsigned version = hwloc_get_api_version();
   if ((version >> 16) != (HWLOC_API_VERSION >> 16)) {
     fprintf(stderr,
-	    "%s compiled for hwloc API 0x%x but running on library API 0x%x.\n"
-	    "You may need to point LD_LIBRARY_PATH to the right hwloc library.\n"
-	    "Aborting since the new ABI is not backward compatible.\n",
-	    callname, (unsigned) HWLOC_API_VERSION, version);
+            "%s compiled for hwloc API 0x%x but running on library API 0x%x.\n"
+            "You may need to point LD_LIBRARY_PATH to the right hwloc library.\n"
+            "Aborting since the new ABI is not backward compatible.\n",
+            callname, (unsigned) HWLOC_API_VERSION, version);
     exit(EXIT_FAILURE);
   }
 }
@@ -51,35 +51,35 @@ hwloc_utils_input_format_usage(FILE *where, int addspaces)
 {
   fprintf (where, "  --input <XML file>\n");
   fprintf (where, "  -i <XML file>   %*sRead topology from XML file <path>\n",
-	   addspaces, " ");
+           addspaces, " ");
 #ifdef HWLOC_LINUX_SYS
   fprintf (where, "  --input <directory>\n");
   fprintf (where, "  -i <directory>  %*sRead topology from chroot containing the /proc and /sys\n",
-	   addspaces, " ");
+           addspaces, " ");
   fprintf (where, "                  %*sof another system\n",
-	   addspaces, " ");
+           addspaces, " ");
 #endif
 #ifdef HWLOC_HAVE_X86_CPUID
   fprintf (where, "  --input <directory>\n");
   fprintf (where, "  -i <directory>  %*sRead topology from directory containing a CPUID dump\n",
-	   addspaces, " ");
+           addspaces, " ");
 #endif
   fprintf (where, "  --input \"node:2 2\"\n");
   fprintf (where, "  -i \"node:2 2\"   %*sSimulate a fake hierarchy, here with 2 NUMA nodes of 2\n",
-	   addspaces, " ");
+           addspaces, " ");
   fprintf (where, "                  %*sprocessors\n",
-	   addspaces, " ");
+           addspaces, " ");
   fprintf (where, "  --input-format <format>\n");
   fprintf (where, "  --if <format>   %*sEnforce input format among "
-	   "xml, "
+           "xml, "
 #ifdef HWLOC_LINUX_SYS
-	   "fsroot, "
+           "fsroot, "
 #endif
 #ifdef HWLOC_HAVE_X86_CPUID
-	   "cpuid, "
+           "cpuid, "
 #endif
-	   "synthetic\n",
-	   addspaces, " ");
+           "synthetic\n",
+           addspaces, " ");
 }
 
 struct hwloc_utils_input_format_s {
@@ -121,11 +121,11 @@ hwloc_utils_parse_input_format(const char *name, const char *callname)
 
 static __hwloc_inline int
 hwloc_utils_lookup_input_option(char *argv[], int argc, int *consumed_opts,
-				char **inputp, struct hwloc_utils_input_format_s *input_formatp,
-				const char *callname)
+                                char **inputp, struct hwloc_utils_input_format_s *input_formatp,
+                                const char *callname)
 {
   if (!strcmp (argv[0], "--input")
-	       || !strcmp (argv[0], "-i")) {
+      || !strcmp (argv[0], "-i")) {
     if (argc <= 1) {
       usage (callname, stderr);
       exit(EXIT_FAILURE);
@@ -138,7 +138,7 @@ hwloc_utils_lookup_input_option(char *argv[], int argc, int *consumed_opts,
     return 1;
   }
   else if (!strcmp (argv[0], "--input-format")
-	   || !strcmp (argv[0], "--if")) {
+           || !strcmp (argv[0], "--if")) {
     if (argc <= 1) {
       usage (callname, stderr);
       exit(EXIT_FAILURE);
@@ -167,13 +167,13 @@ hwloc_utils_autodetect_input_format(const char *input, int verbose)
     size_t len = strlen(input);
     if (len >= 6 && !strcmp(input+len-6, ".shmem")) {
       if (verbose > 0)
-	printf("assuming `%s' is a shmem topology file\n", input);
+        printf("assuming `%s' is a shmem topology file\n", input);
       return HWLOC_UTILS_INPUT_SHMEM;
     }
     if ((len >= 7 && !strcmp(input+len-7, ".tar.gz"))
         || (len >= 8 && !strcmp(input+len-8, ".tar.bz2"))) {
       if (verbose > 0)
-	printf("assuming `%s' is an archive topology file\n", input);
+        printf("assuming `%s' is an archive topology file\n", input);
       return HWLOC_UTILS_INPUT_ARCHIVE;
     }
     if (verbose > 0)
@@ -187,17 +187,17 @@ hwloc_utils_autodetect_input_format(const char *input, int verbose)
     if (childpath) {
       snprintf(childpath, strlen(input) + 10, "%s/pu0", input);
       if (stat(childpath, &childst) == 0 && S_ISREG(childst.st_mode)) {
-	if (verbose > 0)
-	  printf("assuming `%s' is a cpuid dump\n", input);
-	free(childpath);
-	return HWLOC_UTILS_INPUT_CPUID;
+        if (verbose > 0)
+          printf("assuming `%s' is a cpuid dump\n", input);
+        free(childpath);
+        return HWLOC_UTILS_INPUT_CPUID;
       }
       snprintf(childpath, strlen(input) + 10, "%s/proc", input);
       if (stat(childpath, &childst) == 0 && S_ISDIR(childst.st_mode)) {
-	if (verbose > 0)
-	  printf("assuming `%s' is a file-system root\n", input);
-	free(childpath);
-	return HWLOC_UTILS_INPUT_FSROOT;
+        if (verbose > 0)
+          printf("assuming `%s' is a file-system root\n", input);
+        free(childpath);
+        return HWLOC_UTILS_INPUT_FSROOT;
       }
     }
     free(childpath);
@@ -208,9 +208,9 @@ hwloc_utils_autodetect_input_format(const char *input, int verbose)
 
 static __hwloc_inline int
 hwloc_utils_enable_input_format(struct hwloc_topology *topology, unsigned long flags,
-				const char *input,
-				struct hwloc_utils_input_format_s *input_formatp,
-				int verbose, const char *callname)
+                                const char *input,
+                                struct hwloc_utils_input_format_s *input_formatp,
+                                int verbose, const char *callname)
 {
   enum hwloc_utils_input_format *input_format = &input_formatp->format;
   if (*input_format == HWLOC_UTILS_INPUT_DEFAULT && !strcmp(input, "-.xml")) {
@@ -492,7 +492,7 @@ hwloc_pid_from_number(hwloc_pid_t *pidp, int pid_number, int set_info __hwloc_at
       DWORD error = GetLastError();
       char *message;
       FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-		    NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (char *)&message, 0, NULL);
+                    NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (char *)&message, 0, NULL);
       fprintf(stderr, "OpenProcess %d failed %lu: %s\n", pid_number, (unsigned long) error, message);
     }
     return -1;
@@ -529,8 +529,8 @@ hwloc_lstopo_show_summary_depth(FILE *output, size_t prefixmaxlen, hwloc_topolog
     }
 
     fprintf(output, "%*s%u %s (type #%d)\n",
-	    (int)(prefixmaxlen-prefixlen), "",
-	    nbobjs, types, (int) type);
+            (int)(prefixmaxlen-prefixlen), "",
+            nbobjs, types, (int) type);
   }
 }
 


### PR DESCRIPTION
Mostly code refactoring.

Unify the definition of options to increase code readability. Reorder the option checks to enforce topology options to be parsed first. Unmix using tabs and spaces (excepted for cases when the line is cut due to the function's arguments). Enforce using NULL character instead of simply `0`.