### PR TITLE
"KiB" suffix in Size info attr values

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -72,6 +72,8 @@ Version 3.0.0
   + hwloc_topology_allow() is now possible on shmem-adopted topology.
     This allows to share a topology between processes in different
     Linux cgroups, etc.
+  + Size info attribute values that were in KiB are now explicitly
+    suffixed by "KiB".
   + XML format switches to 3.0 by default. Exporting to 2.x is
     possible with the new V2 XML export flag.
 

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -2094,8 +2094,9 @@ These info attributes are attached to OS device objects specified in parentheses
 
 <dl>
 <dt>Vendor, Model, Revision, Size, SectorSize (Storage OS devices)</dt>
-<dd>The vendor and model names, revision, size (in KiB = 1024 bytes)
-and SectorSize (in bytes).
+<dd>The vendor and model names, revision,
+ size (in kibibytes = 1024 bytes, and the value string is suffixed with "KiB")
+ and SectorSize (in bytes).
 </dd>
 <dt>LinuxDeviceID (Storage OS devices)</dt>
 <dd>The major/minor device number such as 8:0 of Linux device.
@@ -2106,7 +2107,7 @@ and SectorSize (in bytes).
 <dt>CXLRAMSize, CXLPMEMSize (CXL Memory OS devices)</dt>
 <dd>The size of the volatile (RAM) or persistent (PMEM) memory
  in a CXL Type-3 device.
- Sizes are in KiB (1024 bytes).
+ Sizes are in kibibytes (1024 bytes), and value strings are suffixed with "KiB".
 </dd>
 <dt>GPUVendor, GPUModel (GPU and/or Co-Processor OS devices)</dt>
 <dd>The vendor and model names of the GPU device.
@@ -2119,7 +2120,7 @@ and SectorSize (in bytes).
 </dd>
 <dt>OpenCLComputeUnits, OpenCLGlobalMemorySize (OpenCL OS devices)</dt>
 <dd>The number of compute units and global memory size of an OpenCL device.
- Sizes are in KiB (1024 bytes).
+ Sizes are in kibibytes (1024 bytes), and value strings are suffixed with "KiB".
 </dd>
 <dt>LevelZeroVendor, LevelZeroModel, LevelZeroBrand,</dt>
 <dt>LevelZeroSerialNumber, LevelZeroBoardNumber (LevelZero OS devices)</dt>
@@ -2150,7 +2151,7 @@ and SectorSize (in bytes).
 </dd>
 <dt>LevelZeroHBMSize, LevelZeroDDRSize, LevelZeroMemorySize (LevelZero OS devices or subdevices)</dt>
 <dd>The amount of HBM or DDR memory of a LevelZero device or subdevice.
- Sizes are in KiB (1024 bytes).
+ Sizes are in kibibytes (1024 bytes), and value strings are suffixed with "KiB".
  If the type of memory could not be determined, the generic name LevelZeroMemorySize is used.
  For devices that contain subdevices, the amount reported in the root device
  includes the memories of all its subdevices.
@@ -2169,7 +2170,7 @@ and SectorSize (in bytes).
  The amount of GPU memory (VRAM),
  of GPU memory that is visible from the host (Visible VRAM),
  and of system memory that is usable by the GPU (Graphics Translation Table).
- Sizes are in KiB (1024 bytes).
+ Sizes are in kibibytes (1024 bytes), and value strings are suffixed with "KiB".
 </dd>
 <dt>XGMIHiveID (RSMI GPU OS devices)</dt>
 <dd>The ID of the group of GPUs (Hive) interconnected by XGMI links
@@ -2189,7 +2190,7 @@ and SectorSize (in bytes).
  The number of shared multiprocessors, the number of cores per
  multiprocessor, the global memory size, the (global) L2 cache size,
  and size of the shared memory in each multiprocessor of a CUDA device.
- Sizes are in KiB (1024 bytes).
+ Sizes are in kibibytes (1024 bytes), and value strings are suffixed with "KiB".
 </dd>
 <dt>VectorEngineModel, VectorEngineSerialNumber (VectorEngine OS devices)</dt>
 <dd>
@@ -2200,7 +2201,7 @@ and SectorSize (in bytes).
 <dd>
  The number of cores, memory size, and the sizes of the (global)
  last level cache and of L2, L1d and L1i caches of a VectorEngine device.
- Sizes are in KiB (1024 bytes).
+ Sizes are in kibibytes (1024 bytes), and value strings are suffixed with "KiB".
 </dd>
 <dt>VectorEngineNUMAPartitioned (VectorEngine OS devices)</dt>
 <dd>
@@ -2280,8 +2281,8 @@ The Solaris kstat processor group name that was used to build this Group object.
 </dd>
 <dt>Vendor, AssetTag, PartNumber, DeviceLocation, BankLocation, FormFactor, Type, Size, Rank (MemoryModule Misc objects)</dt>
 <dd>
-Information about memory modules (DIMMs) extracted from SMBIOS.
-Size is in KiB.
+ Information about memory modules (DIMMs) extracted from SMBIOS.
+ Size is in kibibytes (1024 bytes), and the value string is suffixed with "KiB".
 </dd>
 </dl>
 

