### PR TITLE
Fixes for 128bit pointers on the CHERI architecture

### DIFF
--- a/include/private/xml.h
+++ b/include/private/xml.h
@@ -24,8 +24,9 @@ typedef struct hwloc__xml_import_state_s {
 
   /* opaque data used to store backend-specific data.
    * statically allocated to allow stack-allocation by the common code without knowing actual backend needs.
+   * libxml is 3 ptrs. nolibxml is 3 ptr + one int.
    */
-  char data[32];
+  char data[4 * SIZEOF_VOID_P];
 } * hwloc__xml_import_state_t;
 
 HWLOC_DECLSPEC int hwloc__xml_import_diff(hwloc__xml_import_state_t state, hwloc_topology_diff_t *firstdiffp);
@@ -65,8 +66,9 @@ typedef struct hwloc__xml_export_state_s {
 
   /* opaque data used to store backend-specific data.
    * statically allocated to allow stack-allocation by the common code without knowing actual backend needs.
+   * libxml is 1 ptr. nolibxml is 1 ptr + 2 size_t + 3 ints.
    */
-  char data[40];
+  char data[6 * SIZEOF_VOID_P];
 } * hwloc__xml_export_state_t;
 
 HWLOC_DECLSPEC void hwloc__xml_export_topology(hwloc__xml_export_state_t parentstate, hwloc_topology_t topology, unsigned long flags);


### PR DESCRIPTION
This is mostly for fun, but there are two things that failed on a 128bit architecture (https://www.cl.cam.ac.uk/research/security/ctsrd/cheri/).
1. xml backend private data is stored in a opaque array to avoid propagating libxml stuff everywhere. this array wasn't big enough for 128bit pointers. fix it and make this is bit more portable (but still ugly).
2. the shmem header was only 64bit-aligned, hence the topology stored after it wasn't aligned either.

make check still fails on this architecture because of 'tag-write page fault' in the shmem. Basically we are supposed to share one process pointer with another process because addresses are tagged for security. There are workarounds (untag before writing to shmem and retag after adopting), but it would defeat the entire idea of shmem topology.