### PR TITLE
utils: cleanup and improve location "filters"

### DIFF
--- a/utils/hwloc/hwloc-annotate.c
+++ b/utils/hwloc/hwloc-annotate.c
@@ -172,7 +172,7 @@ get_unique_obj(hwloc_topology_t topology, int topodepth, char *str,
   int err;
 
   typelen = hwloc_calc_parse_level_size(str);
-  if (!typelen || (str[typelen] != ':' && str[typelen] != '=' && str[typelen] != '['))
+  if (!typelen || (str[typelen] != ':' && str[typelen] != '='))
     return NULL;
 
   lcontext.topology = topology;

--- a/utils/hwloc/hwloc-annotate.c
+++ b/utils/hwloc/hwloc-annotate.c
@@ -171,7 +171,7 @@ get_unique_obj(hwloc_topology_t topology, int topodepth, char *str,
   size_t typelen;
   int err;
 
-  typelen = strspn(str, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+  typelen = hwloc_calc_parse_level_size(str);
   if (!typelen || (str[typelen] != ':' && str[typelen] != '=' && str[typelen] != '['))
     return NULL;
 
@@ -809,7 +809,7 @@ int main(int argc, char *argv[])
 	      apply(topology, hwloc_get_root_obj(topology));
 	    } else {
 		size_t typelen;
-		typelen = strspn(location, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+		typelen = hwloc_calc_parse_level_size(location);
 		if (typelen && (location[typelen] == ':' || location[typelen] == '=' || location[typelen] == '[')) {
 			struct hwloc_calc_location_context_s lcontext;
 			lcontext.topology = topology;

--- a/utils/hwloc/hwloc-bind.1in
+++ b/utils/hwloc/hwloc-bind.1in
@@ -88,7 +88,7 @@ in account when looking for NUMA nodes in the input locations.
 
 This option must be combined with NUMA node locations,
 such as \fI--hbm numa:1\fR for binding on the second HBM node.
-It may also be written as \fIhbm:1\fR.
+It may also be written as \fInuma[hbm]:1\fR.
 .TP
 \fB\-\-no\-hbm\fR
 Ignore high bandwidth memory nodes (Intel Xeon Phi MCDRAM)
@@ -297,7 +297,7 @@ To bind on the memory node local to a PU with largest capacity:
 
 To bind memory on the first high-bandwidth memory node on Intel Xeon Phi:
 
-    $ hwloc-bind --membind hbm:0 -- echo hello
+    $ hwloc-bind --membind numa[mcdram]:0 -- echo hello
     $ hwloc-bind --hbm --membind numa:0 -- echo hello
 
 Note that binding the "echo" command to multiple processors is

--- a/utils/hwloc/hwloc-calc.1in
+++ b/utils/hwloc/hwloc-calc.1in
@@ -164,6 +164,9 @@ When combined with \fB\-\-nodeset\fR or \fB\-\-nodeset-output\fR,
 the nodeset is considered instead of the CPU set for finding matching objects.
 This is useful when reporting the output as a number or set of NUMA nodes.
 
+\fI<type\fR may contain a filter to select specific objects among
+the type. For instance \fB\-N "numa[mcdram]"\fR counts MCDRAM NUMA nodes on KNL.
+
 If an OS device subtype such as \fIgpu\fR  is given instead of \fIosdev\fR,
 only the os devices of that subtype will be counted.
 .TP
@@ -181,6 +184,9 @@ objects are strictly included inside the input objects.
 When combined with \fB\-\-nodeset\fR or \fB\-\-nodeset-output\fR,
 the nodeset is considered instead of the CPU set for finding matching objects.
 This is useful when reporting the output as a number or set of NUMA nodes.
+
+\fI<type\fR may contain a filter to select specific objects among
+the type. For instance \fB\-I "numa[mcdram]"\fR lists MCDRAM NUMA nodes on KNL.
 
 If an OS device subtype such as \fIgpu\fR is given instead of \fIosdev\fR,
 only the os devices of that subtype will be returned.
@@ -390,6 +396,16 @@ whose locality is exactly equal to a Package:
 
     $ hwloc-calc --local-memory-flags 0 --best-memattr capacity --physical-output pack:1
     4
+
+To find the number of NUMA nodes with subtype MCDRAM (on KNL):
+
+    $ hwloc-calc -N "numa[mcdram]" all
+    4
+
+To find the NUMA node of subtype MCDRAM (on KNL) near a PU:
+
+    $ hwloc-calc -I "numa[mcdram]" pu:157
+    1
 
 Converting object logical indexes (default) from/to physical/OS indexes
 may be performed with \fB--intersect\fR combined with either \fB--physical-output\fR

--- a/utils/hwloc/hwloc-calc.c
+++ b/utils/hwloc/hwloc-calc.c
@@ -72,12 +72,10 @@ static int logicalo = 1;
 static int nodeseti = 0;
 static int nodeseto = 0;
 static int objecto = 0;
-static int numberofdepth = -1;
-static union hwloc_obj_attr_u numberofattr;
-static int intersectdepth = -1;
-static union hwloc_obj_attr_u intersectattr;
-static int hiernblevels = 0;
-static int *hierdepth = NULL;
+static struct hwloc_calc_level numberof;
+static struct hwloc_calc_level intersect;
+static int hiernblevels;
+static struct hwloc_calc_level *hierlevels;
 static int local_numanodes = 0;
 static unsigned long local_numanode_flags = HWLOC_LOCAL_NUMANODE_FLAG_SMALLER_LOCALITY | HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY;
 static hwloc_memattr_id_t best_memattr_id = (hwloc_memattr_id_t) -1;
@@ -119,7 +117,7 @@ hwloc_calc_hierarch_output(hwloc_topology_t topology, const char *prefix, const 
   hwloc_obj_t obj, prev = NULL;
   unsigned logi = 0;
   int first = 1;
-  while ((obj = hwloc_get_next_obj_covering_cpuset_by_depth(topology, root->cpuset, hierdepth[level], prev)) != NULL) {
+  while ((obj = hwloc_get_next_obj_covering_cpuset_by_depth(topology, root->cpuset, hierlevels[level].depth, prev)) != NULL) {
     char string[256];
     char type[32];
     unsigned idx = logicalo ? logi : obj->os_index;
@@ -190,25 +188,25 @@ hwloc_calc_output(hwloc_topology_t topology, const char *sep, hwloc_bitmap_t set
     }
     printf("\n");
     hwloc_bitmap_free(remaining);
-  } else if (numberofdepth != -1) {
+  } else if (numberof.depth != -1) {
     unsigned nb = 0;
     hwloc_obj_t obj = NULL;
-    while ((obj = hwloc_calc_get_next_obj_covering_set_by_depth(topology, set, nodeseto, numberofdepth, obj)) != NULL) {
-      if (numberofdepth == HWLOC_TYPE_DEPTH_OS_DEVICE
-          && (obj->attr->osdev.type & numberofattr.osdev.type) != numberofattr.osdev.type)
+    while ((obj = hwloc_calc_get_next_obj_covering_set_by_depth(topology, set, nodeseto, numberof.depth, obj)) != NULL) {
+      if (numberof.depth == HWLOC_TYPE_DEPTH_OS_DEVICE
+          && (obj->attr->osdev.type & numberof.attr.osdev.type) != numberof.attr.osdev.type)
         continue;
       nb++;
     }
     printf("%u\n", nb);
-  } else if (intersectdepth != -1) {
+  } else if (intersect.depth != -1) {
     hwloc_obj_t obj = NULL;
     int first = 1;
     if (!sep)
       sep = ",";
-    while ((obj = hwloc_calc_get_next_obj_covering_set_by_depth(topology, set, nodeseto, intersectdepth, obj)) != NULL) {
+    while ((obj = hwloc_calc_get_next_obj_covering_set_by_depth(topology, set, nodeseto, intersect.depth, obj)) != NULL) {
       unsigned idx;
-      if (intersectdepth == HWLOC_TYPE_DEPTH_OS_DEVICE
-          && (obj->attr->osdev.type & intersectattr.osdev.type) != intersectattr.osdev.type)
+      if (intersect.depth == HWLOC_TYPE_DEPTH_OS_DEVICE
+          && (obj->attr->osdev.type & intersect.attr.osdev.type) != intersect.attr.osdev.type)
         continue;
       if (!first)
 	printf("%s", sep);
@@ -288,41 +286,6 @@ hwloc_calc_output(hwloc_topology_t topology, const char *sep, hwloc_bitmap_t set
   return EXIT_SUCCESS;
 }
 
-static int hwloc_calc_type_depth(hwloc_topology_t topology, const char *string, int *depthp, union hwloc_obj_attr_u *attrp, const char *caller)
-{
-  union hwloc_obj_attr_u attr;
-  hwloc_obj_type_t type;
-  int depth;
-  int err;
-
-  err = hwloc_type_sscanf(string, &type, &attr, sizeof(attr));
-  if (err < 0) {
-    char *endptr;
-    depth = strtoul(string, &endptr, 0);
-    if (*endptr) {
-      fprintf(stderr, "unrecognized %s type or depth %s\n", caller, string);
-      return -1;
-    }
-
-    *depthp = depth;
-    return 0;
-  }
-
-  depth = hwloc_get_type_depth_with_attr(topology, type, &attr, sizeof(attr));
-  if (depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
-    fprintf(stderr, "unavailable %s type %s\n", caller, hwloc_obj_type_string(type));
-    return -1;
-  } else  if (depth == HWLOC_TYPE_DEPTH_MULTIPLE) {
-    fprintf(stderr, "cannot use %s type %s with multiple depth, please use the relevant depth\n", caller, hwloc_obj_type_string(type));
-    return -1;
-  }
-
-  if (attrp)
-    memcpy(attrp, &attr, sizeof(attr));
-  *depthp = depth;
-  return 0;
-}
-
 int main(int argc, char *argv[])
 {
   hwloc_topology_t topology;
@@ -333,10 +296,10 @@ int main(int argc, char *argv[])
   int depth = 0;
   hwloc_bitmap_t set;
   int cmdline_args = 0;
-  const char * numberoftype = NULL;
-  const char * intersecttype = NULL;
+  const char * numberof_string = NULL;
+  const char * intersect_string = NULL;
   char *restrictstring = NULL;
-  char * hiertype = NULL;
+  char * hier_string = NULL;
   char * best_memattr_str = NULL;
   char *callname;
   char *outsep = NULL;
@@ -520,7 +483,7 @@ int main(int argc, char *argv[])
 	  usage(callname, stderr);
 	  return EXIT_FAILURE;
 	}
-	numberoftype = argv[1];
+	numberof_string = argv[1];
 	opt = 1;
 	goto next;
       }
@@ -529,7 +492,7 @@ int main(int argc, char *argv[])
 	  usage(callname, stderr);
 	  return EXIT_FAILURE;
 	}
-	intersecttype = argv[1];
+	intersect_string = argv[1];
 	opt = 1;
 	goto next;
       }
@@ -538,7 +501,7 @@ int main(int argc, char *argv[])
 	  usage(callname, stderr);
 	  return EXIT_FAILURE;
 	}
-	hiertype = argv[1];
+	hier_string = argv[1];
 	opt = 1;
 	goto next;
       }
@@ -663,16 +626,34 @@ int main(int argc, char *argv[])
     argv += opt+1;
   }
 
-  if (numberoftype && hwloc_calc_type_depth(topology, numberoftype, &numberofdepth, &numberofattr, "--number-of") < 0)
+  numberof.depth = HWLOC_TYPE_DEPTH_UNKNOWN; /* disable this feature by default */
+  if (numberof_string && hwloc_calc_parse_level(NULL, topology, numberof_string, strlen(numberof_string), &numberof) < 0) {
+    if (numberof.depth == HWLOC_TYPE_DEPTH_MULTIPLE)
+      fprintf(stderr, "cannot use --number-of type %s with multiple depth, please use the relevant depth\n",
+              numberof_string);
+    else if (numberof.depth == HWLOC_TYPE_DEPTH_UNKNOWN)
+      fprintf(stderr, "cannot use --number-of type %s, unavailable\n",
+              numberof_string);
     goto out;
+  }
 
-  if (intersecttype && hwloc_calc_type_depth(topology, intersecttype, &intersectdepth, &intersectattr, "--intersect") < 0)
+  intersect.depth = HWLOC_TYPE_DEPTH_UNKNOWN; /* disable this feature by default */
+  if (intersect_string && hwloc_calc_parse_level(NULL, topology, intersect_string, strlen(intersect_string), &intersect) < 0) {
+    if (intersect.depth == HWLOC_TYPE_DEPTH_MULTIPLE)
+      fprintf(stderr, "cannot use --intersect type %s with multiple depth, please use the relevant depth\n",
+              intersect_string);
+    else if (intersect.depth == HWLOC_TYPE_DEPTH_UNKNOWN)
+      fprintf(stderr, "cannot use --intersect type %s, unavailable\n",
+              intersect_string);
     goto out;
+  }
 
-  if (hiertype) {
+  hiernblevels = 0; /* disable this feature by default */
+  hierlevels = NULL;
+  if (hier_string) {
     char *tmp, *next;
     hiernblevels = 1;
-    tmp = hiertype;
+    tmp = hier_string;
     while (1) {
       tmp = strchr(tmp, '.');
       if (!tmp)
@@ -680,15 +661,22 @@ int main(int argc, char *argv[])
       tmp++;
       hiernblevels++;
     }
-    hierdepth = malloc(hiernblevels * sizeof(int));
-    tmp = hiertype;
+    hierlevels = malloc(hiernblevels * sizeof(struct hwloc_calc_level));
+    tmp = hier_string;
     for(i=0; i<hiernblevels; i++) {
       next = strchr(tmp, '.');
       if (next)
 	*next = '\0';
-      if (hwloc_calc_type_depth(topology, tmp, &hierdepth[i], NULL, "--hierarchical") < 0)
+      if (hwloc_calc_parse_level(NULL, topology, tmp, strlen(tmp), &hierlevels[i]) < 0) {
+        if (hierlevels[i].depth == HWLOC_TYPE_DEPTH_MULTIPLE)
+          fprintf(stderr, "cannot use --hierarchical %s with multiple depth, please use the relevant depth\n",
+                  tmp);
+        else if (hierlevels[i].depth == HWLOC_TYPE_DEPTH_UNKNOWN)
+          fprintf(stderr, "cannot use --hierarchical type %s, unavailable\n",
+                  tmp);
 	goto out;
-      if (hierdepth[i] < 0 && hierdepth[i] != HWLOC_TYPE_DEPTH_NUMANODE) {
+      }
+      if (hierlevels[i].depth < 0 && hierlevels[i].depth != HWLOC_TYPE_DEPTH_NUMANODE) {
 	fprintf(stderr, "unsupported (non-normal) --hierarchical type %s\n", tmp);
 	goto out;
       }
@@ -768,7 +756,7 @@ int main(int argc, char *argv[])
   hwloc_bitmap_free(set);
   hwloc_bitmap_free(cpukind_cpuset);
 
-  free(hierdepth);
+  free(hierlevels);
 
   return ret;
 }

--- a/utils/hwloc/hwloc-calc.c
+++ b/utils/hwloc/hwloc-calc.c
@@ -123,6 +123,8 @@ hwloc_calc_hierarch_output(hwloc_topology_t topology, const char *prefix, const 
     unsigned idx = logicalo ? logi : obj->os_index;
     if (!hwloc_bitmap_intersects(set, obj->cpuset))
      goto next;
+    if (hwloc_calc_check_object_filtered(obj, &hierlevels[level]))
+      goto next;
     hwloc_obj_type_snprintf(type, sizeof(type), obj, HWLOC_OBJ_SNPRINTF_FLAG_LONG_NAMES);
     if (idx == (unsigned)-1)
       snprintf(string, sizeof(string), "%s%s%s:-1", prefix, level ? "." : "", type);
@@ -192,8 +194,7 @@ hwloc_calc_output(hwloc_topology_t topology, const char *sep, hwloc_bitmap_t set
     unsigned nb = 0;
     hwloc_obj_t obj = NULL;
     while ((obj = hwloc_calc_get_next_obj_covering_set_by_depth(topology, set, nodeseto, numberof.depth, obj)) != NULL) {
-      if (numberof.depth == HWLOC_TYPE_DEPTH_OS_DEVICE
-          && (obj->attr->osdev.type & numberof.attr.osdev.type) != numberof.attr.osdev.type)
+      if (hwloc_calc_check_object_filtered(obj, &numberof))
         continue;
       nb++;
     }
@@ -205,8 +206,7 @@ hwloc_calc_output(hwloc_topology_t topology, const char *sep, hwloc_bitmap_t set
       sep = ",";
     while ((obj = hwloc_calc_get_next_obj_covering_set_by_depth(topology, set, nodeseto, intersect.depth, obj)) != NULL) {
       unsigned idx;
-      if (intersect.depth == HWLOC_TYPE_DEPTH_OS_DEVICE
-          && (obj->attr->osdev.type & intersect.attr.osdev.type) != intersect.attr.osdev.type)
+      if (hwloc_calc_check_object_filtered(obj, &intersect))
         continue;
       if (!first)
 	printf("%s", sep);

--- a/utils/hwloc/hwloc-calc.h
+++ b/utils/hwloc/hwloc-calc.h
@@ -25,7 +25,9 @@
 struct hwloc_calc_location_context_s {
   hwloc_topology_t topology;
   int topodepth;
-  int only_hbm; /* -1 for everything, 0 for only non-HBM, 1 for only HBM numa nodes */
+  int only_hbm; /* -1 for everything, 0 for only non-HBM, 1 for only HBM numa nodes
+		 * stored by caller, and passed to struct hwloc_calc_level for actual filtering
+		 */
   int logical;
   int verbose;
 };
@@ -35,6 +37,7 @@ struct hwloc_calc_level {
   int depth;
   hwloc_obj_type_t type;
   union hwloc_obj_attr_u attr;
+  int only_hbm; /* -1 for everything, 0 for only non-HBM, 1 for only HBM numa nodes */
 };
 
 typedef enum hwloc_calc_append_mode_e {
@@ -87,13 +90,13 @@ hwloc_calc_append_set(hwloc_bitmap_t set, hwloc_const_bitmap_t newset,
 static __hwloc_inline unsigned
 hwloc_calc_get_nbobjs_inside_sets_by_depth(struct hwloc_calc_location_context_s *lcontext,
 					   hwloc_const_bitmap_t cpuset, hwloc_const_bitmap_t nodeset,
-					   int depth)
+					   struct hwloc_calc_level *level)
 {
   hwloc_topology_t topology = lcontext->topology;
-  int only_hbm = lcontext->only_hbm;
+  int only_hbm = level->only_hbm;
   hwloc_obj_t obj = NULL;
   unsigned n = 0;
-  while ((obj = hwloc_get_next_obj_by_depth(topology, depth, obj)) != NULL) {
+  while ((obj = hwloc_get_next_obj_by_depth(topology, level->depth, obj)) != NULL) {
     if (!hwloc_bitmap_iszero(obj->cpuset) && !hwloc_bitmap_intersects(obj->cpuset, cpuset))
       continue;
     if (!hwloc_bitmap_iszero(obj->nodeset) && !hwloc_bitmap_intersects(obj->nodeset, nodeset))
@@ -115,14 +118,14 @@ hwloc_calc_get_nbobjs_inside_sets_by_depth(struct hwloc_calc_location_context_s 
 static __hwloc_inline hwloc_obj_t
 hwloc_calc_get_obj_inside_sets_by_depth(struct hwloc_calc_location_context_s *lcontext,
 					hwloc_const_bitmap_t cpuset, hwloc_const_bitmap_t nodeset,
-					int depth, unsigned ind)
+					struct hwloc_calc_level *level, unsigned ind)
 {
   hwloc_topology_t topology = lcontext->topology;
-  int only_hbm = lcontext->only_hbm;
+  int only_hbm = level->only_hbm;
   int logical = lcontext->logical;
   hwloc_obj_t obj = NULL;
   unsigned i = 0;
-  while ((obj = hwloc_get_next_obj_by_depth(topology, depth, obj)) != NULL) {
+  while ((obj = hwloc_get_next_obj_by_depth(topology, level->depth, obj)) != NULL) {
     if (!hwloc_bitmap_iszero(obj->cpuset) && !hwloc_bitmap_intersects(obj->cpuset, cpuset))
       continue;
     if (!hwloc_bitmap_iszero(obj->nodeset) && !hwloc_bitmap_intersects(obj->nodeset, nodeset))
@@ -158,6 +161,10 @@ hwloc_calc_parse_level(struct hwloc_calc_location_context_s *lcontext,
   char *endptr;
   int err;
 
+  level->only_hbm = -1;
+  if (lcontext)
+    level->only_hbm = lcontext->only_hbm;
+
   level->depth = HWLOC_TYPE_DEPTH_UNKNOWN;
 
   if (typelen >= sizeof(typestring))
@@ -175,8 +182,7 @@ hwloc_calc_parse_level(struct hwloc_calc_location_context_s *lcontext,
   }
 
   if (!strcasecmp(typestring, "HBM") || !strcasecmp(typestring, "MCDRAM")) {
-    if (lcontext && lcontext->only_hbm == -1)
-      lcontext->only_hbm = 1;
+    level->only_hbm = 1;
     level->type = HWLOC_OBJ_NUMANODE;
     level->depth = HWLOC_TYPE_DEPTH_NUMANODE;
     return 0;
@@ -292,7 +298,7 @@ hwloc_calc_parse_range(const char *_string,
 
 static __hwloc_inline int
 hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
-			       hwloc_const_bitmap_t rootcpuset, hwloc_const_bitmap_t rootnodeset, int depth,
+			       hwloc_const_bitmap_t rootcpuset, hwloc_const_bitmap_t rootnodeset, struct hwloc_calc_level *level,
 			       const char *string, /* starts with indexes following the colon */
 			       void (*cbfunc)(struct hwloc_calc_location_context_s *, void *, hwloc_obj_t), void *cbdata)
 {
@@ -301,7 +307,7 @@ hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
   hwloc_obj_t obj;
   unsigned width;
   const char *dot, *nextsep = NULL;
-  int nextdepth = -1;
+  struct hwloc_calc_level nextlevel;
   int first, wrap, amount, step;
   unsigned i,j;
   int found = 0;
@@ -321,7 +327,6 @@ hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
   if (dot) {
     /* parse the next string before calling ourself recursively */
     size_t typelen;
-    struct hwloc_calc_level level;
     const char *nextstring = dot+1;
     typelen = strspn(nextstring, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
     if (!typelen || nextstring[typelen] != ':') {
@@ -331,30 +336,29 @@ hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
     }
     nextsep = &nextstring[typelen];
 
-    err = hwloc_calc_parse_level(lcontext, topology, nextstring, typelen, &level);
+    err = hwloc_calc_parse_level(lcontext, topology, nextstring, typelen, &nextlevel);
     if (err < 0) {
-      if (level.depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
+      if (nextlevel.depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
         if (verbose >= 0)
           fprintf(stderr, "could not find level specified by location %s\n", nextstring);
         return -1;
       }
-      if (level.depth == HWLOC_TYPE_DEPTH_MULTIPLE) {
+      if (nextlevel.depth == HWLOC_TYPE_DEPTH_MULTIPLE) {
         if (verbose >= 0)
           fprintf(stderr, "found multiple levels for location %s\n", nextstring);
         return -1;
       }
     }
-    nextdepth = level.depth;
 
     /* we need an object with a cpuset, that's depth>=0 or memory */
-    if (nextdepth < 0 && nextdepth != HWLOC_TYPE_DEPTH_NUMANODE) {
+    if (nextlevel.depth < 0 && nextlevel.depth != HWLOC_TYPE_DEPTH_NUMANODE) {
       if (verbose >= 0)
 	fprintf(stderr, "hierarchical location %s only supported with normal object types\n", string);
       return -1;
     }
   }
 
-  width = hwloc_calc_get_nbobjs_inside_sets_by_depth(lcontext, rootcpuset, rootnodeset, depth);
+  width = hwloc_calc_get_nbobjs_inside_sets_by_depth(lcontext, rootcpuset, rootnodeset, level);
   if (amount == -1)
     amount = (width-first+step-1)/step;
 
@@ -362,24 +366,24 @@ hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
     if (wrap && i>=width)
       i = 0;
 
-    obj = hwloc_calc_get_obj_inside_sets_by_depth(lcontext, rootcpuset, rootnodeset, depth, i);
+    obj = hwloc_calc_get_obj_inside_sets_by_depth(lcontext, rootcpuset, rootnodeset, level, i);
     if (verbose > 0 || (!obj && verbose >= 0)) {
       char *sc, *sn;
       hwloc_bitmap_asprintf(&sc, rootcpuset);
       hwloc_bitmap_asprintf(&sn, rootnodeset);
       if (obj)
 	printf("using object #%u depth %d below cpuset %s nodeset %s\n",
-	       i, depth, sc, sn);
+	       i, level->depth, sc, sn);
       else
 	fprintf(stderr, "object #%u depth %d below cpuset %s nodeset %s does not exist\n",
-		i, depth, sc, sn);
+		i, level->depth, sc, sn);
       free(sc);
       free(sn);
     }
     if (obj) {
       found++;
       if (dot) {
-	hwloc_calc_append_object_range(lcontext, obj->cpuset, obj->nodeset, nextdepth, nextsep+1, cbfunc, cbdata);
+	hwloc_calc_append_object_range(lcontext, obj->cpuset, obj->nodeset, &nextlevel, nextsep+1, cbfunc, cbdata);
       } else {
 	/* add to the temporary cpuset
 	 * and let the caller add/clear/and/xor for the actual final cpuset depending on cmdline options
@@ -629,7 +633,7 @@ hwloc_calc_process_location(struct hwloc_calc_location_context_s *lcontext,
   return hwloc_calc_append_object_range(lcontext,
 					hwloc_topology_get_complete_cpuset(topology),
 					hwloc_topology_get_complete_nodeset(topology),
-					level.depth, sep+1, cbfunc, cbdata);
+					&level, sep+1, cbfunc, cbdata);
 }
 
 struct hwloc_calc_set_context_s {

--- a/utils/hwloc/hwloc-calc.h
+++ b/utils/hwloc/hwloc-calc.h
@@ -89,13 +89,43 @@ hwloc_calc_append_set(hwloc_bitmap_t set, hwloc_const_bitmap_t newset,
   return 0;
 }
 
+/* return 1 if obj is filtered out */
+static __hwloc_inline int
+hwloc_calc_check_object_filtered(hwloc_obj_t obj, struct hwloc_calc_level *level)
+{
+  if (level->subtype[0]) {
+    if (!obj->subtype || strcasecmp(level->subtype, obj->subtype))
+      return 1;
+  }
+
+  if (level->type == HWLOC_OBJ_NUMANODE) {
+    if (level->only_hbm >= 0) {
+      /* filter on hbm */
+      int obj_is_hbm = obj->subtype && !strcmp(obj->subtype, "MCDRAM");
+      if (level->only_hbm != obj_is_hbm)
+        return 1;
+    }
+
+  } else if (level->type == HWLOC_OBJ_PCI_DEVICE) {
+    if (level->pci_vendor != -1 && (int) obj->attr->pcidev.vendor_id != level->pci_vendor)
+      return 1;
+    if (level->pci_device != -1 && (int) obj->attr->pcidev.device_id != level->pci_device)
+      return 1;
+
+  } else if (level->type == HWLOC_OBJ_OS_DEVICE) {
+    if (level->attr.osdev.type != 0 && !(obj->attr->osdev.type & level->attr.osdev.type))
+      return 1;
+  }
+
+  return 0;
+}
+
 static __hwloc_inline unsigned
 hwloc_calc_get_nbobjs_inside_sets_by_depth(struct hwloc_calc_location_context_s *lcontext,
 					   hwloc_const_bitmap_t cpuset, hwloc_const_bitmap_t nodeset,
 					   struct hwloc_calc_level *level)
 {
   hwloc_topology_t topology = lcontext->topology;
-  int only_hbm = level->only_hbm;
   hwloc_obj_t obj = NULL;
   unsigned n = 0;
   while ((obj = hwloc_get_next_obj_by_depth(topology, level->depth, obj)) != NULL) {
@@ -106,16 +136,8 @@ hwloc_calc_get_nbobjs_inside_sets_by_depth(struct hwloc_calc_location_context_s 
     if (hwloc_bitmap_iszero(obj->cpuset) && hwloc_bitmap_iszero(obj->nodeset))
       /* ignore objects with empty sets (both can be empty when outside of cgroup) */
       continue;
-    if (only_hbm >= 0 && obj->type == HWLOC_OBJ_NUMANODE) {
-      /* filter on hbm */
-      int obj_is_hbm = obj->subtype && !strcmp(obj->subtype, "MCDRAM");
-      if (only_hbm != obj_is_hbm)
-	continue;
-    }
-    if (level->subtype[0]) {
-      if (!obj->subtype || strcasecmp(level->subtype, obj->subtype))
-        continue;
-    }
+    if (hwloc_calc_check_object_filtered(obj, level))
+      continue;
     n++;
   }
   return n;
@@ -127,7 +149,6 @@ hwloc_calc_get_obj_inside_sets_by_depth(struct hwloc_calc_location_context_s *lc
 					struct hwloc_calc_level *level, unsigned ind)
 {
   hwloc_topology_t topology = lcontext->topology;
-  int only_hbm = level->only_hbm;
   int logical = lcontext->logical;
   hwloc_obj_t obj = NULL;
   unsigned i = 0;
@@ -139,16 +160,8 @@ hwloc_calc_get_obj_inside_sets_by_depth(struct hwloc_calc_location_context_s *lc
     if (hwloc_bitmap_iszero(obj->cpuset) && hwloc_bitmap_iszero(obj->nodeset))
       /* ignore objects with empty sets (both can be empty when outside of cgroup) */
       continue;
-    if (only_hbm >= 0 && obj->type == HWLOC_OBJ_NUMANODE) {
-      /* filter on hbm */
-      int obj_is_hbm = obj->subtype && !strcmp(obj->subtype, "MCDRAM");
-      if (only_hbm != obj_is_hbm)
-	continue;
-    }
-    if (level->subtype[0]) {
-      if (!obj->subtype || strcasecmp(level->subtype, obj->subtype))
-        continue;
-    }
+    if (hwloc_calc_check_object_filtered(obj, level))
+      continue;
     if (logical) {
       if (i == ind)
 	return obj;
@@ -544,22 +557,8 @@ hwloc_calc_append_iodev_by_index(struct hwloc_calc_location_context_s *lcontext,
     if (obj == prev) /* already used that object, stop wrapping around */
       break;
 
-    if (level->type == HWLOC_OBJ_PCI_DEVICE) {
-      if (level->pci_vendor != -1 && (int) obj->attr->pcidev.vendor_id != level->pci_vendor)
-	continue;
-      if (level->pci_device != -1 && (int) obj->attr->pcidev.device_id != level->pci_device)
-	continue;
-    }
-
-    if (level->type == HWLOC_OBJ_OS_DEVICE) {
-      if ((obj->attr->osdev.type & level->attr.osdev.type) != level->attr.osdev.type)
-	continue;
-    }
-
-    if (level->subtype[0]) {
-      if (!obj->subtype || strcasecmp(level->subtype, obj->subtype))
-        continue;
-    }
+    if (hwloc_calc_check_object_filtered(obj, level))
+      continue;
 
     if (first--)
       continue;

--- a/utils/hwloc/hwloc-calc.h
+++ b/utils/hwloc/hwloc-calc.h
@@ -21,12 +21,20 @@
 #include <ctype.h>
 #include <assert.h>
 
+/* this is a global that doesn't change when walking hierarchy of locations, etc */
 struct hwloc_calc_location_context_s {
   hwloc_topology_t topology;
   int topodepth;
   int only_hbm; /* -1 for everything, 0 for only non-HBM, 1 for only HBM numa nodes */
   int logical;
   int verbose;
+};
+
+/* this a local that changes when going from one level to another in the hierarchy of locations, etc */
+struct hwloc_calc_level {
+  int depth;
+  hwloc_obj_type_t type;
+  union hwloc_obj_attr_u attr;
 };
 
 typedef enum hwloc_calc_append_mode_e {
@@ -138,6 +146,50 @@ hwloc_calc_get_obj_inside_sets_by_depth(struct hwloc_calc_location_context_s *lc
     }
   }
   return NULL;
+}
+
+static __hwloc_inline int
+hwloc_calc_parse_level(struct hwloc_calc_location_context_s *lcontext,
+                       hwloc_topology_t topology,
+                       const char *_typestring, size_t typelen,
+                       struct hwloc_calc_level *level)
+{
+  char typestring[20+1]; /* large enough to store all type names, even with a depth attribute */
+  char *endptr;
+  int err;
+
+  level->depth = HWLOC_TYPE_DEPTH_UNKNOWN;
+
+  if (typelen >= sizeof(typestring))
+    return -1;
+  snprintf(typestring, typelen+1, "%s", _typestring);
+
+  err = hwloc_type_sscanf(typestring, &level->type, &level->attr, sizeof(level->attr));
+  if (!err) {
+    /* parsed a correct type */
+    level->depth = hwloc_get_type_depth_with_attr(topology, level->type, &level->attr, sizeof(level->attr));
+    if (level->depth == HWLOC_TYPE_DEPTH_UNKNOWN
+        || level->depth == HWLOC_TYPE_DEPTH_MULTIPLE)
+      return -1;
+    return 0;
+  }
+
+  if (!strcasecmp(typestring, "HBM") || !strcasecmp(typestring, "MCDRAM")) {
+    if (lcontext && lcontext->only_hbm == -1)
+      lcontext->only_hbm = 1;
+    level->type = HWLOC_OBJ_NUMANODE;
+    level->depth = HWLOC_TYPE_DEPTH_NUMANODE;
+    return 0;
+  }
+
+  /* couldn't parse the type, try a depth value */
+  level->depth = strtoul(typestring, &endptr, 0);
+  if (typestring[0] == '-' || *endptr || level->depth >= hwloc_topology_get_depth(topology)) {
+    level->depth = HWLOC_TYPE_DEPTH_UNKNOWN;
+    return -1;
+  }
+  level->type = HWLOC_OBJ_TYPE_NONE;
+  return 0;
 }
 
 static __hwloc_inline int

--- a/utils/hwloc/hwloc-calc.h
+++ b/utils/hwloc/hwloc-calc.h
@@ -203,7 +203,7 @@ hwloc_calc_parse_level_filter(hwloc_topology_t topology __hwloc_attribute_unused
       return -1;
     }
 
-  } else if (level->type != HWLOC_OBJ_OS_DEVICE) {
+  } else {
     fprintf(stderr, "invalid filter specification %s\n", filter);
     return -1;
   }
@@ -241,11 +241,14 @@ hwloc_calc_parse_level(struct hwloc_calc_location_context_s *lcontext,
         || level->depth == HWLOC_TYPE_DEPTH_MULTIPLE)
       return -1;
 
-    bracket = strchr(typestring, '[');
-    if (bracket) {
-      err = hwloc_calc_parse_level_filter(topology, bracket+1, level);
-      if (err < 0)
-        return -1;
+    if (level->type != HWLOC_OBJ_OS_DEVICE || hwloc_strncasecmp(typestring, "os", 2) || !level->attr.osdev.type) {
+      /* don't use filters for OSdev if it was already parsed as "OS*[osdev.type]" */
+      bracket = strchr(typestring, '[');
+      if (bracket) {
+        err = hwloc_calc_parse_level_filter(topology, bracket+1, level);
+        if (err < 0)
+          return -1;
+      }
     }
     return 0;
   }

--- a/utils/hwloc/hwloc-calc.h
+++ b/utils/hwloc/hwloc-calc.h
@@ -151,6 +151,18 @@ hwloc_calc_get_obj_inside_sets_by_depth(struct hwloc_calc_location_context_s *lc
   return NULL;
 }
 
+/* return the length of the type/depth prefix
+ * 0 if not found or invalid.
+ */
+static __hwloc_inline size_t
+hwloc_calc_parse_level_size(const char *string)
+{
+  /* type/depth prefix ends with either '.' (for child), "=" (for name of osdev),
+   * ':' (for index).
+   */
+  return strcspn(string, ":=.");
+}
+
 static __hwloc_inline int
 hwloc_calc_parse_level(struct hwloc_calc_location_context_s *lcontext,
                        hwloc_topology_t topology,
@@ -328,7 +340,7 @@ hwloc_calc_append_object_range(struct hwloc_calc_location_context_s *lcontext,
     /* parse the next string before calling ourself recursively */
     size_t typelen;
     const char *nextstring = dot+1;
-    typelen = strspn(nextstring, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+    typelen = hwloc_calc_parse_level_size(nextstring);
     if (!typelen || nextstring[typelen] != ':') {
       if (verbose >= 0)
 	fprintf(stderr, "hierarchical sublocation %s contains types not followed by colon and index range\n", nextstring);
@@ -592,6 +604,14 @@ hwloc_calc_process_location(struct hwloc_calc_location_context_s *lcontext,
     hwloc_obj_t obj = NULL;
 
     if (*sep == ':' || *sep == '[') {
+      if (level.type == HWLOC_OBJ_PCI_DEVICE) {
+        /* FIXME: temporary hack because typelen includes pci and osdev filters
+         * but only osdev types are handled in hwloc_calc_parse_level()
+         */
+        const char *bracket = strchr(arg, '[');
+        if (bracket && bracket-sep < 0)
+          sep = bracket;
+      }
       return hwloc_calc_append_iodev_by_index(lcontext, level.type, level.depth, sep, cbfunc, cbdata);
 
     } else if (*sep == '=' && level.type == HWLOC_OBJ_PCI_DEVICE) {
@@ -696,7 +716,7 @@ hwloc_calc_process_location_as_set(struct hwloc_calc_location_context_s *lcontex
 				 mode, verbose);
 
   /* try to match a type/depth followed by a special character */
-  typelen = strspn(arg, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+  typelen = hwloc_calc_parse_level_size(arg);
   if (typelen && (arg[typelen] == ':' || arg[typelen] == '=' || arg[typelen] == '[')) {
     /* process type/depth */
     struct hwloc_calc_process_location_set_cbdata_s cbdata;

--- a/utils/hwloc/hwloc-info.1in
+++ b/utils/hwloc/hwloc-info.1in
@@ -295,6 +295,12 @@ To display information about the core whose physical index is 2:
      os index = 2
     ...
 
+To list the OS devices that are of subtype OpenCL:
+
+    $ hwloc-info -s "os[OpenCL]:all"
+    OSDev[Co-Processor,GPU]:6
+    OSDev[Co-Processor,GPU]:8
+
 To list the NUMA nodes that are local a PU:
 
     $ hwloc-info --local-memory pu:25

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -530,10 +530,14 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
   } else if (show_descendants_depth != HWLOC_TYPE_DEPTH_UNKNOWN) {
     if (show_descendants_depth >= 0) {
       /* normal level */
-      unsigned i = 0;
-      unsigned n = hwloc_calc_get_nbobjs_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, show_descendants_depth);
+      struct hwloc_calc_level level;
+      unsigned i = 0, n;
+      level.type = HWLOC_OBJ_TYPE_NONE;
+      level.depth = show_descendants_depth;
+      level.only_hbm = -1;
+      n = hwloc_calc_get_nbobjs_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, &level);
       for(i=0; i<n; i++) {
-	hwloc_obj_t child = hwloc_calc_get_obj_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, show_descendants_depth, i);
+	hwloc_obj_t child = hwloc_calc_get_obj_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, &level, i);
 	if (show_index_prefix)
 	  snprintf(prefix, sizeof(prefix), "%u.%u: ", current_obj, i);
         hwloc_info_show_descendant(topology, child, obj, objs, i, prefix, verbose);

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -1051,7 +1051,7 @@ main (int argc, char *argv[])
         return EXIT_FAILURE;
       } else {
 	/* try to match a type/depth followed by a special character */
-	typelen = strspn(argv[0], "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+	typelen = hwloc_calc_parse_level_size(argv[0]);
 	if (typelen && (argv[0][typelen] == ':' || argv[0][typelen] == '=' || argv[0][typelen] == '[')) {
 	  err = hwloc_calc_process_location(&lcontext, argv[0], typelen,
 					    hwloc_calc_process_location_info_cb, NULL);

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -535,6 +535,7 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
       level.type = HWLOC_OBJ_TYPE_NONE;
       level.depth = show_descendants_depth;
       level.only_hbm = -1;
+      level.pci_vendor = level.pci_device = -1;
       n = hwloc_calc_get_nbobjs_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, &level);
       for(i=0; i<n; i++) {
 	hwloc_obj_t child = hwloc_calc_get_obj_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, &level, i);
@@ -1052,7 +1053,7 @@ main (int argc, char *argv[])
       } else {
 	/* try to match a type/depth followed by a special character */
 	typelen = hwloc_calc_parse_level_size(argv[0]);
-	if (typelen && (argv[0][typelen] == ':' || argv[0][typelen] == '=' || argv[0][typelen] == '[')) {
+	if (typelen && (argv[0][typelen] == ':' || argv[0][typelen] == '=')) {
 	  err = hwloc_calc_process_location(&lcontext, argv[0], typelen,
 					    hwloc_calc_process_location_info_cb, NULL);
 	}

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -535,6 +535,7 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
       level.type = HWLOC_OBJ_TYPE_NONE;
       level.depth = show_descendants_depth;
       level.only_hbm = -1;
+      level.subtype[0] = '\0';
       level.pci_vendor = level.pci_device = -1;
       n = hwloc_calc_get_nbobjs_inside_sets_by_depth(lcontext, obj->cpuset, obj->nodeset, &level);
       for(i=0; i<n; i++) {

--- a/utils/hwloc/hwloc.7in
+++ b/utils/hwloc/hwloc.7in
@@ -1,5 +1,5 @@
 .\" -*- nroff -*-
-.\" Copyright © 2010-2020 Inria.  All rights reserved.
+.\" Copyright © 2010-2023 Inria.  All rights reserved.
 .\" Copyright © 2010 Université of Bordeaux
 .\" Copyright © 2009-2010 Cisco Systems, Inc.  All rights reserved.
 .\" See COPYING in top-level directory.
@@ -86,6 +86,16 @@ hwloc objects represent types of mapped items (e.g., packages, cores,
 etc.) in a topology tree; indexes are non-negative integers that
 specify a unique physical object in a topology tree.  Both concepts
 are described in detail, below.
+.br
+
+.br
+Some filters may be added after the type to further specify which
+objects are wanted.
+\fI<type>[subtype=<subtype>]\fR selects objects matching the given
+type and also its subtype string attribute.
+For instance \fINUMA[MCDRAM]\fR selects NUMA nodes of subtype MCDRAM on KNL.
+The prefix \fIsubtype=\fR may be avoided if there is no ambiguity.
+\fIOS[Net]\fR also selects OS devices whose OS-device-specific type is Network.
 .br
 
 .br

--- a/utils/hwloc/hwloc.7in
+++ b/utils/hwloc/hwloc.7in
@@ -211,7 +211,7 @@ A set of processors and memory.
 A NUMA node; a set of processors around memory which the processors
 can directly access.
 .
-If \fBhbm\fR is used instead of \fBnumanode\fR in locations,
+If \fBnuma[hbm]\fR is used instead of \fBnumanode\fR in locations,
 command-line tools only consider high-bandwidth memory nodes such as Intel Xeon Phi MCDRAM.
 .
 .TP

--- a/utils/hwloc/test-hwloc-calc.output
+++ b/utils/hwloc/test-hwloc-calc.output
@@ -76,6 +76,15 @@ Group0:1.Group2:2 Group0:1.Group2:3
 # Number of objects at depth 3 in a NUMA Node
 16
 
+# Number of MCDRAM subtype NUMA Nodes
+4
+
+# List of MCDRAM subtype NUMA Nodes near 2 L3
+3,5
+
+# Hierarchical list of MCDRAM subtype NUMA nodes within Package
+Package:0.NUMANode:1 Package:0.NUMANode:7
+
 # List of Machine objects
 0
 

--- a/utils/hwloc/test-hwloc-calc.sh.in
+++ b/utils/hwloc/test-hwloc-calc.sh.in
@@ -120,6 +120,15 @@ set -e
   echo "# Number of objects at depth 3 in a NUMA Node"
   $calc --if synthetic --input "node:4 core:4 pu:4" node:2 -N 3
   echo
+  echo "# Number of MCDRAM subtype NUMA Nodes"
+  $calc --if xml --input $xmldir/64intel64-fakeKNL-SNC4-hybrid.xml -N 'numa[mcdram]' all
+  echo
+  echo "# List of MCDRAM subtype NUMA Nodes near 2 L3"
+  $calc --if xml --input $xmldir/64intel64-fakeKNL-SNC4-hybrid.xml -I 'numa[mcdram]' l3:1-2
+  echo
+  echo "# Hierarchical list of MCDRAM subtype NUMA nodes within Package"
+  $calc --if xml --input $xmldir/64intel64-fakeKNL-SNC4-hybrid.xml -H 'pack.numa[mcdram]' 'numa[mcdram]:0' 'numa[mcdram]:3'
+  echo
 
   echo "# List of Machine objects"
   $calc --if synthetic --input "node:4 core:4 pu:4" root --intersect Machine

--- a/utils/hwloc/test-hwloc-info.output
+++ b/utils/hwloc/test-hwloc-info.output
@@ -504,6 +504,22 @@ NUMANode:10
 NUMANode:11
 
 
+# MCDRAM subtype NUMA filter
+NUMANode:3
+NUMANode:5
+
+# NVML subtype OSdev type filter
+OSDev[Co-Processor,GPU]:2
+OSDev[Co-Processor,GPU]:5
+OSDev[Co-Processor,GPU]:8
+OSDev[Co-Processor,GPU]:11
+
+# GPU OSdev type filter
+OSDev[Co-Processor,GPU]:3
+OSDev[Co-Processor,GPU]:4
+OSDev[Co-Processor,GPU]:5
+
+
 # cpukinds for the entire machine
 Machine L#0
  type = Machine

--- a/utils/hwloc/test-hwloc-info.sh.in
+++ b/utils/hwloc/test-hwloc-info.sh.in
@@ -15,6 +15,7 @@ srcdir="$HWLOC_top_srcdir/utils/hwloc"
 builddir="$HWLOC_top_builddir/utils/hwloc"
 info="$builddir/hwloc-info"
 linuxdir="$HWLOC_top_srcdir/tests/hwloc/linux"
+xmldir="$HWLOC_top_srcdir/tests/hwloc/xml"
 
 HWLOC_PLUGINS_PATH=${HWLOC_top_builddir}/hwloc/.libs
 export HWLOC_PLUGINS_PATH
@@ -117,6 +118,17 @@ set -e
   echo
   echo "# only the highest capacity among 2 local-or-larger memories for one PU, silent"
   $info --if synthetic --input "pack:4 [numa(memory=1000000)] l3:2 [numa(memory=1000)] core:4 pu:2" --local-memory-flags larger --best-memattr capacity -s pu:63
+  echo
+
+  echo
+  echo "# MCDRAM subtype NUMA filter"
+  $info --if xml --input $xmldir/64intel64-fakeKNL-SNC4-hybrid.xml -s 'numa[mcdram]:1-2'
+  echo
+  echo "# NVML subtype OSdev type filter"
+  $info --if xml --input $xmldir/power8gpudistances.xml -s 'os[nvml]:all'
+  echo
+  echo "# GPU OSdev type filter"
+  $info --if xml --input $xmldir/power8gpudistances.xml -s 'os[gpu]:3-5'
   echo
 
   echo

--- a/utils/lstopo/lstopo-no-graphics.1in
+++ b/utils/lstopo/lstopo-no-graphics.1in
@@ -163,6 +163,9 @@ otherwise it will imply \fB\-\-cpuset\fR.
 .TP
 \fB\-\-only\fR <type>
 Only show objects of the given type in the textual output.
+
+\fI<type>\fR may contain a filter to select specific objects among
+the type. For instance \fB\-\-only "numa[mcdram]"\fR only shows MCDRAM NUMA nodes on KNL.
 .TP
 \fB\-\-filter\fR <type>:<kind>, \fB\-\-filter\fR <type>
 Filter objects of type <type>, or of any type if <type> is "all".

--- a/utils/lstopo/lstopo-text.c
+++ b/utils/lstopo/lstopo-text.c
@@ -192,25 +192,28 @@ output_only (struct lstopo_output *loutput, hwloc_obj_t l)
 {
   FILE *output = loutput->file;
   hwloc_obj_t child;
-  if (loutput->show_only == l->type) {
-    output_console_obj (loutput, l, 0);
-    fprintf (output, "\n");
+  if (loutput->show_only.type == l->type
+      || loutput->show_only.depth == l->depth) {
+    if (!hwloc_calc_check_object_filtered(l, &loutput->show_only)) {
+      output_console_obj (loutput, l, 0);
+      fprintf (output, "\n");
+    }
   }
   /* there can be anything below normal children */
   for_each_child(child, l)
     output_only (loutput, child);
   /* there can be only memory or Misc below memory children */
-  if (hwloc_obj_type_is_memory(loutput->show_only) || loutput->show_only == HWLOC_OBJ_MISC) {
+  if (loutput->show_only.type == HWLOC_OBJ_TYPE_NONE || hwloc_obj_type_is_memory(loutput->show_only.type) || loutput->show_only.type == HWLOC_OBJ_MISC) {
     for(child = l->memory_first_child; child; child = child->next_sibling)
       output_only (loutput, child);
   }
   /* there can be only I/O or Misc below I/O children */
-  if (hwloc_obj_type_is_io(loutput->show_only) || loutput->show_only == HWLOC_OBJ_MISC) {
+  if (loutput->show_only.type == HWLOC_OBJ_TYPE_NONE || hwloc_obj_type_is_io(loutput->show_only.type) || loutput->show_only.type == HWLOC_OBJ_MISC) {
     for_each_io_child(child, l)
       output_only (loutput, child);
   }
   /* there can be only Misc below Misc children */
-  if (loutput->show_only == HWLOC_OBJ_MISC) {
+  if (loutput->show_only.type == HWLOC_OBJ_TYPE_NONE || loutput->show_only.type == HWLOC_OBJ_MISC) {
     /* Misc can only contain other Misc, no need to recurse otherwise */
     for_each_misc_child(child, l)
       output_only (loutput, child);
@@ -505,27 +508,31 @@ output_console(struct lstopo_output *loutput, const char *filename)
    * if verbose_mode > 1, print both.
    */
 
-  if (loutput->show_only != HWLOC_OBJ_TYPE_NONE) {
-    if (verbose_mode > 1)
-      fprintf(output, "Only showing %s objects\n", hwloc_obj_type_string(loutput->show_only));
+  if (loutput->show_only.depth != HWLOC_TYPE_DEPTH_UNKNOWN) {
+    if (verbose_mode > 1) {
+      if (loutput->show_only.type != HWLOC_OBJ_TYPE_NONE)
+        fprintf(output, "Only showing some %s objects\n", hwloc_obj_type_string(loutput->show_only.type));
+      else
+        fprintf(output, "Only showing some objects at depth %d\n", loutput->show_only.depth);
+    }
     output_only (loutput, hwloc_get_root_obj(topology));
   } else if (verbose_mode >= 1) {
     output_topology (loutput, hwloc_get_root_obj(topology), NULL, 0);
     fprintf(output, "\n");
   }
 
-  if ((verbose_mode > 1 || !verbose_mode) && loutput->show_only == HWLOC_OBJ_TYPE_NONE) {
+  if ((verbose_mode > 1 || !verbose_mode) && loutput->show_only.depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
     hwloc_lstopo_show_summary(output, topology);
   }
 
-  if (verbose_mode > 1 && loutput->show_only == HWLOC_OBJ_TYPE_NONE) {
+  if (verbose_mode > 1 && loutput->show_only.depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
     output_distances(loutput);
     output_memattrs(loutput);
     output_cpukinds(loutput);
     output_windows_processor_groups(loutput, verbose_mode > 2);
   }
 
-  if (verbose_mode > 1 && loutput->show_only == HWLOC_OBJ_TYPE_NONE) {
+  if (verbose_mode > 1 && loutput->show_only.depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
     hwloc_const_bitmap_t complete = hwloc_topology_get_complete_cpuset(topology);
     hwloc_const_bitmap_t topo = hwloc_topology_get_topology_cpuset(topology);
     hwloc_const_bitmap_t allowed = hwloc_topology_get_allowed_cpuset(topology);

--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -13,6 +13,7 @@
 #include "private/autogen/config.h"
 #include "hwloc.h"
 #include "misc.h"
+#include "hwloc-calc.h"
 
 enum lstopo_drawing_e {
   LSTOPO_DRAWING_PREPARE,
@@ -100,7 +101,7 @@ struct lstopo_output {
   int show_memattrs_only;
   int show_cpukinds_only;
   int show_windows_processor_groups_only;
-  hwloc_obj_type_t show_only;
+  struct hwloc_calc_level show_only;
   int show_cpuset;
   int show_taskset;
   int transform_distances;


### PR DESCRIPTION
Generalize the existing OSDev[net] and PCI[vendor:device] with type[subtype]. This will notably be useful for selection different kinds of memory, e.g. NUMA[HBM].

This now works for locations given to tools (hwloc-bind/info/calc/annotate input objects) as well as options (hwloc-calc -N -I -H, lstopo --only, etc).

This replaces a lot of the old custom logic with a new "struct hwloc_calc_level" that describes a level (type, depth, attribute, subtype, etc) that may be used to filter input/output objects.