--- a/hwloc/topology-cuda.c
+++ b/hwloc/topology-cuda.c
@@ -112,10 +112,10 @@ hwloc_cuda_discover(struct hwloc_backend *backend, struct hwloc_disc_status *dst
     if (!cures && prop.name[0] != '\0')
       hwloc_obj_add_info(cuda_device, "GPUModel", prop.name);
 
-    snprintf(number, sizeof(number), "%llu", ((unsigned long long) prop.totalGlobalMem) >> 10);
+    snprintf(number, sizeof(number), "%lluKiB", ((unsigned long long) prop.totalGlobalMem) >> 10);
     hwloc_obj_add_info(cuda_device, "CUDAGlobalMemorySize", number);
 
-    snprintf(number, sizeof(number), "%llu", ((unsigned long long) prop.l2CacheSize) >> 10);
+    snprintf(number, sizeof(number), "%lluKiB", ((unsigned long long) prop.l2CacheSize) >> 10);
     hwloc_obj_add_info(cuda_device, "CUDAL2CacheSize", number);
 
     snprintf(number, sizeof(number), "%d", prop.multiProcessorCount);
@@ -127,7 +127,7 @@ hwloc_cuda_discover(struct hwloc_backend *backend, struct hwloc_disc_status *dst
       hwloc_obj_add_info(cuda_device, "CUDACoresPerMP", number);
     }
 
-    snprintf(number, sizeof(number), "%llu", ((unsigned long long) prop.sharedMemPerBlock) >> 10);
+    snprintf(number, sizeof(number), "%lluKiB", ((unsigned long long) prop.sharedMemPerBlock) >> 10);
     hwloc_obj_add_info(cuda_device, "CUDASharedMemorySizePerMP", number);
 
     parent = NULL;

--- a/hwloc/topology-levelzero.c
+++ b/hwloc/topology-levelzero.c
@@ -265,7 +265,7 @@ hwloc__levelzero_memory_get_from_sysman(zes_device_handle_t h,
           if (osdev != root_osdev) {
             /* set the subdevice memory immediately */
             snprintf(name, sizeof(name), "LevelZero%sSize", type);
-            snprintf(value, sizeof(value), "%llu", (unsigned long long) mprop.physicalSize >> 10);
+            snprintf(value, sizeof(value), "%lluKiB", (unsigned long long) mprop.physicalSize >> 10);
             hwloc_obj_add_info(osdev, name, value);
           }
         }
@@ -277,12 +277,12 @@ hwloc__levelzero_memory_get_from_sysman(zes_device_handle_t h,
   /* set the root device memory at the end, once subdevice memories were agregated */
   if (totalHBMkB) {
     char value[64];
-    snprintf(value, sizeof(value), "%llu", totalHBMkB);
+    snprintf(value, sizeof(value), "%lluKiB", totalHBMkB);
     hwloc_obj_add_info(root_osdev, "LevelZeroHBMSize", value);
   }
   if (totalDDRkB) {
     char value[64];
-    snprintf(value, sizeof(value), "%llu", totalDDRkB);
+    snprintf(value, sizeof(value), "%lluKiB", totalDDRkB);
     hwloc_obj_add_info(root_osdev, "LevelZeroDDRSize", value);
   }
 
@@ -325,7 +325,7 @@ hwloc__levelzero_memory_get_from_coreapi(ze_device_handle_t h,
         if (!_name[0])
           _name = "Memory";
         snprintf(name, sizeof(name), "LevelZero%sSize", _name); /* HBM or DDR, or Memory if unknown */
-        snprintf(value, sizeof(value), "%llu", (unsigned long long) mh[m].totalSize >> 10);
+        snprintf(value, sizeof(value), "%lluKiB", (unsigned long long) mh[m].totalSize >> 10);
         hwloc_obj_add_info(osdev, name, value);
       }
     }

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -6255,7 +6255,7 @@ hwloc_linuxfs_block_class_fillinfos(struct hwloc_backend *backend __hwloc_attrib
   if (hwloc_read_path_by_length(path, line, sizeof(line), root_fd) > 0) {
     unsigned long long value = strtoull(line, NULL, 10);
     /* linux always reports size in 512-byte units for blocks, we want kB */
-    snprintf(line, sizeof(line), "%llu", value / 2);
+    snprintf(line, sizeof(line), "%lluKiB", value / 2);
     hwloc_obj_add_info(obj, "Size", line);
   }
 
@@ -6465,7 +6465,7 @@ hwloc_linuxfs_dax_class_fillinfos(struct hwloc_backend *backend __hwloc_attribut
   if (hwloc_read_path_by_length(path, line, sizeof(line), root_fd) > 0) {
     unsigned long long value = strtoull(line, NULL, 10);
     /* linux always reports size in bytes for dax, we want kB */
-    snprintf(line, sizeof(line), "%llu", value >> 10);
+    snprintf(line, sizeof(line), "%lluKiB", value >> 10);
     hwloc_obj_add_info(obj, "Size", line);
   }
 
@@ -6825,13 +6825,19 @@ hwloc_linuxfs_ve_class_fillinfos(int root_fd,
 
   snprintf(path, sizeof(path), "%s/memory_size", osdevpath); /* in GB */
   if (!hwloc_read_path_as_uint(path, &val, root_fd)) {
-    snprintf(tmp, sizeof(tmp), "%llu", ((unsigned long long) val) * 1024*1024); /* convert from GB to kB */
+    snprintf(tmp, sizeof(tmp), "%lluKiB", ((unsigned long long) val) * 1024*1024); /* convert from GB to kB */
     hwloc_obj_add_info(obj, "VectorEngineMemorySize", tmp);
   }
   snprintf(path, sizeof(path), "%s/cache_llc", osdevpath); /* in kB */
   if (hwloc_read_path_by_length(path, tmp, sizeof(tmp), root_fd) > 0) {
     size_t len;
     len = strspn(tmp, "0123456789");
+    if (len < sizeof(tmp)-3) {
+      tmp[len] = 'K';
+      tmp[len+1] = 'i';
+      tmp[len+2] = 'B';
+      len += 3;
+    }
     tmp[len] = '\0';
     hwloc_obj_add_info(obj, "VectorEngineLLCSize", tmp);
   }
@@ -6839,6 +6845,12 @@ hwloc_linuxfs_ve_class_fillinfos(int root_fd,
   if (hwloc_read_path_by_length(path, tmp, sizeof(tmp), root_fd) > 0) {
     size_t len;
     len = strspn(tmp, "0123456789");
+    if (len < sizeof(tmp)-3) { /* shouldn't ever fail since sizeof = 64 */
+      tmp[len] = 'K';
+      tmp[len+1] = 'i';
+      tmp[len+2] = 'B';
+      len += 3;
+    }
     tmp[len] = '\0';
     hwloc_obj_add_info(obj, "VectorEngineL2Size", tmp);
   }
@@ -6846,6 +6858,12 @@ hwloc_linuxfs_ve_class_fillinfos(int root_fd,
   if (hwloc_read_path_by_length(path, tmp, sizeof(tmp), root_fd) > 0) {
     size_t len;
     len = strspn(tmp, "0123456789");
+    if (len < sizeof(tmp)-3) { /* shouldn't ever fail since sizeof = 64 */
+      tmp[len] = 'K';
+      tmp[len+1] = 'i';
+      tmp[len+2] = 'B';
+      len += 3;
+    }
     tmp[len] = '\0';
     hwloc_obj_add_info(obj, "VectorEngineL1dSize", tmp);
   }
@@ -6853,6 +6871,12 @@ hwloc_linuxfs_ve_class_fillinfos(int root_fd,
   if (hwloc_read_path_by_length(path, tmp, sizeof(tmp), root_fd) > 0) {
     size_t len;
     len = strspn(tmp, "0123456789");
+    if (len < sizeof(tmp)-3) { /* shouldn't ever fail since sizeof = 64 */
+      tmp[len] = 'K';
+      tmp[len+1] = 'i';
+      tmp[len+2] = 'B';
+      len += 3;
+    }
     tmp[len] = '\0';
     hwloc_obj_add_info(obj, "VectorEngineL1iSize", tmp);
   }
@@ -6997,7 +7021,7 @@ hwloc_linuxfs_cxlmem_fillinfos(int root_fd,
   if (hwloc_read_path_by_length(path, tmp, sizeof(tmp), root_fd) > 0) {
     unsigned long long value = strtoull(tmp, NULL, 0);
     if (value)  {
-      snprintf(tmp, sizeof(tmp), "%llu", value / 1024);
+      snprintf(tmp, sizeof(tmp), "%lluKiB", value / 1024);
       hwloc_obj_add_info(obj, "CXLRAMSize", tmp);
     }
   }
@@ -7005,7 +7029,7 @@ hwloc_linuxfs_cxlmem_fillinfos(int root_fd,
   if (hwloc_read_path_by_length(path, tmp, sizeof(tmp), root_fd) > 0) {
     unsigned long long value = strtoull(tmp, NULL, 0);
     if (value)  {
-      snprintf(tmp, sizeof(tmp), "%llu", value / 1024);
+      snprintf(tmp, sizeof(tmp), "%lluKiB", value / 1024);
       hwloc_obj_add_info(obj, "CXLPMEMSize", tmp);
     }
     obj->attr->osdev.type |= HWLOC_OBJ_OSDEV_STORAGE;
@@ -7189,7 +7213,7 @@ static int dmi_memory_device_size(char *buffer, size_t len,
     if (!(code & 0x8000)) /* MiB (otherwise KiB) */
       memory_size <<= 10;
   }
-  snprintf(buffer, len, "%llu", (unsigned long long) memory_size);
+  snprintf(buffer, len, "%lluKiB", (unsigned long long) memory_size);
   return 0;
 }
 

--- a/hwloc/topology-opencl.c
+++ b/hwloc/topology-opencl.c
@@ -169,7 +169,7 @@ hwloc_opencl_discover(struct hwloc_backend *backend, struct hwloc_disc_status *d
       hwloc_obj_add_info(osdev, "OpenCLComputeUnits", buffer);
 
       clGetDeviceInfo(device_ids[i], CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(globalmemsize), &globalmemsize, NULL);
-      snprintf(buffer, sizeof(buffer), "%llu", (unsigned long long) globalmemsize / 1024);
+      snprintf(buffer, sizeof(buffer), "%lluKiB", (unsigned long long) globalmemsize / 1024);
       hwloc_obj_add_info(osdev, "OpenCLGlobalMemorySize", buffer);
 
       parent = NULL;

--- a/hwloc/topology-rsmi.c
+++ b/hwloc/topology-rsmi.c
@@ -318,19 +318,19 @@ hwloc_rsmi_discover(struct hwloc_backend *backend, struct hwloc_disc_status *dst
     ret = rsmi_dev_memory_total_get(i, RSMI_MEM_TYPE_VRAM, &memory);
     if (ret == RSMI_STATUS_SUCCESS) {
       char tmp[64];
-      snprintf(tmp, sizeof(tmp), "%llu", (unsigned long long)memory/1024);
+      snprintf(tmp, sizeof(tmp), "%lluKiB", (unsigned long long)memory/1024);
       hwloc_obj_add_info(osdev, "RSMIVRAMSize", tmp);
     }
     ret = rsmi_dev_memory_total_get(i, RSMI_MEM_TYPE_VIS_VRAM, &memory);
     if (ret == RSMI_STATUS_SUCCESS) {
       char tmp[64];
-      snprintf(tmp, sizeof(tmp), "%llu", (unsigned long long)memory/1024);
+      snprintf(tmp, sizeof(tmp), "%lluKiB", (unsigned long long)memory/1024);
       hwloc_obj_add_info(osdev, "RSMIVisibleVRAMSize", tmp);
     }
     ret = rsmi_dev_memory_total_get(i, RSMI_MEM_TYPE_GTT, &memory);
     if (ret == RSMI_STATUS_SUCCESS) {
       char tmp[64];
-      snprintf(tmp, sizeof(tmp), "%llu", (unsigned long long)memory/1024);
+      snprintf(tmp, sizeof(tmp), "%lluKiB", (unsigned long long)memory/1024);
       hwloc_obj_add_info(osdev, "RSMIGTTSize", tmp);
     }
     /* there's also rsmi_dev_memory_usage_get() to get what's currently used in these memories */

--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -469,6 +469,30 @@ hwloc__xml_import_obj_info(hwloc_topology_t topology,
             hwloc__add_info(&topology->infos, infoname, infovalue);
             return 0;
           }
+        } else if (obj->type == HWLOC_OBJ_OS_DEVICE) {
+          /* if infoname contains Size (but is not SectorSize), add "KiB" suffix to infovalue if missing */
+          if (strstr(infoname, "Size") && strcmp(infoname, "SectorSize") && !strstr(infovalue, "KiB")) {
+            /* CUDA: CUDAGlobalMemorySize CUDAL2CacheSize CUDASharedMemorySizePerMP
+             * LevelZero: LevelZeroMemorySize LevelZeroHBMSize LevelZeroDDRSize
+             * OpenCL: OpenCLGlobalMemorySize
+             * RSMI: RSMIVRAMSize RSMIVisibleVRAMSize RSMIGTTSize
+             * VectorEngine: VectorEngineMemorySize VectorEngineLLCSize VectorEngineL2Size VectorEngineL1dSize VectorEngineL1iSize
+             * CXL: CXLRAMSize CXLPMEMSize
+             * Block and DAX: Size
+             */
+            char tmp[64];
+            snprintf(tmp, sizeof(tmp), "%sKiB", infovalue);
+            hwloc_obj_add_info(obj, infoname, tmp);
+            return 0;
+          }
+        } else if (obj->type == HWLOC_OBJ_MISC && obj->subtype && !strcmp(obj->subtype, "MemoryModule")) {
+          /* Misc/MemoryModule Size needs "KiB" suffix if missing too */
+          if (!strcmp(infoname, "Size") && !strstr(infovalue, "KiB")) {
+            char tmp[64];
+            snprintf(tmp, sizeof(tmp), "%sKiB", infovalue);
+            hwloc_obj_add_info(obj, infoname, tmp);
+            return 0;
+          }
         }
       }
       hwloc_obj_add_info(obj, infoname, infovalue);

--- a/tests/hwloc/linux/2pa-pcidomain32bits.console
+++ b/tests/hwloc/linux/2pa-pcidomain32bits.console
@@ -8,7 +8,7 @@ Machine (P#0 total=2004MiB DMIProductName="CloudStack KVM Hypervisor" DMIProduct
             PU L#0 (P#0)
     HostBridge L#0 (buses=0000:[00-00])
       PCI L#0 (busid=0000:00:01.1 id=8086:7010 class=0101(IDE) PCISlot=1)
-        OSDev[Storage](Removable Media Device) L#0 (Size=1048575 SectorSize=512 LinuxDeviceID=11:0 Model=QEMU_DVD-ROM Revision=1.5.3 SerialNumber=QM00003) "sr0"
+        OSDev[Storage](Removable Media Device) L#0 (Size=1048575KiB SectorSize=512 LinuxDeviceID=11:0 Model=QEMU_DVD-ROM Revision=1.5.3 SerialNumber=QM00003) "sr0"
       PCI L#1 (busid=0000:00:02.0 id=1013:00b8 class=0300(VGA) PCISlot=2)
       PCI L#2 (busid=0000:00:03.0 id=1af4:1000 class=0200(Ethernet) PCISlot=3)
         OSDev[Network] L#1 (Address=06:7a:4c:00:00:22) "ens3"
@@ -20,7 +20,7 @@ Machine (P#0 total=2004MiB DMIProductName="CloudStack KVM Hypervisor" DMIProduct
             PU L#1 (P#1)
     HostBridge L#1 (buses=10000:[00-00])
       PCI L#3 (busid=10000:00:04.0 id=1af4:1001 class=0100(SCSI))
-        OSDev[Storage] L#2 (Size=20971520 SectorSize=512 LinuxDeviceID=254:0) "vda"
+        OSDev[Storage] L#2 (Size=20971520KiB SectorSize=512 LinuxDeviceID=254:0) "vda"
 depth 0:           1 Machine (type #0)
  depth 1:          2 Package (type #1)
   depth 2:         2 L2Cache (type #5)

--- a/tests/hwloc/linux/32em64t-2n8c+dax+nvme+mic+dimms.xml
+++ b/tests/hwloc/linux/32em64t-2n8c+dax+nvme+mic+dimms.xml
@@ -113,7 +113,7 @@
         </object>
         <object type="PCIDev" pci_busid="0000:00:02.0" pci_type="0108 [8086:0953] [8086:3709] 01 02" pci_link_speed="0.000000">
           <object type="OSDev" name="nvme0n1" subtype="Disk" osdev_type="1">
-            <info name="Size" value="390711384"/>
+            <info name="Size" value="390711384KiB"/>
             <info name="SectorSize" value="512"/>
             <info name="LinuxDeviceID" value="259:0"/>
           </object>
@@ -158,7 +158,7 @@
         <object type="PCIDev" pci_busid="0000:00:1f.0" pci_type="0601 [8086:1d41] [1028:0518] 06 00" pci_link_speed="0.000000"/>
         <object type="PCIDev" pci_busid="0000:00:1f.2" pci_type="0106 [8086:1d02] [1028:0518] 06 01" pci_link_speed="0.000000">
           <object type="OSDev" name="sda" subtype="Disk" osdev_type="1">
-            <info name="Size" value="244198584"/>
+            <info name="Size" value="244198584KiB"/>
             <info name="SectorSize" value="512"/>
             <info name="LinuxDeviceID" value="8:0"/>
             <info name="Model" value="MTFDDAK256MAM-1K12"/>
@@ -171,21 +171,21 @@
       <object type="OSDev" name="dax0.0" subtype="NVM" osdev_type="3">
         <info name="DAXType" value="NVM"/>
         <info name="DAXParent" value="LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region0"/>
-        <info name="Size" value="105281536"/>
+        <info name="Size" value="105281536KiB"/>
         <info name="LinuxDeviceID" value="252:1"/>
       </object>
       <object type="OSDev" name="pmem0.1" subtype="NVM" osdev_type="1">
-        <info name="Size" value="105281536"/>
+        <info name="Size" value="105281536KiB"/>
         <info name="SectorSize" value="512"/>
         <info name="LinuxDeviceID" value="259:0"/>
       </object>
       <object type="OSDev" name="pmem0.2s" subtype="NVM" osdev_type="1">
-        <info name="Size" value="106849352"/>
+        <info name="Size" value="106849352KiB"/>
         <info name="SectorSize" value="4096"/>
         <info name="LinuxDeviceID" value="259:1"/>
       </object>
       <object type="OSDev" name="pmem0.3" subtype="NVM" osdev_type="1">
-        <info name="Size" value="471859200"/>
+        <info name="Size" value="471859200KiB"/>
         <info name="SectorSize" value="512"/>
         <info name="LinuxDeviceID" value="259:2"/>
       </object>
@@ -325,21 +325,21 @@
       <object type="OSDev" name="dax1.3" subtype="NVM" osdev_type="3">
         <info name="DAXType" value="NVM"/>
         <info name="DAXParent" value="LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region1/dax1.0"/>
-        <info name="Size" value="61929472"/>
+        <info name="Size" value="61929472KiB"/>
         <info name="LinuxDeviceID" value="252:6"/>
       </object>
       <object type="OSDev" name="pmem1" subtype="NVM" osdev_type="1">
-        <info name="Size" value="62914560"/>
+        <info name="Size" value="62914560KiB"/>
         <info name="SectorSize" value="512"/>
         <info name="LinuxDeviceID" value="259:3"/>
       </object>
       <object type="OSDev" name="pmem1.1s" subtype="NVM" osdev_type="1">
-        <info name="Size" value="62852124"/>
+        <info name="Size" value="62852124KiB"/>
         <info name="SectorSize" value="4096"/>
         <info name="LinuxDeviceID" value="259:4"/>
       </object>
       <object type="OSDev" name="pmem1.2" subtype="NVM" osdev_type="1">
-        <info name="Size" value="61929472"/>
+        <info name="Size" value="61929472KiB"/>
         <info name="SectorSize" value="512"/>
         <info name="LinuxDeviceID" value="259:5"/>
       </object>
@@ -448,7 +448,7 @@
       <info name="PartNumber" value="HMT351R7CFR8C-PB  "/>
       <info name="FormFactor" value="DIMM"/>
       <info name="Type" value="DDR3"/>
-      <info name="Size" value="4194304"/>
+      <info name="Size" value="4194304KiB"/>
       <info name="Rank" value="2"/>
     </object>
     <object type="Misc" os_index="1" subtype="MemoryModule">
@@ -459,7 +459,7 @@
       <info name="PartNumber" value="HMT351R7CFR8C-PB  "/>
       <info name="FormFactor" value="DIMM"/>
       <info name="Type" value="DDR3"/>
-      <info name="Size" value="4194304"/>
+      <info name="Size" value="4194304KiB"/>
       <info name="Rank" value="2"/>
     </object>
     <object type="Misc" os_index="2" subtype="MemoryModule">
@@ -470,7 +470,7 @@
       <info name="PartNumber" value="HMT351R7CFR8C-PB  "/>
       <info name="FormFactor" value="DIMM"/>
       <info name="Type" value="DDR3"/>
-      <info name="Size" value="4194304"/>
+      <info name="Size" value="4194304KiB"/>
       <info name="Rank" value="2"/>
     </object>
     <object type="Misc" os_index="3" subtype="MemoryModule">
@@ -481,7 +481,7 @@
       <info name="PartNumber" value="HMT351R7CFR8C-PB  "/>
       <info name="FormFactor" value="DIMM"/>
       <info name="Type" value="DDR3"/>
-      <info name="Size" value="4194304"/>
+      <info name="Size" value="4194304KiB"/>
       <info name="Rank" value="2"/>
     </object>
     <object type="Misc" os_index="12" subtype="MemoryModule">
@@ -492,7 +492,7 @@
       <info name="PartNumber" value="HMT351R7CFR8C-PB  "/>
       <info name="FormFactor" value="DIMM"/>
       <info name="Type" value="DDR3"/>
-      <info name="Size" value="4194304"/>
+      <info name="Size" value="4194304KiB"/>
       <info name="Rank" value="2"/>
     </object>
     <object type="Misc" os_index="13" subtype="MemoryModule">
@@ -503,7 +503,7 @@
       <info name="PartNumber" value="HMT351R7CFR8C-PB  "/>
       <info name="FormFactor" value="DIMM"/>
       <info name="Type" value="DDR3"/>
-      <info name="Size" value="4194304"/>
+      <info name="Size" value="4194304KiB"/>
       <info name="Rank" value="2"/>
     </object>
     <object type="Misc" os_index="14" subtype="MemoryModule">
@@ -514,7 +514,7 @@
       <info name="PartNumber" value="HMT351R7CFR8C-PB  "/>
       <info name="FormFactor" value="DIMM"/>
       <info name="Type" value="DDR3"/>
-      <info name="Size" value="4194304"/>
+      <info name="Size" value="4194304KiB"/>
       <info name="Rank" value="2"/>
     </object>
     <object type="Misc" os_index="15" subtype="MemoryModule">
@@ -525,7 +525,7 @@
       <info name="PartNumber" value="HMT351R7CFR8C-PB  "/>
       <info name="FormFactor" value="DIMM"/>
       <info name="Type" value="DDR3"/>
-      <info name="Size" value="4194304"/>
+      <info name="Size" value="4194304KiB"/>
       <info name="Rank" value="2"/>
     </object>
   </object>

--- a/tests/hwloc/linux/32intel64-2p8co2t+8ve.console
+++ b/tests/hwloc/linux/32intel64-2p8co2t+8ve.console
@@ -57,33 +57,33 @@ Machine (P#0 total=93GiB DMIProductName=SYS-4029GP-TRT2-1-NE010 DMIProductVersio
             PCI L#0 (busid=0000:1a:00.0 id=15b3:1013 class=0207(InfiniBand) link=15.75GB/s)
           PCIBridge L#4 (busid=0000:19:08.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[1b-1b])
             PCI L#1 (busid=0000:1b:00.0 id=1bcf:001c class=0b40(Co-Processor) link=15.75GB/s)
-              OSDev[Co-Processor](VectorEngine) L#0 (VectorEngineModel=1 VectorEngineSerialNumber=32424a32333030343900000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648 VectorEngineLLCSize=16384 VectorEngineL2Size=256 VectorEngineL1dSize=32 VectorEngineL1iSize=32) "ve0"
+              OSDev[Co-Processor](VectorEngine) L#0 (VectorEngineModel=1 VectorEngineSerialNumber=32424a32333030343900000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648KiB VectorEngineLLCSize=16384KiB VectorEngineL2Size=256KiB VectorEngineL1dSize=32KiB VectorEngineL1iSize=32KiB) "ve0"
           PCIBridge L#5 (busid=0000:19:0c.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[1c-1c])
             PCI L#2 (busid=0000:1c:00.0 id=1bcf:001c class=0b40(Co-Processor) link=15.75GB/s)
-              OSDev[Co-Processor](VectorEngine) L#1 (VectorEngineModel=1 VectorEngineSerialNumber=32424a35303030313800000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648 VectorEngineLLCSize=16384 VectorEngineL2Size=256 VectorEngineL1dSize=32 VectorEngineL1iSize=32) "ve1"
+              OSDev[Co-Processor](VectorEngine) L#1 (VectorEngineModel=1 VectorEngineSerialNumber=32424a35303030313800000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648KiB VectorEngineLLCSize=16384KiB VectorEngineL2Size=256KiB VectorEngineL1dSize=32KiB VectorEngineL1iSize=32KiB) "ve1"
           PCIBridge L#6 (busid=0000:19:10.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[1d-1d])
             PCI L#3 (busid=0000:1d:00.0 id=1bcf:001c class=0b40(Co-Processor) link=15.75GB/s)
-              OSDev[Co-Processor](VectorEngine) L#2 (VectorEngineModel=1 VectorEngineSerialNumber=32424a32333030363800000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648 VectorEngineLLCSize=16384 VectorEngineL2Size=256 VectorEngineL1dSize=32 VectorEngineL1iSize=32) "ve2"
+              OSDev[Co-Processor](VectorEngine) L#2 (VectorEngineModel=1 VectorEngineSerialNumber=32424a32333030363800000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648KiB VectorEngineLLCSize=16384KiB VectorEngineL2Size=256KiB VectorEngineL1dSize=32KiB VectorEngineL1iSize=32KiB) "ve2"
           PCIBridge L#7 (busid=0000:19:14.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[1e-1e])
             PCI L#4 (busid=0000:1e:00.0 id=1bcf:001c class=0b40(Co-Processor) link=15.75GB/s)
-              OSDev[Co-Processor](VectorEngine) L#3 (VectorEngineModel=1 VectorEngineSerialNumber=32424a35303030313700000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648 VectorEngineLLCSize=16384 VectorEngineL2Size=256 VectorEngineL1dSize=32 VectorEngineL1iSize=32) "ve3"
+              OSDev[Co-Processor](VectorEngine) L#3 (VectorEngineModel=1 VectorEngineSerialNumber=32424a35303030313700000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648KiB VectorEngineLLCSize=16384KiB VectorEngineL2Size=256KiB VectorEngineL1dSize=32KiB VectorEngineL1iSize=32KiB) "ve3"
     HostBridge L#8 (buses=0000:[3a-41])
       PCIBridge L#9 (busid=0000:3a:00.0 id=8086:2030 class=0604(PCIBridge) link=15.75GB/s buses=0000:[3b-41])
         PCIBridge L#10 (busid=0000:3b:00.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[3c-41])
           PCIBridge L#11 (busid=0000:3c:04.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[3d-3d])
             PCI L#5 (busid=0000:3d:00.0 id=1bcf:001c class=0b40(Co-Processor) link=15.75GB/s)
-              OSDev[Co-Processor](VectorEngine) L#4 (VectorEngineModel=1 VectorEngineSerialNumber=32424a32333030353000000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648 VectorEngineLLCSize=16384 VectorEngineL2Size=256 VectorEngineL1dSize=32 VectorEngineL1iSize=32) "ve4"
+              OSDev[Co-Processor](VectorEngine) L#4 (VectorEngineModel=1 VectorEngineSerialNumber=32424a32333030353000000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648KiB VectorEngineLLCSize=16384KiB VectorEngineL2Size=256KiB VectorEngineL1dSize=32KiB VectorEngineL1iSize=32KiB) "ve4"
           PCIBridge L#12 (busid=0000:3c:08.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[3e-3e])
             PCI L#6 (busid=0000:3e:00.0 id=15b3:1013 class=0207(InfiniBand) link=15.75GB/s)
           PCIBridge L#13 (busid=0000:3c:0c.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[3f-3f])
             PCI L#7 (busid=0000:3f:00.0 id=1bcf:001c class=0b40(Co-Processor) link=15.75GB/s)
-              OSDev[Co-Processor](VectorEngine) L#5 (VectorEngineModel=1 VectorEngineSerialNumber=32424a34383030353200000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648 VectorEngineLLCSize=16384 VectorEngineL2Size=256 VectorEngineL1dSize=32 VectorEngineL1iSize=32) "ve5"
+              OSDev[Co-Processor](VectorEngine) L#5 (VectorEngineModel=1 VectorEngineSerialNumber=32424a34383030353200000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648KiB VectorEngineLLCSize=16384KiB VectorEngineL2Size=256KiB VectorEngineL1dSize=32KiB VectorEngineL1iSize=32KiB) "ve5"
           PCIBridge L#14 (busid=0000:3c:10.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[40-40])
             PCI L#8 (busid=0000:40:00.0 id=1bcf:001c class=0b40(Co-Processor) link=15.75GB/s)
-              OSDev[Co-Processor](VectorEngine) L#6 (VectorEngineModel=1 VectorEngineSerialNumber=32424a34383030343500000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648 VectorEngineLLCSize=16384 VectorEngineL2Size=256 VectorEngineL1dSize=32 VectorEngineL1iSize=32) "ve6"
+              OSDev[Co-Processor](VectorEngine) L#6 (VectorEngineModel=1 VectorEngineSerialNumber=32424a34383030343500000000000000 VectorEngineCores=8 VectorEngineMemorySize=50331648KiB VectorEngineLLCSize=16384KiB VectorEngineL2Size=256KiB VectorEngineL1dSize=32KiB VectorEngineL1iSize=32KiB) "ve6"
           PCIBridge L#15 (busid=0000:3c:14.0 id=10b5:9797 class=0604(PCIBridge) link=15.75GB/s buses=0000:[41-41])
             PCI L#9 (busid=0000:41:00.0 id=1bcf:001c class=0b40(Co-Processor) link=15.75GB/s)
-              OSDev[Co-Processor](VectorEngine) L#7 (VectorEngineModel=1 VectorEngineSerialNumber=32424a34383030343800000000000000 VectorEngineNUMAPartitioned=1 VectorEngineCores=8 VectorEngineMemorySize=50331648 VectorEngineLLCSize=16384 VectorEngineL2Size=256 VectorEngineL1dSize=32 VectorEngineL1iSize=32) "ve7"
+              OSDev[Co-Processor](VectorEngine) L#7 (VectorEngineModel=1 VectorEngineSerialNumber=32424a34383030343800000000000000 VectorEngineNUMAPartitioned=1 VectorEngineCores=8 VectorEngineMemorySize=50331648KiB VectorEngineLLCSize=16384KiB VectorEngineL2Size=256KiB VectorEngineL1dSize=32KiB VectorEngineL1iSize=32KiB) "ve7"
     HostBridge L#16 (buses=0000:[5d-60])
       PCIBridge L#17 (busid=0000:5d:02.0 id=8086:2032 class=0604(PCIBridge) link=7.88GB/s buses=0000:[5e-60])
         PCIBridge L#18 (busid=0000:5e:00.0 id=8086:37c0 class=0604(PCIBridge) link=7.88GB/s buses=0000:[5f-60])

--- a/tests/hwloc/linux/40intel64-2g2n4c+pcilocality.xml
+++ b/tests/hwloc/linux/40intel64-2g2n4c+pcilocality.xml
@@ -220,7 +220,7 @@
         <object type="Bridge" bridge_type="1-1" depth="1" bridge_pci="0000:[01-01]" pci_busid="0000:00:03.0" pci_type="0604 [8086:340a] [0000:0000] 22 00" pci_link_speed="0.000000">
           <object type="PCIDev" pci_busid="0000:01:00.0" pci_type="0104 [1000:0079] [1028:1f17] 05 00" pci_link_speed="0.000000">
             <object type="OSDev" name="sda" osdev_type="1">
-              <info name="Size" value="1756495872"/>
+              <info name="Size" value="1756495872KiB"/>
               <info name="SectorSize" value="512"/>
               <info name="LinuxDeviceID" value="8:0"/>
             </object>
@@ -271,7 +271,7 @@
         <object type="PCIDev" pci_busid="0000:00:1f.0" pci_type="0601 [8086:3a18] [1028:02d3] 00 00" pci_link_speed="0.000000"/>
         <object type="PCIDev" pci_busid="0000:00:1f.2" pci_type="0101 [8086:3a20] [1028:02d3] 00 8f" pci_link_speed="1.000000">
           <object type="OSDev" name="sr0" osdev_type="1">
-            <info name="Size" value="1048575"/>
+            <info name="Size" value="1048575KiB"/>
             <info name="SectorSize" value="512"/>
             <info name="LinuxDeviceID" value="11:0"/>
           </object>

--- a/tests/hwloc/linux/40intel64-4n10c+pci-conflicts.console
+++ b/tests/hwloc/linux/40intel64-4n10c+pci-conflicts.console
@@ -212,7 +212,7 @@ Machine (P#0 total=512GiB)
   HostBridge L#0 (buses=0000:[00-01])
     PCIBridge L#1 (busid=0000:00:03.0 id=8086:340a class=0604(PCIBridge) buses=0000:[01-01])
       PCI L#0 (busid=0000:01:00.0 id=1000:0079 class=0104(RAID))
-        OSDev[Storage] L#0 (Size=1756495872 SectorSize=512 LinuxDeviceID=8:0) "sda"
+        OSDev[Storage] L#0 (Size=1756495872KiB SectorSize=512 LinuxDeviceID=8:0) "sda"
 depth 0:           1 Machine (type #0)
  depth 1:          3 Package (type #1)
   depth 2:         3 L3Cache (type #6)

--- a/tests/hwloc/linux/fakeheteromemtiers.console
+++ b/tests/hwloc/linux/fakeheteromemtiers.console
@@ -14,7 +14,7 @@ Machine (P#0 total=6090MiB DMIProductName="Standard PC (i440FX + PIIX, 1996)" DM
             L1iCache L#1 (P#1 size=32KiB linesize=64 ways=8)
               Core L#1 (P#1)
                 PU L#1 (P#1)
-        OSDev[Memory](SPM) L#0 (DAXType=SPM DAXParent=hmem.0 Size=524288 LinuxDeviceID=253:0) "dax0.0"
+        OSDev[Memory](SPM) L#0 (DAXType=SPM DAXParent=hmem.0 Size=524288KiB LinuxDeviceID=253:0) "dax0.0"
       Group0 L#1 (total=1875MiB)
         NUMANode(DRAM) L#2 (P#1 local=979MiB total=979MiB MemoryTier=1)
         NUMANode(HBM) L#3 (P#4 local=512MiB total=512MiB DAXDevice=dax1.0 DAXType=SPM DAXParent=hmem.1 MemoryTier=0)
@@ -29,7 +29,7 @@ Machine (P#0 total=6090MiB DMIProductName="Standard PC (i440FX + PIIX, 1996)" DM
             L1iCache L#3 (P#3 size=32KiB linesize=64 ways=8)
               Core L#3 (P#3)
                 PU L#3 (P#3)
-        OSDev[Memory](SPM) L#1 (DAXType=SPM DAXParent=hmem.2 Size=524288 LinuxDeviceID=253:2) "dax2.0"
+        OSDev[Memory](SPM) L#1 (DAXType=SPM DAXParent=hmem.2 Size=524288KiB LinuxDeviceID=253:2) "dax2.0"
       Group0 L#2 (total=896MiB)
         NUMANode(HBM) L#5 (P#2 local=512MiB total=512MiB DAXDevice=dax3.0 DAXType=SPM DAXParent=hmem.3 MemoryTier=0)
         NUMANode(NVM) L#6 (P#9 local=384MiB total=384MiB DAXDevice=dax8.0 DAXType=NVM DAXParent=LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region8/dax8.1 MemoryTier=2)
@@ -43,7 +43,7 @@ Machine (P#0 total=6090MiB DMIProductName="Standard PC (i440FX + PIIX, 1996)" DM
             L1iCache L#5 (P#5 size=32KiB linesize=64 ways=8)
               Core L#5 (P#5)
                 PU L#5 (P#5)
-        OSDev[Memory,Storage](NVM) L#2 (DAXType=NVM DAXParent=LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region6/dax6.1 Size=514048 LinuxDeviceID=253:6) "dax6.0"
+        OSDev[Memory,Storage](NVM) L#2 (DAXType=NVM DAXParent=LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region6/dax6.1 Size=514048KiB LinuxDeviceID=253:6) "dax6.0"
 depth 0:            1 Machine (type #0)
  depth 1:           1 Package (type #1)
   depth 2:          1 L3Cache (type #6)

--- a/tests/hwloc/xml/32em64t-2n8c2t-pci-normalio.xml
+++ b/tests/hwloc/xml/32em64t-2n8c2t-pci-normalio.xml
@@ -230,11 +230,11 @@
             <object type="OSDev" gp_index="136" id="obj136" name="cuda0" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla K40m"/>
-              <info name="CUDAGlobalMemorySize" value="11796032"/>
-              <info name="CUDAL2CacheSize" value="1536"/>
+              <info name="CUDAGlobalMemorySize" value="11796032KiB"/>
+              <info name="CUDAL2CacheSize" value="1536KiB"/>
               <info name="CUDAMultiProcessors" value="15"/>
               <info name="CUDACoresPerMP" value="192"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="137" id="obj137" name="card0" osdev_type="4"/>
           </object>
@@ -249,7 +249,7 @@
               <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
               <info name="OpenCLPlatformDeviceIndex" value="1"/>
               <info name="OpenCLComputeUnits" value="32"/>
-              <info name="OpenCLGlobalMemorySize" value="3087360"/>
+              <info name="OpenCLGlobalMemorySize" value="3087360KiB"/>
             </object>
           </object>
           <object type="PCIDev" gp_index="140" id="obj140" pci_busid="0000:04:00.0" pci_type="0207 [15b3:1013] [15b3:0013] 00 00" pci_link_speed="0.000000">

--- a/tests/hwloc/xml/32em64t-2n8c2t-pci-wholeio.xml
+++ b/tests/hwloc/xml/32em64t-2n8c2t-pci-wholeio.xml
@@ -230,11 +230,11 @@
             <object type="OSDev" gp_index="136" id="obj136" name="cuda0" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla K40m"/>
-              <info name="CUDAGlobalMemorySize" value="11796032"/>
-              <info name="CUDAL2CacheSize" value="1536"/>
+              <info name="CUDAGlobalMemorySize" value="11796032KiB"/>
+              <info name="CUDAL2CacheSize" value="1536KiB"/>
               <info name="CUDAMultiProcessors" value="15"/>
               <info name="CUDACoresPerMP" value="192"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="137" id="obj137" name="card0" osdev_type="4"/>
           </object>
@@ -249,7 +249,7 @@
               <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
               <info name="OpenCLPlatformDeviceIndex" value="1"/>
               <info name="OpenCLComputeUnits" value="32"/>
-              <info name="OpenCLGlobalMemorySize" value="3087360"/>
+              <info name="OpenCLGlobalMemorySize" value="3087360KiB"/>
             </object>
           </object>
           <object type="PCIDev" gp_index="140" id="obj140" pci_busid="0000:04:00.0" pci_type="0207 [15b3:1013] [15b3:0013] 00 00" pci_link_speed="0.000000">

--- a/tests/hwloc/xml/cxlmem+dax.v2.xml
+++ b/tests/hwloc/xml/cxlmem+dax.v2.xml
@@ -72,7 +72,7 @@
       <object type="OSDev" gp_index="48" name="dax0.0" subtype="SPM" osdev_type="0">
         <info name="DAXType" value="SPM"/>
         <info name="DAXParent" value="hmem.0"/>
-        <info name="Size" value="1048576"/>
+        <info name="Size" value="1048576KiB"/>
         <info name="LinuxDeviceID" value="253:0"/>
       </object>
     </object>
@@ -89,7 +89,7 @@
         <info name="PCIVendor" value="Intel Corporation"/>
         <info name="PCIDevice" value="82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]"/>
         <object type="OSDev" gp_index="46" name="sr0" subtype="Removable Media Device" osdev_type="0">
-          <info name="Size" value="1048575"/>
+          <info name="Size" value="1048575KiB"/>
           <info name="SectorSize" value="512"/>
           <info name="LinuxDeviceID" value="11:0"/>
           <info name="Model" value="QEMU_DVD-ROM"/>
@@ -97,7 +97,7 @@
           <info name="SerialNumber" value="QM00005"/>
         </object>
         <object type="OSDev" gp_index="47" name="sda" subtype="Disk" osdev_type="0">
-          <info name="Size" value="10485760"/>
+          <info name="Size" value="10485760KiB"/>
           <info name="SectorSize" value="512"/>
           <info name="LinuxDeviceID" value="8:0"/>
           <info name="Model" value="QEMU_HARDDISK"/>
@@ -123,7 +123,7 @@
                   <info name="PCISlot" value="4"/>
                   <info name="PCIVendor" value="Intel Corporation"/>
                   <object type="OSDev" gp_index="52" name="mem2" subtype="CXLMem" osdev_type="0">
-                    <info name="CXLRAMSize" value="262144"/>
+                    <info name="CXLRAMSize" value="262144KiB"/>
                   </object>
                 </object>
               </object>
@@ -133,7 +133,7 @@
                   <info name="PCISlot" value="5"/>
                   <info name="PCIVendor" value="Intel Corporation"/>
                   <object type="OSDev" gp_index="51" name="mem0" subtype="CXLMem" osdev_type="0">
-                    <info name="CXLPMEMSize" value="262144"/>
+                    <info name="CXLPMEMSize" value="262144KiB"/>
                   </object>
                 </object>
               </object>
@@ -150,7 +150,7 @@
                   <info name="PCISlot" value="6"/>
                   <info name="PCIVendor" value="Intel Corporation"/>
                   <object type="OSDev" gp_index="53" name="mem3" subtype="CXLMem" osdev_type="0">
-                    <info name="CXLRAMSize" value="262144"/>
+                    <info name="CXLRAMSize" value="262144KiB"/>
                   </object>
                 </object>
               </object>
@@ -160,8 +160,8 @@
                   <info name="PCISlot" value="7"/>
                   <info name="PCIVendor" value="Intel Corporation"/>
                   <object type="OSDev" gp_index="50" name="mem1" subtype="CXLMem" osdev_type="0">
-                    <info name="CXLRAMSize" value="262144"/>
-                    <info name="CXLPMEMSize" value="262144"/>
+                    <info name="CXLRAMSize" value="262144KiB"/>
+                    <info name="CXLPMEMSize" value="262144KiB"/>
                   </object>
                 </object>
               </object>

--- a/tests/hwloc/xml/cxlmem+dax.v3.xml
+++ b/tests/hwloc/xml/cxlmem+dax.v3.xml
@@ -65,7 +65,7 @@
       <object type="OSDev" gp_index="48" id="obj48" name="dax0.0" subtype="SPM" osdev_type="2">
         <info name="DAXType" value="SPM"/>
         <info name="DAXParent" value="hmem.0"/>
-        <info name="Size" value="1048576"/>
+        <info name="Size" value="1048576KiB"/>
         <info name="LinuxDeviceID" value="253:0"/>
       </object>
     </object>
@@ -82,7 +82,7 @@
         <info name="PCIVendor" value="Intel Corporation"/>
         <info name="PCIDevice" value="82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]"/>
         <object type="OSDev" gp_index="46" id="obj46" name="sr0" subtype="Removable Media Device" osdev_type="1">
-          <info name="Size" value="1048575"/>
+          <info name="Size" value="1048575KiB"/>
           <info name="SectorSize" value="512"/>
           <info name="LinuxDeviceID" value="11:0"/>
           <info name="Model" value="QEMU_DVD-ROM"/>
@@ -90,7 +90,7 @@
           <info name="SerialNumber" value="QM00005"/>
         </object>
         <object type="OSDev" gp_index="47" id="obj47" name="sda" subtype="Disk" osdev_type="1">
-          <info name="Size" value="10485760"/>
+          <info name="Size" value="10485760KiB"/>
           <info name="SectorSize" value="512"/>
           <info name="LinuxDeviceID" value="8:0"/>
           <info name="Model" value="QEMU_HARDDISK"/>
@@ -116,7 +116,7 @@
                   <info name="PCISlot" value="4"/>
                   <info name="PCIVendor" value="Intel Corporation"/>
                   <object type="OSDev" gp_index="52" id="obj52" name="mem2" subtype="CXLMem" osdev_type="2">
-                    <info name="CXLRAMSize" value="262144"/>
+                    <info name="CXLRAMSize" value="262144KiB"/>
                   </object>
                 </object>
               </object>
@@ -126,7 +126,7 @@
                   <info name="PCISlot" value="5"/>
                   <info name="PCIVendor" value="Intel Corporation"/>
                   <object type="OSDev" gp_index="51" id="obj51" name="mem0" subtype="CXLMem" osdev_type="3">
-                    <info name="CXLPMEMSize" value="262144"/>
+                    <info name="CXLPMEMSize" value="262144KiB"/>
                   </object>
                 </object>
               </object>
@@ -143,7 +143,7 @@
                   <info name="PCISlot" value="6"/>
                   <info name="PCIVendor" value="Intel Corporation"/>
                   <object type="OSDev" gp_index="53" id="obj53" name="mem3" subtype="CXLMem" osdev_type="2">
-                    <info name="CXLRAMSize" value="262144"/>
+                    <info name="CXLRAMSize" value="262144KiB"/>
                   </object>
                 </object>
               </object>
@@ -153,8 +153,8 @@
                   <info name="PCISlot" value="7"/>
                   <info name="PCIVendor" value="Intel Corporation"/>
                   <object type="OSDev" gp_index="50" id="obj50" name="mem1" subtype="CXLMem" osdev_type="3">
-                    <info name="CXLRAMSize" value="262144"/>
-                    <info name="CXLPMEMSize" value="262144"/>
+                    <info name="CXLRAMSize" value="262144KiB"/>
+                    <info name="CXLPMEMSize" value="262144KiB"/>
                   </object>
                 </object>
               </object>

--- a/tests/hwloc/xml/power8gpudistances.xml
+++ b/tests/hwloc/xml/power8gpudistances.xml
@@ -38,11 +38,11 @@
             <object type="OSDev" gp_index="328" id="obj328" name="cuda0" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla P100-SXM2-16GB"/>
-              <info name="CUDAGlobalMemorySize" value="16671616"/>
-              <info name="CUDAL2CacheSize" value="4096"/>
+              <info name="CUDAGlobalMemorySize" value="16671616KiB"/>
+              <info name="CUDAL2CacheSize" value="4096KiB"/>
               <info name="CUDAMultiProcessors" value="56"/>
               <info name="CUDACoresPerMP" value="64"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="324" id="obj324" name="opencl0d0" subtype="OpenCL" osdev_type="12">
               <info name="OpenCLDeviceType" value="GPU"/>
@@ -52,7 +52,7 @@
               <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
               <info name="OpenCLPlatformDeviceIndex" value="0"/>
               <info name="OpenCLComputeUnits" value="56"/>
-              <info name="OpenCLGlobalMemorySize" value="16671616"/>
+              <info name="OpenCLGlobalMemorySize" value="16671616KiB"/>
             </object>
             <object type="OSDev" gp_index="332" id="obj332" name="nvml0" subtype="NVML" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
@@ -69,11 +69,11 @@
             <object type="OSDev" gp_index="329" id="obj329" name="cuda1" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla P100-SXM2-16GB"/>
-              <info name="CUDAGlobalMemorySize" value="16671616"/>
-              <info name="CUDAL2CacheSize" value="4096"/>
+              <info name="CUDAGlobalMemorySize" value="16671616KiB"/>
+              <info name="CUDAL2CacheSize" value="4096KiB"/>
               <info name="CUDAMultiProcessors" value="56"/>
               <info name="CUDACoresPerMP" value="64"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="325" id="obj325" name="opencl0d1" subtype="OpenCL" osdev_type="12">
               <info name="OpenCLDeviceType" value="GPU"/>
@@ -83,7 +83,7 @@
               <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
               <info name="OpenCLPlatformDeviceIndex" value="1"/>
               <info name="OpenCLComputeUnits" value="56"/>
-              <info name="OpenCLGlobalMemorySize" value="16671616"/>
+              <info name="OpenCLGlobalMemorySize" value="16671616KiB"/>
             </object>
             <object type="OSDev" gp_index="333" id="obj333" name="nvml1" subtype="NVML" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
@@ -129,11 +129,11 @@
             <object type="OSDev" gp_index="330" id="obj330" name="cuda2" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla P100-SXM2-16GB"/>
-              <info name="CUDAGlobalMemorySize" value="16671616"/>
-              <info name="CUDAL2CacheSize" value="4096"/>
+              <info name="CUDAGlobalMemorySize" value="16671616KiB"/>
+              <info name="CUDAL2CacheSize" value="4096KiB"/>
               <info name="CUDAMultiProcessors" value="56"/>
               <info name="CUDACoresPerMP" value="64"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="326" id="obj326" name="opencl0d2" subtype="OpenCL" osdev_type="12">
               <info name="OpenCLDeviceType" value="GPU"/>
@@ -143,7 +143,7 @@
               <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
               <info name="OpenCLPlatformDeviceIndex" value="2"/>
               <info name="OpenCLComputeUnits" value="56"/>
-              <info name="OpenCLGlobalMemorySize" value="16671616"/>
+              <info name="OpenCLGlobalMemorySize" value="16671616KiB"/>
             </object>
             <object type="OSDev" gp_index="334" id="obj334" name="nvml2" subtype="NVML" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
@@ -160,11 +160,11 @@
             <object type="OSDev" gp_index="331" id="obj331" name="cuda3" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla P100-SXM2-16GB"/>
-              <info name="CUDAGlobalMemorySize" value="16671616"/>
-              <info name="CUDAL2CacheSize" value="4096"/>
+              <info name="CUDAGlobalMemorySize" value="16671616KiB"/>
+              <info name="CUDAL2CacheSize" value="4096KiB"/>
               <info name="CUDAMultiProcessors" value="56"/>
               <info name="CUDACoresPerMP" value="64"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="327" id="obj327" name="opencl0d3" subtype="OpenCL" osdev_type="12">
               <info name="OpenCLDeviceType" value="GPU"/>
@@ -174,7 +174,7 @@
               <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
               <info name="OpenCLPlatformDeviceIndex" value="3"/>
               <info name="OpenCLComputeUnits" value="56"/>
-              <info name="OpenCLGlobalMemorySize" value="16671616"/>
+              <info name="OpenCLGlobalMemorySize" value="16671616KiB"/>
             </object>
             <object type="OSDev" gp_index="335" id="obj335" name="nvml3" subtype="NVML" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>

--- a/utils/hwloc/test-hwloc-annotate.output2
+++ b/utils/hwloc/test-hwloc-annotate.output2
@@ -38,11 +38,11 @@
             <object type="OSDev" gp_index="328" id="obj328" name="cuda0" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla P100-SXM2-16GB"/>
-              <info name="CUDAGlobalMemorySize" value="16671616"/>
-              <info name="CUDAL2CacheSize" value="4096"/>
+              <info name="CUDAGlobalMemorySize" value="16671616KiB"/>
+              <info name="CUDAL2CacheSize" value="4096KiB"/>
               <info name="CUDAMultiProcessors" value="56"/>
               <info name="CUDACoresPerMP" value="64"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="324" id="obj324" name="opencl0d0" subtype="OpenCL" osdev_type="12">
               <info name="OpenCLDeviceType" value="GPU"/>
@@ -52,7 +52,7 @@
               <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
               <info name="OpenCLPlatformDeviceIndex" value="0"/>
               <info name="OpenCLComputeUnits" value="56"/>
-              <info name="OpenCLGlobalMemorySize" value="16671616"/>
+              <info name="OpenCLGlobalMemorySize" value="16671616KiB"/>
             </object>
             <object type="OSDev" gp_index="332" id="obj332" name="nvml0" subtype="NVML" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
@@ -69,11 +69,11 @@
             <object type="OSDev" gp_index="329" id="obj329" name="cuda1" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla P100-SXM2-16GB"/>
-              <info name="CUDAGlobalMemorySize" value="16671616"/>
-              <info name="CUDAL2CacheSize" value="4096"/>
+              <info name="CUDAGlobalMemorySize" value="16671616KiB"/>
+              <info name="CUDAL2CacheSize" value="4096KiB"/>
               <info name="CUDAMultiProcessors" value="56"/>
               <info name="CUDACoresPerMP" value="64"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="325" id="obj325" name="opencl0d1" subtype="OpenCL" osdev_type="12">
               <info name="OpenCLDeviceType" value="GPU"/>
@@ -83,7 +83,7 @@
               <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
               <info name="OpenCLPlatformDeviceIndex" value="1"/>
               <info name="OpenCLComputeUnits" value="56"/>
-              <info name="OpenCLGlobalMemorySize" value="16671616"/>
+              <info name="OpenCLGlobalMemorySize" value="16671616KiB"/>
             </object>
             <object type="OSDev" gp_index="333" id="obj333" name="nvml1" subtype="NVML" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
@@ -129,11 +129,11 @@
             <object type="OSDev" gp_index="330" id="obj330" name="cuda2" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla P100-SXM2-16GB"/>
-              <info name="CUDAGlobalMemorySize" value="16671616"/>
-              <info name="CUDAL2CacheSize" value="4096"/>
+              <info name="CUDAGlobalMemorySize" value="16671616KiB"/>
+              <info name="CUDAL2CacheSize" value="4096KiB"/>
               <info name="CUDAMultiProcessors" value="56"/>
               <info name="CUDACoresPerMP" value="64"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="326" id="obj326" name="opencl0d2" subtype="OpenCL" osdev_type="12">
               <info name="OpenCLDeviceType" value="GPU"/>
@@ -143,7 +143,7 @@
               <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
               <info name="OpenCLPlatformDeviceIndex" value="2"/>
               <info name="OpenCLComputeUnits" value="56"/>
-              <info name="OpenCLGlobalMemorySize" value="16671616"/>
+              <info name="OpenCLGlobalMemorySize" value="16671616KiB"/>
             </object>
             <object type="OSDev" gp_index="334" id="obj334" name="nvml2" subtype="NVML" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
@@ -160,11 +160,11 @@
             <object type="OSDev" gp_index="331" id="obj331" name="cuda3" subtype="CUDA" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>
               <info name="GPUModel" value="Tesla P100-SXM2-16GB"/>
-              <info name="CUDAGlobalMemorySize" value="16671616"/>
-              <info name="CUDAL2CacheSize" value="4096"/>
+              <info name="CUDAGlobalMemorySize" value="16671616KiB"/>
+              <info name="CUDAL2CacheSize" value="4096KiB"/>
               <info name="CUDAMultiProcessors" value="56"/>
               <info name="CUDACoresPerMP" value="64"/>
-              <info name="CUDASharedMemorySizePerMP" value="48"/>
+              <info name="CUDASharedMemorySizePerMP" value="48KiB"/>
             </object>
             <object type="OSDev" gp_index="327" id="obj327" name="opencl0d3" subtype="OpenCL" osdev_type="12">
               <info name="OpenCLDeviceType" value="GPU"/>
@@ -174,7 +174,7 @@
               <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
               <info name="OpenCLPlatformDeviceIndex" value="3"/>
               <info name="OpenCLComputeUnits" value="56"/>
-              <info name="OpenCLGlobalMemorySize" value="16671616"/>
+              <info name="OpenCLGlobalMemorySize" value="16671616KiB"/>
             </object>
             <object type="OSDev" gp_index="335" id="obj335" name="nvml3" subtype="NVML" osdev_type="12">
               <info name="GPUVendor" value="NVIDIA Corporation"/>


### PR DESCRIPTION
All "...Size" info attributes (in OS device) are in KiB (except SectorSize). It's documented but may still be confusing since size structure fields (cache and memory sizes) are in bytes. Explicitly add "KiB" suffix the info attribute value.
Convert v2 strings on import. And v2 can still import those.
Apps shouldn't break unless they parsed using strtoul and checked the next character.
