### PR TITLE
fix#676 use hwloc_access instead of hwloc_accessat

### DIFF
--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -2287,17 +2287,17 @@ hwloc_find_linux_cgroup_mntpnt(enum hwloc_linux_cgroup_type_e *cgtype, char **mn
   size_t bufsize;
 
   /* try standard mount points */
-  if (!hwloc_accessat("/sys/fs/cgroup/cpuset.cpus.effective", R_OK, fsroot_fd)) {
+  if (!hwloc_access("/sys/fs/cgroup/cpuset.cpus.effective", R_OK, fsroot_fd)) {
     hwloc_debug("Found standard cgroup2/cpuset mount point at /sys/fs/cgroup/\n");
     *cgtype = HWLOC_LINUX_CGROUP2;
     *mntpnt = strdup("/sys/fs/cgroup");
     return;
-  } else if (!hwloc_accessat("/sys/fs/cgroup/cpuset/cpuset.cpus", R_OK, fsroot_fd)) {
+  } else if (!hwloc_access("/sys/fs/cgroup/cpuset/cpuset.cpus", R_OK, fsroot_fd)) {
     hwloc_debug("Found standard cgroup1/cpuset mount point at /sys/fs/cgroup/cpuset/\n");
     *cgtype = HWLOC_LINUX_CGROUP1;
     *mntpnt = strdup("/sys/fs/cgroup/cpuset");
     return;
-  } else if (!hwloc_accessat("/dev/cpuset/cpus", R_OK, fsroot_fd)) {
+  } else if (!hwloc_access("/dev/cpuset/cpus", R_OK, fsroot_fd)) {
     hwloc_debug("Found standard cpuset mount point at /dev/cpuset/\n");
     *cgtype = HWLOC_LINUX_CPUSET;
     *mntpnt = strdup("/dev/cpuset");


### PR DESCRIPTION
Fix https://github.com/open-mpi/hwloc/issues/676:

`HAVE_OPENAT` should not defined on old suse 9.
Change `hwloc_accessat` to inline version `hwloc_access` as it  preserves compiler parameter checking.