### PR TITLE
hwloc-info improvements

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,8 @@ Version 3.0.0
 * Tools
   + lstopo has a new --osf option to tune the displaying of object
     attributes and units.
+  + hwloc-info --objects, --topology and --support are deprecated in
+    favor of passing levels, topology and support as targets.
 * Removed features
   + Netloc.
   + Importing and exporting from/to hwloc 1.x XML.

--- a/contrib/completion/bash/hwloc
+++ b/contrib/completion/bash/hwloc
@@ -1,5 +1,5 @@
 #
-# Copyright © 2018-2023 Inria.  All rights reserved.
+# Copyright © 2018-2024 Inria.  All rights reserved.
 # See COPYING in top-level directory.
 #
 
@@ -163,6 +163,7 @@ _hwloc_info(){
 		   --support
 		   -v --verbose
 		   -q --quiet -s --silent
+		   --get-attr
 		   --ancestors
 		   --ancestor
 		   --children
@@ -226,6 +227,9 @@ _hwloc_info(){
 		;;
 	    --best-memattr)
 		COMPREPLY=( "<memattr>" "" )
+		;;
+	    --get-attr)
+		COMPREPLY=( "<name>" "" )
 		;;
 	esac
     fi

--- a/utils/hwloc/hwloc-info.1in
+++ b/utils/hwloc/hwloc-info.1in
@@ -42,11 +42,14 @@ The list may also contain special keywords such as:
 
     \fBroot\fR for the topology root object.
 
-    \fBlevels\fR for information about topology levels (default if no target object is given, identical to \fB\-\-topology\fR).
+    \fBlevels\fR for information about topology levels (default if no target object is given, supersedes \fB\-\-topology\fR in hwloc 2.x).
 
-    \fBtopology\fR for info attributes attached to the topology (usually included in \fB\-\-topology \-v\fR).
+    \fBtopology\fR for info attributes attached to the topology (formerly included in \fB\-\-topology \-v\fR in hwloc 2.x).
 
-    \fBsupport\fR for information about supported features (identical to \fB\-\-support\fR).
+    \fBsupport\fR for information about supported features (supersedes \fB\-\-support\fR in hwloc 2.x).
+    The features are those available through the \fBhwloc_topology_get_support()\fR function.
+    This is useful for verifying which CPU or memory binding options are supported
+    by the current hwloc installation.
 
 Real targets and special keywords may be combined:
 
@@ -61,25 +64,6 @@ it should be read before reading this man page.
 .\" **************************
 .SH OPTIONS
 .
-.TP
-\fB\-\-objects\fR
-Report information specific objects.
-This is the default if some objects are given on the command-line.
-.TP
-\fB\-\-topology\fR
-Report a summary of the topology instead of about some specific objects.
-This is the default if no object is given on the command-line.
-This is equivalent to passing \fIlevels\fR as a target object on the command-line.
-
-If \-v is also given, topology info attributes are also shown.
-This is equivalent to passing \fIlevels topology\fR as a target object on the command-line.
-.TP
-\fB\-\-support\fR
-Report the features that are supported by hwloc on the topology.
-The features are those available through the \fBhwloc_topology_get_support()\fR function.
-This is useful for verifying which CPU or memory binding options are supported
-by the current hwloc installation.
-This is equivalent to passing \fIsupport\fR as a target object on the command-line.
 .TP
 \fB\-i\fR <path>, \fB\-\-input\fR <path>
 Read the topology from <path> instead of discovering the topology of the local machine.
@@ -304,9 +288,9 @@ Display help message and exit.
 hwloc-info displays information about the specified objects.
 It is intended to be used with tools such as grep for filtering
 certain attribute lines.
-When no object is specified, or when \fB\-\-topology\fR is passed,
-hwloc-info prints a summary of the topology.
-When \fB\-\-support\fR is passed, hwloc-info lists the supported
+When no object is specified, hwloc-info prints a summary of the topology
+(as if \fBlevels\fR was given).
+When \fBsupport\fR is given, hwloc-info lists the supported
 features for the topology.
 .
 .PP

--- a/utils/hwloc/hwloc-info.1in
+++ b/utils/hwloc/hwloc-info.1in
@@ -18,7 +18,10 @@ hwloc-info \- Show some information about some objects, a topology or supported 
 \fI<object>\fR...
 .PP
 .B hwloc-info
-[ \fIoptions \fR]...
+[ \fIoptions \fR] root
+.
+.B hwloc-info
+[ \fIoptions \fR] [ topology | levels | support ]
 .
 .PP
 \fI<object>\fR... may be a space-separated list of target objects to query.
@@ -39,6 +42,16 @@ The list may also contain special keywords such as:
 
     \fBroot\fR for the topology root object.
 
+    \fBlevels\fR for information about topology levels (default if no target object is given, identical to \fB\-\-topology\fR).
+
+    \fBtopology\fR for info attributes attached to the topology (usually included in \fB\-\-topology \-v\fR).
+
+    \fBsupport\fR for information about supported features (identical to \fB\-\-support\fR).
+
+Real targets and special keywords may be combined:
+
+    $ hwloc-info core:2 topology pu:3 levels
+
 .PP
 Note that hwloc(7) provides a detailed explanation of the hwloc system
 and of valid <object> formats;
