### PR TITLE
windows: Fix type of hostname_size parameter

### DIFF
--- a/hwloc/topology-windows.c
+++ b/hwloc/topology-windows.c
@@ -989,7 +989,11 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
   OSVERSIONINFOEX osvi;
   char versionstr[20];
   char hostname[122] = "";
-  unsigned hostname_size = sizeof(hostname);
+#if !defined(__CYGWIN__)
+  DWORD hostname_size = sizeof(hostname);
+#else
+  size_t hostname_size = sizeof(hostname);
+#endif
   int has_efficiencyclass = 0;
   struct hwloc_win_efficiency_classes eclasses;
   char *env = getenv("HWLOC_WINDOWS_PROCESSOR_GROUP_OBJS");

--- a/utils/lstopo/lstopo-draw.c
+++ b/utils/lstopo/lstopo-draw.c
@@ -1737,7 +1737,11 @@ output_draw(struct lstopo_output *loutput)
     unsigned maxtextwidth = 0, textwidth;
     unsigned ndl = 0;
     char hostname[122] = "";
-    unsigned long hostname_size = sizeof(hostname);
+#if defined(HWLOC_WIN_SYS) && !defined(__CYGWIN__)
+    DWORD hostname_size = sizeof(hostname);
+#else
+    size_t hostname_size = sizeof(hostname);
+#endif
     unsigned infocount = 0;
 
     /* prepare legend lines and compute the width */


### PR DESCRIPTION
Avoids warning: passing argument 2 of 'GetComputerNameA' from incompatible pointer type [-Wincompatible-pointer-types]