@@ -56,13 +69,17 @@ This is the default if some objects are given on the command-line.
 \fB\-\-topology\fR
 Report a summary of the topology instead of about some specific objects.
 This is the default if no object is given on the command-line.
+This is equivalent to passing \fIlevels\fR as a target object on the command-line.
+
 If \-v is also given, topology info attributes are also shown.
+This is equivalent to passing \fIlevels topology\fR as a target object on the command-line.
 .TP
 \fB\-\-support\fR
 Report the features that are supported by hwloc on the topology.
 The features are those available through the \fBhwloc_topology_get_support()\fR function.
 This is useful for verifying which CPU or memory binding options are supported
 by the current hwloc installation.
+This is equivalent to passing \fIsupport\fR as a target object on the command-line.
 .TP
 \fB\-i\fR <path>, \fB\-\-input\fR <path>
 Read the topology from <path> instead of discovering the topology of the local machine.
@@ -351,9 +368,9 @@ to find where a NUMA node is attached in the hierarchy of CPU cores:
     $ hwloc-info --ancestor kind=normal --first -s numa:1
     Package:0
 
-To see info attributes of the topology:
+To see levels and info attributes of the topology:
 
-    $ hwloc-info --topology --verbose
+    $ hwloc-info levels topology
     depth 0:           1 Machine (type #0)
      depth 1:          1 Package (type #1)
       depth 2:         2 Core (type #2)

--- a/utils/hwloc/hwloc-info.1in
+++ b/utils/hwloc/hwloc-info.1in
@@ -98,6 +98,17 @@ Include additional detail.
 Reduce the amount of details to show.
 A single summary line per object is displayed.
 .TP
+\fB\-\-get\-attr\fR <name>
+Only report the attribute of name <name> for each object (instead of all attributes).
+The name must exactly match what is usually reported by the program,
+for instance "complete cpuset" in "0.1: complete cpuset = %0x00ffff00".
+
+Only the value is reported, any other prefix or object name is ignored,
+so that the output may easily be used by other tools.
+
+This option also works on topology information but it is ignored for
+\fBlevels\fR and \fBsupport\fR keywords.
+.TP
 \fB\-\-ancestors\fR
 Display information about the object as well as
 about all its ancestors up to the root of the topology.
@@ -329,6 +340,12 @@ To list the OS devices that are of subtype OpenCL:
     $ hwloc-info -s "os[OpenCL]:all"
     OSDev[Co-Processor,GPU]:6
     OSDev[Co-Processor,GPU]:8
+
+To find the PCI bus ID of PCI devices containing OpenCL devices:
+
+    $ hwloc-info --ancestor PCI --get-attr "attr PCI bus id" 'os[opencl]:all'
+    0000:05:00.0
+    0000:42:00.0
 
 To list the NUMA nodes that are local a PU:
 

--- a/utils/hwloc/hwloc-info.1in
+++ b/utils/hwloc/hwloc-info.1in
@@ -5,7 +5,7 @@
 .\" See COPYING in top-level directory.
 .TH HWLOC-INFO "1" "%HWLOC_DATE%" "%PACKAGE_VERSION%" "%PACKAGE_NAME%"
 .SH NAME
-hwloc-info \- Show some information about some objects or about a topology or about support features
+hwloc-info \- Show some information about some objects, a topology or supported features
 .
 .\" **************************
 .\"    Synopsis Section
@@ -20,6 +20,25 @@ hwloc-info \- Show some information about some objects or about a topology or ab
 .B hwloc-info
 [ \fIoptions \fR]...
 .
+.PP
+\fI<object>\fR... may be a space-separated list of target objects to query.
+The program reports all information about one object before looking at the next one:
+
+    $ hwloc-info core:2 package:1 pu:all
+    Core L#2
+     type = Core
+     ...
+    Package L#1
+     ...
+    PU L#0
+     ...
+    PU L#1
+     ...
+
+The list may also contain special keywords such as:
+
+    \fBroot\fR for the topology root object.
+
 .PP
 Note that hwloc(7) provides a detailed explanation of the hwloc system
 and of valid <object> formats;
@@ -265,7 +284,7 @@ Display help message and exit.
 .\" **************************
 .SH DESCRIPTION
 .
-hwloc-info displays information about the specified object.
+hwloc-info displays information about the specified objects.
 It is intended to be used with tools such as grep for filtering
 certain attribute lines.
 When no object is specified, or when \fB\-\-topology\fR is passed,

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -90,9 +90,6 @@ void usage(const char *name, FILE *where)
 {
   fprintf (where, "Usage: %s [ options ] [ object | root | levels | topology | support ... ]\n", name);
   fprintf (where, "\nOutput options:\n");
-  fprintf (where, "  --objects             Report information about specific objects\n");
-  fprintf (where, "  --topology            Report information the topology\n");
-  fprintf (where, "  --support             Report information about supported features\n");
   fprintf (where, "  -v --verbose          Include additional details\n");
   fprintf (where, "  -q --quiet -s         Reduce the amount of details to show\n");
   fprintf (where, "  --ancestors           Display the chain of ancestor objects up to the root\n");
@@ -744,11 +741,11 @@ main (int argc, char *argv[])
   while (argc >= 1) {
     opt = 0;
     if (*argv[0] == '-') {
-      if (!strcmp (argv[0], "--objects"))
+      if (!strcmp (argv[0], "--objects")) /* backward compat with v2 */
 	mode = HWLOC_INFO_MODE_OBJECTS;
-      else if (!strcmp (argv[0], "--topology"))
+      else if (!strcmp (argv[0], "--topology")) /* backward compat with v2 */
 	mode = HWLOC_INFO_MODE_TOPOLOGY;
-      else if (!strcmp (argv[0], "--support"))
+      else if (!strcmp (argv[0], "--support")) /* backward compat with v2 */
 	mode = HWLOC_INFO_MODE_SUPPORT;
       else if (!strcmp (argv[0], "-v") || !strcmp (argv[0], "--verbose"))
         verbose_mode++;

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -630,6 +630,74 @@ hwloc_calc_process_location_info_cb(struct hwloc_calc_location_context_s *lconte
   current_obj++;
 }
 
+static void
+hwloc_info_show_levels(FILE *output, hwloc_topology_t topology)
+{
+  hwloc_lstopo_show_summary(output, topology);
+}
+
+static void
+hwloc_info_show_topology_infos(hwloc_topology_t topology)
+{
+  struct hwloc_infos_s *infos = hwloc_topology_get_infos(topology);
+  unsigned i;
+  for(i=0; i<infos->count; i++)
+    printf("info %s = %s\n", infos->array[i].name, infos->array[i].value);
+}
+
+static void
+hwloc_info_show_support(hwloc_topology_t topology)
+{
+  const struct hwloc_topology_support *support = hwloc_topology_get_support(topology);
+
+#ifdef HWLOC_DEBUG
+  HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_support) == 4*sizeof(void*));
+  HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_discovery_support) == 6);
+  HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_cpubind_support) == 11);
+  HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_membind_support) == 15);
+  HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_misc_support) == 1);
+#endif
+
+#define DO(x,y) printf(#x ":" #y " = %u\n", (unsigned char) support->x->y);
+  DO(discovery, pu);
+  DO(discovery, disallowed_pu);
+  DO(discovery, numa);
+  DO(discovery, numa_memory);
+  DO(discovery, disallowed_numa);
+  DO(discovery, cpukind_efficiency);
+
+  DO(cpubind, set_thisproc_cpubind);
+  DO(cpubind, get_thisproc_cpubind);
+  DO(cpubind, set_proc_cpubind);
+  DO(cpubind, get_proc_cpubind);
+  DO(cpubind, set_thisthread_cpubind);
+  DO(cpubind, get_thisthread_cpubind);
+  DO(cpubind, set_thread_cpubind);
+  DO(cpubind, get_thread_cpubind);
+  DO(cpubind, get_thisproc_last_cpu_location);
+  DO(cpubind, get_proc_last_cpu_location);
+  DO(cpubind, get_thisthread_last_cpu_location);
+
+  DO(membind, set_thisproc_membind);
+  DO(membind, get_thisproc_membind);
+  DO(membind, set_proc_membind);
+  DO(membind, get_proc_membind);
+  DO(membind, set_thisthread_membind);
+  DO(membind, get_thisthread_membind);
+  DO(membind, set_area_membind);
+  DO(membind, get_area_membind);
+  DO(membind, alloc_membind);
+  DO(membind, firsttouch_membind);
+  DO(membind, bind_membind);
+  DO(membind, interleave_membind);
+  DO(membind, nexttouch_membind);
+  DO(membind, migrate_membind);
+  DO(membind, get_area_memlocation);
+
+  DO(misc, imported_support);
+#undef DO
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -976,63 +1044,12 @@ main (int argc, char *argv[])
   }
 
   if (mode == HWLOC_INFO_MODE_TOPOLOGY) {
-    hwloc_lstopo_show_summary(stdout, topology);
-    if (verbose_mode > 0) {
-      struct hwloc_infos_s *infos = hwloc_topology_get_infos(topology);
-      unsigned i;
-      for(i=0; i<infos->count; i++)
-        printf("info %s = %s\n", infos->array[i].name, infos->array[i].value);
-    }
+    hwloc_info_show_levels(stdout, topology);
+    if (verbose_mode > 0)
+      hwloc_info_show_topology_infos(topology);
 
   } else if (mode == HWLOC_INFO_MODE_SUPPORT) {
-    const struct hwloc_topology_support *support = hwloc_topology_get_support(topology);
-
-#ifdef HWLOC_DEBUG
-    HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_support) == 4*sizeof(void*));
-    HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_discovery_support) == 6);
-    HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_cpubind_support) == 11);
-    HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_membind_support) == 15);
-    HWLOC_BUILD_ASSERT(sizeof(struct hwloc_topology_misc_support) == 1);
-#endif
-
-#define DO(x,y) printf(#x ":" #y " = %u\n", (unsigned char) support->x->y);
-    DO(discovery, pu);
-    DO(discovery, disallowed_pu);
-    DO(discovery, numa);
-    DO(discovery, numa_memory);
-    DO(discovery, disallowed_numa);
-    DO(discovery, cpukind_efficiency);
-
-    DO(cpubind, set_thisproc_cpubind);
-    DO(cpubind, get_thisproc_cpubind);
-    DO(cpubind, set_proc_cpubind);
-    DO(cpubind, get_proc_cpubind);
-    DO(cpubind, set_thisthread_cpubind);
-    DO(cpubind, get_thisthread_cpubind);
-    DO(cpubind, set_thread_cpubind);
-    DO(cpubind, get_thread_cpubind);
-    DO(cpubind, get_thisproc_last_cpu_location);
-    DO(cpubind, get_proc_last_cpu_location);
-    DO(cpubind, get_thisthread_last_cpu_location);
-
-    DO(membind, set_thisproc_membind);
-    DO(membind, get_thisproc_membind);
-    DO(membind, set_proc_membind);
-    DO(membind, get_proc_membind);
-    DO(membind, set_thisthread_membind);
-    DO(membind, get_thisthread_membind);
-    DO(membind, set_area_membind);
-    DO(membind, get_area_membind);
-    DO(membind, alloc_membind);
-    DO(membind, firsttouch_membind);
-    DO(membind, bind_membind);
-    DO(membind, interleave_membind);
-    DO(membind, nexttouch_membind);
-    DO(membind, migrate_membind);
-    DO(membind, get_area_memlocation);
-
-    DO(misc, imported_support);
-#undef DO
+    hwloc_info_show_support(topology);
 
   } else if (mode == HWLOC_INFO_MODE_OBJECTS) {
     struct hwloc_calc_location_context_s lcontext;

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -88,7 +88,7 @@ static unsigned current_obj;
 
 void usage(const char *name, FILE *where)
 {
-  fprintf (where, "Usage: %s [ options ] [ object | root ... ]\n", name);
+  fprintf (where, "Usage: %s [ options ] [ object | root | levels | topology | support ... ]\n", name);
   fprintf (where, "\nOutput options:\n");
   fprintf (where, "  --objects             Report information about specific objects\n");
   fprintf (where, "  --topology            Report information the topology\n");
@@ -1060,7 +1060,13 @@ main (int argc, char *argv[])
     lcontext.verbose = verbose_mode;
     current_obj = 0;
     while (argc >= 1) {
-      if (!strcmp(argv[0], "all") || !strcmp(argv[0], "root")) {
+      if (!strcmp(argv[0], "levels")) {
+        hwloc_info_show_levels(stdout, topology);
+      } else if (!strcmp(argv[0], "topology")) {
+        hwloc_info_show_topology_infos(topology);
+      } else if (!strcmp(argv[0], "support")) {
+        hwloc_info_show_support(topology);
+      } else if (!strcmp(argv[0], "all") || !strcmp(argv[0], "root")) {
 	hwloc_calc_process_location_info_cb(&lcontext, NULL, hwloc_get_root_obj(topology));
       } else if (*argv[0] == '-') {
         fprintf(stderr, "Cannot handle command-line option %s after some locations.\n", argv[0]);

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2009 CNRS
- * Copyright © 2009-2023 Inria.  All rights reserved.
+ * Copyright © 2009-2024 Inria.  All rights reserved.
  * Copyright © 2009-2012 Université Bordeaux
  * Copyright © 2009-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright © 2023 Université de Reims Champagne-Ardenne.  All rights reserved.
@@ -88,7 +88,7 @@ static unsigned current_obj;
 
 void usage(const char *name, FILE *where)
 {
-  fprintf (where, "Usage: %s [ options ] [ locations ]\n", name);
+  fprintf (where, "Usage: %s [ options ] [ object | root ... ]\n", name);
   fprintf (where, "\nOutput options:\n");
   fprintf (where, "  --objects             Report information about specific objects\n");
   fprintf (where, "  --topology            Report information the topology\n");

--- a/utils/hwloc/hwloc-info.c
+++ b/utils/hwloc/hwloc-info.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 #include <fcntl.h>
 #include <assert.h>
 
@@ -126,62 +127,85 @@ void usage(const char *name, FILE *where)
 }
 
 static void
+hwloc_info_show_attr(const char *prefix, const char *name, const char *value)
+{
+  printf("%s %s = %s\n", prefix, name, value);
+}
+
+static void
 hwloc_info_show_obj(hwloc_topology_t topology, hwloc_obj_t obj, const char *type, const char *prefix, int verbose)
 {
-  char s[128];
+  char name[512], value[512];
   unsigned i;
   if (verbose < 0)
     return;
-  printf("%s type = %s\n", prefix, hwloc_obj_type_string(obj->type));
-  printf("%s full type = %s\n", prefix, type);
+
+  hwloc_info_show_attr(prefix, "type", hwloc_obj_type_string(obj->type));
+  hwloc_info_show_attr(prefix, "full type", type);
   if (obj->subtype)
-    printf("%s subtype = %s\n", prefix, obj->subtype);
-  printf("%s logical index = %u\n", prefix, obj->logical_index);
-  if (obj->os_index != (unsigned) -1)
-    printf("%s os index = %u\n", prefix, obj->os_index);
-  printf("%s gp index = %llu\n", prefix, (unsigned long long) obj->gp_index);
+    hwloc_info_show_attr(prefix, "subtype", obj->subtype);
+
+  snprintf(value, sizeof(value), "%u", obj->logical_index);
+  hwloc_info_show_attr(prefix, "logical index", value);
+  if (obj->os_index != (unsigned) -1) {
+    snprintf(value, sizeof(value), "%u", obj->os_index);
+    hwloc_info_show_attr(prefix, "os index", value);
+  }
+  snprintf(value, sizeof(value), "%llu", (unsigned long long) obj->gp_index);
+  hwloc_info_show_attr(prefix, "gp index", value);
+
   if (obj->name)
-    printf("%s name = %s\n", prefix, obj->name);
-  printf("%s depth = %d\n", prefix, obj->depth);
-  printf("%s sibling rank = %u\n", prefix, obj->sibling_rank);
-  printf("%s children = %u\n", prefix, obj->arity);
-  printf("%s memory children = %u\n", prefix, obj->memory_arity);
-  printf("%s i/o children = %u\n", prefix, obj->io_arity);
-  printf("%s misc children = %u\n", prefix, obj->misc_arity);
+    hwloc_info_show_attr(prefix, "name", obj->name);
+
+  snprintf(value, sizeof(value), "%d", obj->depth);
+  hwloc_info_show_attr(prefix, "depth", value);
+  snprintf(value, sizeof(value), "%u", obj->sibling_rank);
+  hwloc_info_show_attr(prefix, "sibling rank", value);
+  snprintf(value, sizeof(value), "%u", obj->arity);
+  hwloc_info_show_attr(prefix, "children", value);
+  snprintf(value, sizeof(value), "%u", obj->memory_arity);
+  hwloc_info_show_attr(prefix, "memory children", value);
+  snprintf(value, sizeof(value), "%u", obj->io_arity);
+  hwloc_info_show_attr(prefix, "i/o children", value);
+  snprintf(value, sizeof(value), "%u", obj->misc_arity);
+  hwloc_info_show_attr(prefix, "misc children", value);
 
   if (obj->type == HWLOC_OBJ_NUMANODE) {
-    printf("%s local memory = %llu\n", prefix, (unsigned long long) obj->attr->numanode.local_memory);
+    snprintf(value, sizeof(value), "%llu", (unsigned long long) obj->attr->numanode.local_memory);
+    hwloc_info_show_attr(prefix, "local memory", value);
   }
-  if (obj->total_memory)
-    printf("%s total memory = %llu\n", prefix, (unsigned long long) obj->total_memory);
+  if (obj->total_memory) {
+    snprintf(value, sizeof(value), "%llu", (unsigned long long) obj->total_memory);
+    hwloc_info_show_attr(prefix, "total memory", value);
+  }
 
   if (obj->cpuset) {
-    hwloc_bitmap_snprintf(s, sizeof(s), obj->cpuset);
-    printf("%s cpuset = %s\n", prefix, s);
+    hwloc_bitmap_snprintf(value, sizeof(value), obj->cpuset);
+    hwloc_info_show_attr(prefix, "cpuset", value);
 
-    hwloc_bitmap_snprintf(s, sizeof(s), obj->complete_cpuset);
-    printf("%s complete cpuset = %s\n", prefix, s);
+    hwloc_bitmap_snprintf(value, sizeof(value), obj->complete_cpuset);
+    hwloc_info_show_attr(prefix, "complete cpuset", value);
 
     {
       hwloc_bitmap_t allowed_cpuset = hwloc_bitmap_dup(obj->cpuset);
       hwloc_bitmap_and(allowed_cpuset, allowed_cpuset, hwloc_topology_get_allowed_cpuset(topology));
-      hwloc_bitmap_snprintf(s, sizeof(s), allowed_cpuset);
+      hwloc_bitmap_snprintf(value, sizeof(value), allowed_cpuset);
       hwloc_bitmap_free(allowed_cpuset);
-      printf("%s allowed cpuset = %s\n", prefix, s);
+      hwloc_info_show_attr(prefix, "allowed cpuset", value);
     }
 
-    hwloc_bitmap_snprintf(s, sizeof(s), obj->nodeset);
-    printf("%s nodeset = %s\n", prefix, s);
+    hwloc_bitmap_snprintf(value, sizeof(value), obj->nodeset);
+    hwloc_info_show_attr(prefix, "nodeset", value);
 
-    hwloc_bitmap_snprintf(s, sizeof(s), obj->complete_nodeset);
-    printf("%s complete nodeset = %s\n", prefix, s);
+    hwloc_bitmap_snprintf(value, sizeof(value), obj->complete_nodeset);
+    hwloc_info_show_attr(prefix, "complete nodeset", value);
 
     {
       hwloc_bitmap_t allowed_nodeset = hwloc_bitmap_dup(obj->nodeset);
       hwloc_bitmap_and(allowed_nodeset, allowed_nodeset, hwloc_topology_get_allowed_nodeset(topology));
-      hwloc_bitmap_snprintf(s, sizeof(s), allowed_nodeset);
+      hwloc_bitmap_snprintf(value, sizeof(value), allowed_nodeset);
       hwloc_bitmap_free(allowed_nodeset);
-      printf("%s allowed nodeset = %s\n", prefix, s);
+      hwloc_info_show_attr(prefix, "allowed nodeset", value);
     }
   }
 
@@ -195,74 +219,88 @@ hwloc_info_show_obj(hwloc_topology_t topology, hwloc_obj_t obj, const char *type
   case HWLOC_OBJ_L2ICACHE:
   case HWLOC_OBJ_L3ICACHE:
   case HWLOC_OBJ_MEMCACHE:
-    printf("%s attr cache depth = %u\n", prefix, obj->attr->cache.depth);
+    snprintf(value, sizeof(value), "%u", obj->attr->cache.depth);
+    hwloc_info_show_attr(prefix, "attr cache depth", value);
     switch (obj->attr->cache.type) {
-    case HWLOC_OBJ_CACHE_UNIFIED: printf("%s attr cache type = Unified\n", prefix); break;
-    case HWLOC_OBJ_CACHE_DATA: printf("%s attr cache type = Data\n", prefix); break;
-    case HWLOC_OBJ_CACHE_INSTRUCTION: printf("%s attr cache type = Instruction\n", prefix); break;
+    case HWLOC_OBJ_CACHE_UNIFIED: hwloc_info_show_attr(prefix, "attr cache type", "Unified"); break;
+    case HWLOC_OBJ_CACHE_DATA: hwloc_info_show_attr(prefix, "attr cache type", "Data"); break;
+    case HWLOC_OBJ_CACHE_INSTRUCTION: hwloc_info_show_attr(prefix, "attr cache type", "Instruction"); break;
     }
-    printf("%s attr cache size = %llu\n", prefix, (unsigned long long) obj->attr->cache.size);
-    printf("%s attr cache line size = %u\n", prefix, obj->attr->cache.linesize);
-    if (obj->attr->cache.associativity == -1)
-      printf("%s attr cache ways = Fully-associative\n", prefix);
-    else if (obj->attr->cache.associativity != 0)
-      printf("%s attr cache ways = %d\n", prefix, obj->attr->cache.associativity);
+    snprintf(value, sizeof(value), "%llu", (unsigned long long) obj->attr->cache.size);
+    hwloc_info_show_attr(prefix, "attr cache size", value);
+    snprintf(value, sizeof(value), "%u", obj->attr->cache.linesize);
+    hwloc_info_show_attr(prefix, "attr cache line size", value);
+    if (obj->attr->cache.associativity == -1) {
+      hwloc_info_show_attr(prefix, "attr cache line ways", "Fully-associative");
+    } else if (obj->attr->cache.associativity != 0) {
+      snprintf(value, sizeof(value), "%d", obj->attr->cache.associativity);
+      hwloc_info_show_attr(prefix, "attr cache line ways", value);
+    }
     break;
   case HWLOC_OBJ_GROUP:
-    printf("%s attr group depth = %u\n", prefix, obj->attr->group.depth);
+    snprintf(value, sizeof(value), "%u", obj->attr->group.depth);
+    hwloc_info_show_attr(prefix, "attr group depth", value);
     break;
   case HWLOC_OBJ_BRIDGE:
     switch (obj->attr->bridge.upstream_type) {
     case HWLOC_OBJ_BRIDGE_HOST:
-      printf("%s attr bridge upstream type = Host\n", prefix);
+      hwloc_info_show_attr(prefix, "attr bridge upstream type", "Host");
       break;
     case HWLOC_OBJ_BRIDGE_PCI:
-      printf("%s attr bridge upstream type = PCI\n", prefix);
-      printf("%s attr PCI bus id = %04x:%02x:%02x.%01x\n",
-	     prefix, obj->attr->pcidev.domain, obj->attr->pcidev.bus, obj->attr->pcidev.dev, obj->attr->pcidev.func);
-      printf("%s attr PCI class = %04x\n",
-	     prefix, obj->attr->pcidev.class_id);
-      printf("%s attr PCI id = %04x:%04x\n",
-	     prefix, obj->attr->pcidev.vendor_id, obj->attr->pcidev.device_id);
-      if (obj->attr->pcidev.linkspeed)
-	printf("%s attr PCI linkspeed = %f GB/s\n", prefix, obj->attr->pcidev.linkspeed);
+      hwloc_info_show_attr(prefix, "attr bridge upstream type", "PCI");
+      snprintf(value, sizeof(value), "%04x:%02x:%02x.%01x",
+               obj->attr->pcidev.domain, obj->attr->pcidev.bus, obj->attr->pcidev.dev, obj->attr->pcidev.func);
+      hwloc_info_show_attr(prefix, "attr PCI bus id", value);
+      snprintf(value, sizeof(value), "%04x", obj->attr->pcidev.class_id);
+      hwloc_info_show_attr(prefix, "attr PCI class", value);
+      snprintf(value, sizeof(value), "%04x:%04x", obj->attr->pcidev.vendor_id, obj->attr->pcidev.device_id);
+      hwloc_info_show_attr(prefix, "attr PCI id", value);
+      if (obj->attr->pcidev.linkspeed) {
+	snprintf(value, sizeof(value), "%f GB/s\n", obj->attr->pcidev.linkspeed);
+        hwloc_info_show_attr(prefix, "attr PCI linkspeed", value);
+      }
       break;
     }
     switch (obj->attr->bridge.downstream_type) {
     case HWLOC_OBJ_BRIDGE_HOST:
       assert(0);
     case HWLOC_OBJ_BRIDGE_PCI:
-      printf("%s attr bridge downstream type = PCI\n", prefix);
-      printf("%s attr PCI secondary bus = %02x\n",
-	     prefix, obj->attr->bridge.downstream.pci.secondary_bus);
-      printf("%s attr PCI subordinate bus = %02x\n",
-	     prefix, obj->attr->bridge.downstream.pci.subordinate_bus);
+      hwloc_info_show_attr(prefix, "attr bridge downstream type", "PCI");
+      snprintf(value, sizeof(value), "%02x", obj->attr->bridge.downstream.pci.secondary_bus);
+      hwloc_info_show_attr(prefix, "attr PCI secondary bus bus", value);
+      snprintf(value, sizeof(value), "%02x", obj->attr->bridge.downstream.pci.subordinate_bus);
+      hwloc_info_show_attr(prefix, "attr PCI subordinate bus bus", value);
       break;
     }
     break;
   case HWLOC_OBJ_PCI_DEVICE:
-    printf("%s attr PCI bus id = %04x:%02x:%02x.%01x\n",
-	   prefix, obj->attr->pcidev.domain, obj->attr->pcidev.bus, obj->attr->pcidev.dev, obj->attr->pcidev.func);
-    printf("%s attr PCI class = %04x\n",
-	   prefix, obj->attr->pcidev.class_id);
-    printf("%s attr PCI id = %04x:%04x\n",
-	   prefix, obj->attr->pcidev.vendor_id, obj->attr->pcidev.device_id);
-    if (obj->attr->pcidev.linkspeed)
-      printf("%s attr PCI linkspeed = %f GB/s\n", prefix, obj->attr->pcidev.linkspeed);
+    snprintf(value, sizeof(value), "%04x:%02x:%02x.%01x",
+             obj->attr->pcidev.domain, obj->attr->pcidev.bus, obj->attr->pcidev.dev, obj->attr->pcidev.func);
+    hwloc_info_show_attr(prefix, "attr PCI bus id", value);
+    snprintf(value, sizeof(value), "%04x", obj->attr->pcidev.class_id);
+    hwloc_info_show_attr(prefix, "attr PCI class", value);
+    snprintf(value, sizeof(value), "%04x:%04x", obj->attr->pcidev.vendor_id, obj->attr->pcidev.device_id);
+    hwloc_info_show_attr(prefix, "attr PCI id", value);
+    if (obj->attr->pcidev.linkspeed) {
+      snprintf(value, sizeof(value), "%f GB/s\n", obj->attr->pcidev.linkspeed);
+      hwloc_info_show_attr(prefix, "attr PCI linkspeed", value);
+    }
     break;
   case HWLOC_OBJ_OS_DEVICE:
-    printf("%s attr osdev type = %s\n", prefix, type);
+    hwloc_info_show_attr(prefix, "attr osdev type", type);
     break;
   default:
     /* nothing to show */
     break;
   }
 
-  printf("%s symmetric subtree = %d\n", prefix, obj->symmetric_subtree);
+  snprintf(value, sizeof(value), "%d", obj->symmetric_subtree);
+  hwloc_info_show_attr(prefix, "symmetric subtree", value);
 
   for(i=0; i<obj->infos.count; i++) {
     struct hwloc_info_s *info = &obj->infos.array[i];
-    printf("%s info %s = %s\n", prefix, info->name, info->value);
+    snprintf(name, sizeof(name), "info %s", info->name);
+    hwloc_info_show_attr(prefix, name, info->value);
   }
 
   if (hwloc_obj_type_is_normal(obj->type)) {
@@ -280,14 +318,16 @@ hwloc_info_show_obj(hwloc_topology_t topology, hwloc_obj_t obj, const char *type
         partial = 1;
       else
         continue;
-      printf("%s cpukind = %u%s\n",
-             prefix, i, partial ? " (partially)" : "");
-      if (efficiency != -1)
-        printf("%s cpukind efficiency = %d\n",
-               prefix, efficiency);
-      for(j=0; j<infosp->count; j++)
-        printf("%s cpukind info %s = %s\n",
-               prefix, infosp->array[j].name, infosp->array[j].value);
+      snprintf(value, sizeof(value), "%u%s", i, partial ? " (partially)" : "");
+      hwloc_info_show_attr(prefix, "cpukind", value);
+      if (efficiency != -1) {
+        snprintf(value, sizeof(value), "%d", efficiency);
+        hwloc_info_show_attr(prefix, "cpukind efficiency", value);
+      }
+      for(j=0; j<infosp->count; j++) {
+        snprintf(name, sizeof(name), "cpukind info %s", infosp->array[j].name);
+        hwloc_info_show_attr(prefix, name, infosp->array[j].value);
+      }
     }
     hwloc_bitmap_free(cpuset);
   }
@@ -298,22 +338,24 @@ hwloc_info_show_obj(hwloc_topology_t topology, hwloc_obj_t obj, const char *type
      */
     unsigned id;
     for(id=0; ; id++) {
-      const char *name;
+      const char *mname;
       unsigned long flags;
       int err;
 
-      err = hwloc_memattr_get_name(topology, id, &name);
+      err = hwloc_memattr_get_name(topology, id, &mname);
       if (err < 0)
         break;
       err = hwloc_memattr_get_flags(topology, id, &flags);
       assert(!err);
 
       if (!(flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR)) {
-        hwloc_uint64_t value;
-        err = hwloc_memattr_get_value(topology, id, obj, NULL, 0, &value);
-        if (!err)
-          printf("%s memory attribute %s = %llu\n",
-                 prefix, name, (unsigned long long) value);
+        hwloc_uint64_t mvalue;
+        err = hwloc_memattr_get_value(topology, id, obj, NULL, 0, &mvalue);
+        if (!err) {
+          snprintf(name, sizeof(name), "memory attribute %s", mname);
+          snprintf(value, sizeof(value), "%llu", (unsigned long long) mvalue);
+          hwloc_info_show_attr(prefix, name, value);
+        }
       } else {
         unsigned nr_initiators = 0;
         err = hwloc_memattr_get_initiators(topology, id, obj, 0, &nr_initiators, NULL, NULL);
@@ -339,8 +381,9 @@ hwloc_info_show_obj(hwloc_topology_t topology, hwloc_obj_t obj, const char *type
                 } else {
                   assert(0);
                 }
-                printf("%s memory attribute %s from initiator %s = %llu\n",
-                       prefix, name, inits, (unsigned long long) values[j]);
+                snprintf(name, sizeof(name), "memory attribute %s from initiator %s", mname, inits);
+                snprintf(value, sizeof(value), "%llu", (unsigned long long) values[j]);
+                hwloc_info_show_attr(prefix, name, value);
                 if (inits != _inits)
                   free(inits);
               }

--- a/utils/hwloc/test-hwloc-info.output
+++ b/utils/hwloc/test-hwloc-info.output
@@ -9,6 +9,9 @@ Special depth -3:  2 NUMANode (type #13)
 info Backend = Synthetic
 info SyntheticDescription = node:2 core:3 pu:4
 
+# topology infos --get-attr
+node:2 core:3 pu:4
+
 # levels support
 depth 0:           1 Machine (type #0)
  depth 1:          2 Group0 (type #12)
@@ -398,6 +401,10 @@ L1dCache:5
 # Where a NUMA is attached
 L3Cache:1
 Package:2
+
+# Allowed cpuset of where NUMA is attached
+0x0000ff00
+0x0000ffff,0x0
 
 # Children of L2 and Core of Node, silent
 L1dCache:2

--- a/utils/hwloc/test-hwloc-info.output
+++ b/utils/hwloc/test-hwloc-info.output
@@ -5,16 +5,16 @@ depth 0:           1 Machine (type #0)
    depth 3:        24 PU (type #3)
 Special depth -3:  2 NUMANode (type #13)
 
-# --topology --verbose
+# topology infos
+info Backend = Synthetic
+info SyntheticDescription = node:2 core:3 pu:4
+
+# levels support
 depth 0:           1 Machine (type #0)
  depth 1:          2 Group0 (type #12)
   depth 2:         6 Core (type #2)
    depth 3:        24 PU (type #3)
 Special depth -3:  2 NUMANode (type #13)
-info Backend = Synthetic
-info SyntheticDescription = node:2 core:3 pu:4
-
-# --support
 discovery:pu = 1
 discovery:disallowed_pu = 0
 discovery:numa = 1
@@ -48,8 +48,6 @@ membind:nexttouch_membind = 0
 membind:migrate_membind = 0
 membind:get_area_memlocation = 0
 misc:imported_support = 0
-
-# --objects
 
 # Core range
 Core L#2

--- a/utils/hwloc/test-hwloc-info.sh.in
+++ b/utils/hwloc/test-hwloc-info.sh.in
@@ -46,6 +46,9 @@ set -e
   echo "# topology infos"
   $info --if synthetic --input "node:2 core:3 pu:4" topology | grep -v hwlocVersion | grep -v ProcessName
   echo
+  echo "# topology infos --get-attr"
+  $info --if synthetic --input "node:2 core:3 pu:4" --get-attr "info SyntheticDescription" topology
+  echo
   echo "# levels support"
   $info --if synthetic --input "node:2 core:3 pu:4" levels support
   echo
@@ -77,6 +80,9 @@ set -e
   echo
   echo "# Where a NUMA is attached"
   $info --if synthetic --input "pack:4 [numa] l3:2 [numa] [numa] core:4 pu:2" --ancestor kind=normal --first -s numa:3 numa:14
+  echo
+  echo "# Allowed cpuset of where NUMA is attached"
+  $info --if synthetic --input "pack:4 [numa] l3:2 [numa] [numa] core:4 pu:2" --ancestor kind=normal --first --get-attr "allowed cpuset" numa:3 numa:14
   echo
 
   echo "# Children of L2 and Core of Node, silent"

--- a/utils/hwloc/test-hwloc-info.sh.in
+++ b/utils/hwloc/test-hwloc-info.sh.in
@@ -3,7 +3,7 @@
 
 #
 # Copyright © 2009 CNRS
-# Copyright © 2009-2023 Inria.  All rights reserved.
+# Copyright © 2009-2024 Inria.  All rights reserved.
 # Copyright © 2009 Université Bordeaux
 # Copyright © 2014 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
@@ -43,14 +43,11 @@ set -e
   echo "# (default)"
   $info --if synthetic --input "node:2 core:3 pu:4"
   echo
-  echo "# --topology --verbose"
-  $info --if synthetic --input "node:2 core:3 pu:4" --topology --verbose | grep -v hwlocVersion | grep -v ProcessName
+  echo "# topology infos"
+  $info --if synthetic --input "node:2 core:3 pu:4" topology | grep -v hwlocVersion | grep -v ProcessName
   echo
-  echo "# --support"
-  $info --if synthetic --input "node:2 core:3 pu:4" --support
-  echo
-  echo "# --objects"
-  $info --if synthetic --input "node:2 core:3 pu:4" --objects
+  echo "# levels support"
+  $info --if synthetic --input "node:2 core:3 pu:4" levels support
   echo
 
   echo "# Core range"


### PR DESCRIPTION
Add keywords to query levels, support and topo info just like other objects, depreate --objects/--topology/--support.
Add --get-attr to get a single info.