### PR TITLE
L0: switch to zesInit()

### DIFF
--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -1410,10 +1410,9 @@ return clGetDeviceIDs(0, 0, 0, NULL, NULL);
       echo
       echo "**** LevelZero configuration"
 
-      HWLOC_PKG_CHECK_MODULES([LEVELZERO], [libze_loader], [zesDevicePciGetProperties], [level_zero/zes_api.h],
+      HWLOC_PKG_CHECK_MODULES([LEVELZERO], [libze_loader], [zesDriverGetDeviceByUuidExp], [level_zero/zes_api.h],
                               [hwloc_levelzero_happy=yes
                                HWLOC_LEVELZERO_REQUIRES=libze_loader
-			       AC_CHECK_LIB([ze_loader], [zesInit], [AC_DEFINE(HWLOC_HAVE_ZESINIT, 1, [Define to 1 if zesInit is available])])
 			       AC_CHECK_LIB([ze_loader], [zeDevicePciGetPropertiesExt], [AC_DEFINE(HWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT, 1, [Define to 1 if zeDevicePciGetPropertiesExt is available])])
                               ], [hwloc_levelzero_happy=no])
       if test x$hwloc_levelzero_happy = xno; then
@@ -1422,9 +1421,8 @@ return clGetDeviceIDs(0, 0, 0, NULL, NULL);
           AC_CHECK_LIB([ze_loader], [zeInit], [
             AC_CHECK_HEADERS([level_zero/zes_api.h], [
               AC_CHECK_LIB([ze_loader],
-	                   [zesDevicePciGetProperties],
+	                   [zesDriverGetDeviceByUuidExp],
 	                   [HWLOC_LEVELZERO_LIBS="-lze_loader"
-			    AC_CHECK_LIB([ze_loader], [zesInit], [AC_DEFINE(HWLOC_HAVE_ZESINIT, 1, [Define to 1 if zesInit is available])])
 			    AC_CHECK_LIB([ze_loader], [zeDevicePciGetPropertiesExt], [AC_DEFINE(HWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT, 1, [Define to 1 if zeDevicePciGetPropertiesExt is available])])
                            ], [hwloc_levelzero_happy=no])
             ], [hwloc_levelzero_happy=no])

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -771,7 +771,9 @@ man3_gpu_DATA = \
         $(DOX_MAN_DIR)/man3/hwloc_rsmi_get_device_osdev_by_index.3 \
         $(DOX_MAN_DIR)/man3/hwlocality_levelzero.3 \
         $(DOX_MAN_DIR)/man3/hwloc_levelzero_get_device_cpuset.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_levelzero_get_sysman_device_cpuset.3 \
         $(DOX_MAN_DIR)/man3/hwloc_levelzero_get_device_osdev.3 \
+        $(DOX_MAN_DIR)/man3/hwloc_levelzero_get_sysman_device_osdev.3 \
         $(DOX_MAN_DIR)/man3/hwlocality_gl.3 \
         $(DOX_MAN_DIR)/man3/hwloc_gl_get_display_osdev_by_port_device.3 \
         $(DOX_MAN_DIR)/man3/hwloc_gl_get_display_osdev_by_name.3 \

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -490,6 +490,7 @@ The hwloc core may also benefit from the following development packages:
 <li>the oneAPI Level Zero library.
   The relevant development package is usually <tt>level-zero-dev</tt>
   or <tt>level-zero-devel</tt>.
+  The implementation must be recent enough to support <tt>zesDriverGetDeviceByUuidExp()</tt>
 </li>
 <li>libxml2 for full XML import/export support (otherwise, the
     internal minimalistic parser will only be able to import

--- a/hwloc/topology-levelzero.c
+++ b/hwloc/topology-levelzero.c
@@ -815,13 +815,11 @@ hwloc_levelzero_discover(struct hwloc_backend *backend, struct hwloc_disc_status
 
   hwloc__levelzero_ports_init(&hports);
 
-#ifdef HWLOC_HAVE_ZESINIT
   res = zesInit(0);
   if (res != ZE_RESULT_SUCCESS) {
     hwloc_debug("hwloc/levelzero: Failed to initialize LevelZero Sysman in zesInit(): 0x%x\n", (unsigned)res);
     hwloc_debug("hwloc/levelzero: Continuing. Hopefully ZES_ENABLE_SYSMAN=1\n");
   }
-#endif /* HWLOC_HAVE_ZESINIT */
 
   /* Tell L0 to create sysman devices.
    * If somebody already initialized L0 without Sysman,

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -54,56 +54,6 @@
 #endif
 
 
-#ifdef HWLOC_HAVE_LEVELZERO
-/*
- * Define ZES_ENABLE_SYSMAN=1 early so that the LevelZero backend gets Sysman enabled.
- *
- * Only if the levelzero was enabled in this build so that we don't enable sysman
- * for external levelzero users when hwloc doesn't need it. If somebody ever loads
- * an external levelzero plugin in a hwloc library built without levelzero (unlikely),
- * he may have to manually set ZES_ENABLE_SYSMAN=1.
- *
- * Use the constructor if supported and/or the Windows DllMain callback.
- * Do it in the main hwloc library instead of the levelzero component because
- * the latter could be loaded later as a plugin.
- *
- * L0 seems to be using getenv() to check this variable on Windows
- * (at least in the Intel Compute-Runtime of March 2021),
- * but setenv() doesn't seem to exist on Windows, hence use putenv() to set the variable.
- *
- * For the record, Get/SetEnvironmentVariable() is not exactly the same as getenv/putenv():
- * - getenv() doesn't see what was set with SetEnvironmentVariable()
- * - GetEnvironmentVariable() doesn't see putenv() in cygwin (while it does in MSVC and MinGW).
- * Hence, if L0 ever switches from getenv() to GetEnvironmentVariable(),
- * it will break in cygwin, we'll have to use both putenv() and SetEnvironmentVariable().
- * Hopefully L0 will provide a way to enable Sysman without env vars before it happens.
- */
-#if HWLOC_HAVE_ATTRIBUTE_CONSTRUCTOR
-static void hwloc_constructor(void) __attribute__((constructor));
-static void hwloc_constructor(void)
-{
-  if (!getenv("ZES_ENABLE_SYSMAN"))
-#ifdef HWLOC_WIN_SYS
-    putenv("ZES_ENABLE_SYSMAN=1");
-#else
-    setenv("ZES_ENABLE_SYSMAN", "1", 1);
-#endif
-}
-#endif
-#ifdef HWLOC_WIN_SYS
-BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpReserved)
-{
-  if (fdwReason == DLL_PROCESS_ATTACH) {
-    if (!getenv("ZES_ENABLE_SYSMAN"))
-      /* Windows does not have a setenv, so use putenv. */
-      putenv((char *) "ZES_ENABLE_SYSMAN=1");
-  }
-  return TRUE;
-}
-#endif
-#endif /* HWLOC_HAVE_LEVELZERO */
-
-
 unsigned hwloc_get_api_version(void)
 {
   return HWLOC_API_VERSION;

--- a/include/hwloc/levelzero.h
+++ b/include/hwloc/levelzero.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021-2023 Inria.  All rights reserved.
+ * Copyright © 2021-2024 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -131,9 +131,15 @@ hwloc_levelzero_get_device_osdev(hwloc_topology_t topology, ze_device_handle_t d
 
   osdev = NULL;
   while ((osdev = hwloc_get_next_osdev(topology, osdev)) != NULL) {
-    hwloc_obj_t pcidev = osdev->parent;
+    hwloc_obj_t pcidev;
 
     if (strncmp(osdev->name, "ze", 2))
+      continue;
+
+    pcidev = osdev;
+    while (pcidev && pcidev->type != HWLOC_OBJ_PCI_DEVICE)
+      pcidev = pcidev->parent;
+    if (!pcidev)
       continue;
 
     if (pcidev

--- a/include/hwloc/levelzero.h
+++ b/include/hwloc/levelzero.h
@@ -32,7 +32,8 @@ extern "C" {
 /** \defgroup hwlocality_levelzero Interoperability with the oneAPI Level Zero interface.
  *
  * This interface offers ways to retrieve topology information about
- * devices managed by the Level Zero API.
+ * devices managed by the Level Zero API, both for main Core devices (ZE API)
+ * and the Sysman devices (ZES API).
  *
  * @{
  */
@@ -44,8 +45,68 @@ extern "C" {
  * the Level Zero device \p device.
  *
  * Topology \p topology and device \p device must match the local machine.
+ * The Level Zero library must have been initialized with zeInit().
+ * I/O devices detection and the Level Zero component are not needed in the
+ * topology.
+ *
+ * The function only returns the locality of the device.
+ * If more information about the device is needed, OS objects should
+ * be used instead, see hwloc_levelzero_get_device_osdev().
+ *
+ * This function is currently only implemented in a meaningful way for
+ * Linux; other systems will simply get a full cpuset.
+ *
+ * \return 0 on success.
+ * \return -1 on error, for instance if device information could not be found.
+ *
+ * \note zeDevicePciGetPropertiesExt() must be supported, or the entire machine
+ * locality will be returned.
+ */
+static __hwloc_inline int
+hwloc_levelzero_get_device_cpuset(hwloc_topology_t topology __hwloc_attribute_unused,
+                                  ze_device_handle_t device, hwloc_cpuset_t set)
+{
+#ifdef HWLOC_LINUX_SYS
+  /* If we're on Linux, use the sysfs mechanism to get the local cpus */
+#define HWLOC_LEVELZERO_DEVICE_SYSFS_PATH_MAX 128
+  char path[HWLOC_LEVELZERO_DEVICE_SYSFS_PATH_MAX];
+  ze_pci_ext_properties_t pci;
+  ze_result_t res;
+
+  if (!hwloc_topology_is_thissystem(topology)) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  pci.stype =  ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES;
+  pci.pNext = NULL;
+  res = zeDevicePciGetPropertiesExt(device, &pci);
+  if (res != ZE_RESULT_SUCCESS) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  sprintf(path, "/sys/bus/pci/devices/%04x:%02x:%02x.%01x/local_cpus",
+          pci.address.domain, pci.address.bus, pci.address.device, pci.address.function);
+  if (hwloc_linux_read_path_as_cpumask(path, set) < 0
+      || hwloc_bitmap_iszero(set))
+    hwloc_bitmap_copy(set, hwloc_topology_get_complete_cpuset(topology));
+#else
+  /* Non-Linux systems simply get a full cpuset */
+  hwloc_bitmap_copy(set, hwloc_topology_get_complete_cpuset(topology));
+#endif
+  return 0;
+}
+
+/** \brief Get the CPU set of logical processors that are physically
+ * close to the Level Zero Sysman device \p device
+ *
+ * Store in \p set the CPU-set describing the locality of
+ * the Level Zero device \p device.
+ *
+ * Topology \p topology and device \p device must match the local machine.
  * The Level Zero library must have been initialized with Sysman enabled
- * (by calling zesInit(0)).
+ * with zesInit().
  * I/O devices detection and the Level Zero component are not needed in the
  * topology.
  *
@@ -60,15 +121,14 @@ extern "C" {
  * \return -1 on error, for instance if device information could not be found.
  */
 static __hwloc_inline int
-hwloc_levelzero_get_device_cpuset(hwloc_topology_t topology __hwloc_attribute_unused,
-                                  ze_device_handle_t device, hwloc_cpuset_t set)
+hwloc_levelzero_get_sysman_device_cpuset(hwloc_topology_t topology __hwloc_attribute_unused,
+                                         zes_device_handle_t device, hwloc_cpuset_t set)
 {
 #ifdef HWLOC_LINUX_SYS
   /* If we're on Linux, use the sysfs mechanism to get the local cpus */
 #define HWLOC_LEVELZERO_DEVICE_SYSFS_PATH_MAX 128
   char path[HWLOC_LEVELZERO_DEVICE_SYSFS_PATH_MAX];
   zes_pci_properties_t pci;
-  zes_device_handle_t sdevice = device;
   ze_result_t res;
 
   if (!hwloc_topology_is_thissystem(topology)) {
@@ -76,7 +136,7 @@ hwloc_levelzero_get_device_cpuset(hwloc_topology_t topology __hwloc_attribute_un
     return -1;
   }
 
-  res = zesDevicePciGetProperties(sdevice, &pci);
+  res = zesDevicePciGetProperties(device, &pci);
   if (res != ZE_RESULT_SUCCESS) {
     errno = EINVAL;
     return -1;
@@ -101,6 +161,72 @@ hwloc_levelzero_get_device_cpuset(hwloc_topology_t topology __hwloc_attribute_un
  * \return \c NULL if none could be found.
  *
  * Topology \p topology and device \p dv_ind must match the local machine.
+ * The Level Zero library must have been initialized with zeInit().
+ * I/O devices detection and the Level Zero component must be enabled in the
+ * topology. If not, the locality of the object may still be found using
+ * hwloc_levelzero_get_device_cpuset().
+ *
+ * \note The corresponding hwloc PCI device may be found by looking
+ * at the result parent pointer (unless PCI devices are filtered out).
+ *
+ * \note zeDevicePciGetPropertiesExt() must be supported.
+ */
+static __hwloc_inline hwloc_obj_t
+hwloc_levelzero_get_device_osdev(hwloc_topology_t topology, ze_device_handle_t device)
+{
+  ze_pci_ext_properties_t pci;
+  ze_result_t res;
+  hwloc_obj_t osdev;
+
+  if (!hwloc_topology_is_thissystem(topology)) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  pci.stype = ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES;
+  pci.pNext = NULL;
+  res = zeDevicePciGetPropertiesExt(device, &pci);
+  if (res != ZE_RESULT_SUCCESS) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  osdev = NULL;
+  while ((osdev = hwloc_get_next_osdev(topology, osdev)) != NULL) {
+    hwloc_obj_t pcidev;
+
+    if (strncmp(osdev->name, "ze", 2))
+      continue;
+
+    pcidev = osdev;
+    while (pcidev && pcidev->type != HWLOC_OBJ_PCI_DEVICE)
+      pcidev = pcidev->parent;
+    if (!pcidev)
+      continue;
+
+    if (pcidev
+      && pcidev->type == HWLOC_OBJ_PCI_DEVICE
+      && pcidev->attr->pcidev.domain == pci.address.domain
+      && pcidev->attr->pcidev.bus == pci.address.bus
+      && pcidev->attr->pcidev.dev == pci.address.device
+      && pcidev->attr->pcidev.func == pci.address.function)
+      return osdev;
+
+    /* FIXME: when we'll have serialnumber, try it in case PCI is filtered-out */
+  }
+
+  return NULL;
+}
+
+/** \brief Get the hwloc OS device object corresponding to Level Zero Sysman device
+ * \p device.
+ *
+ * \return The hwloc OS device object that describes the given Level Zero device \p device.
+ * \return \c NULL if none could be found.
+ *
+ * Topology \p topology and device \p dv_ind must match the local machine.
+ * The Level Zero library must have been initialized with Sysman enabled
+ * with zesInit().
  * I/O devices detection and the Level Zero component must be enabled in the
  * topology. If not, the locality of the object may still be found using
  * hwloc_levelzero_get_device_cpuset().
@@ -109,9 +235,8 @@ hwloc_levelzero_get_device_cpuset(hwloc_topology_t topology __hwloc_attribute_un
  * at the result parent pointer (unless PCI devices are filtered out).
  */
 static __hwloc_inline hwloc_obj_t
-hwloc_levelzero_get_device_osdev(hwloc_topology_t topology, ze_device_handle_t device)
+hwloc_levelzero_get_sysman_device_osdev(hwloc_topology_t topology, zes_device_handle_t device)
 {
-  zes_device_handle_t sdevice = device;
   zes_pci_properties_t pci;
   ze_result_t res;
   hwloc_obj_t osdev;
@@ -121,9 +246,8 @@ hwloc_levelzero_get_device_osdev(hwloc_topology_t topology, ze_device_handle_t d
     return NULL;
   }
 
-  res = zesDevicePciGetProperties(sdevice, &pci);
+  res = zesDevicePciGetProperties(device, &pci);
   if (res != ZE_RESULT_SUCCESS) {
-    /* L0 was likely initialized without sysman, don't bother */
     errno = EINVAL;
     return NULL;
   }

--- a/include/hwloc/levelzero.h
+++ b/include/hwloc/levelzero.h
@@ -45,8 +45,7 @@ extern "C" {
  *
  * Topology \p topology and device \p device must match the local machine.
  * The Level Zero library must have been initialized with Sysman enabled
- * (by calling zesInit(0) if supported,
- *  or by setting ZES_ENABLE_SYSMAN=1 in the environment).
+ * (by calling zesInit(0)).
  * I/O devices detection and the Level Zero component are not needed in the
  * topology.
  *

--- a/include/hwloc/rename.h
+++ b/include/hwloc/rename.h
@@ -616,7 +616,9 @@ extern "C" {
 /* levelzero.h */
 
 #define hwloc_levelzero_get_device_cpuset HWLOC_NAME(levelzero_get_device_cpuset)
+#define hwloc_levelzero_get_sysman_device_cpuset HWLOC_NAME(levelzero_get_sysman_device_cpuset)
 #define hwloc_levelzero_get_device_osdev HWLOC_NAME(levelzero_get_device_osdev)
+#define hwloc_levelzero_get_sysman_device_osdev HWLOC_NAME(levelzero_get_sysman_device_osdev)
 
 /* gl.h */
 

--- a/tests/hwloc/levelzero.c
+++ b/tests/hwloc/levelzero.c
@@ -12,7 +12,7 @@
 #include "hwloc.h"
 #include "hwloc/levelzero.h"
 
-/* check the RSMI helpers */
+/* check the LevelZero helpers */
 
 static int check_levelzero_backend(hwloc_topology_t topology)
 {
@@ -29,31 +29,25 @@ int main(void)
 {
   hwloc_topology_t topology;
   ze_driver_handle_t *drh;
+  zes_driver_handle_t *sdrh;
   uint32_t nbdrivers, i, k;
   ze_result_t res;
   int has_levelzero_backend;
   int err = 0;
-
-  /* SKIP until zesInit() support is finalized in the core and helpers */
-  return 77;
-
-  res = zeInit(0);
-  if (res != ZE_RESULT_SUCCESS) {
-    fprintf(stderr, "Failed to initialize LevelZero in zeInit(): %d\n", (int)res);
-    return 0;
-  }
-
-  res = zesInit(0);
-  if (res != ZE_RESULT_SUCCESS) {
-    fprintf(stderr, "Failed to initialize LevelZero Sysman in zesInit(): %d\n", (int)res);
-    return 0;
-  }
 
   hwloc_topology_init(&topology);
   hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
   hwloc_topology_load(topology);
 
   has_levelzero_backend = check_levelzero_backend(topology);
+
+  printf("testing ZE devices\n");
+
+  res = zeInit(0);
+  if (res != ZE_RESULT_SUCCESS) {
+    fprintf(stderr, "Failed to initialize LevelZero in zeInit(): %d\n", (int)res);
+    return 0;
+  }
 
   nbdrivers = 0;
   res = zeDriverGet(&nbdrivers, NULL);
@@ -131,7 +125,97 @@ int main(void)
       }
       hwloc_bitmap_free(set);
     }
+    free(dvh);
   }
+  free(drh);
+
+  printf("testing ZES devices\n");
+
+  res = zesInit(0);
+  if (res != ZE_RESULT_SUCCESS) {
+    fprintf(stderr, "Failed to initialize LevelZero Sysman in zesInit(): %d\n", (int)res);
+    return 0;
+  }
+
+  nbdrivers = 0;
+  res = zesDriverGet(&nbdrivers, NULL);
+  if (res != ZE_RESULT_SUCCESS || !nbdrivers)
+    return 0;
+  sdrh = malloc(nbdrivers * sizeof(*sdrh));
+  if (!sdrh)
+    return 0;
+  res = zesDriverGet(&nbdrivers, sdrh);
+  if (res != ZE_RESULT_SUCCESS) {
+    free(sdrh);
+    return 0;
+  }
+
+  printf("found %u L0 ZES drivers\n", nbdrivers);
+
+  k = 0;
+  for(i=0; i<nbdrivers; i++) {
+    uint32_t nbdevices, j;
+    zes_device_handle_t *sdvh;
+
+    nbdevices = 0;
+    res = zesDeviceGet(sdrh[i], &nbdevices, NULL);
+    if (res != ZE_RESULT_SUCCESS || !nbdevices)
+      continue;
+    sdvh = malloc(nbdevices * sizeof(*sdvh));
+    if (!sdvh)
+      continue;
+    res = zeDeviceGet(sdrh[i], &nbdevices, sdvh);
+    if (res != ZE_RESULT_SUCCESS) {
+      free(sdvh);
+      continue;
+    }
+
+    printf("found %u L0 ZES devices in driver #%u\n", nbdevices, i);
+
+    for (j=0; j<nbdevices; j++, k++) {
+      hwloc_bitmap_t set;
+      hwloc_obj_t osdev, ancestor;
+      const char *value;
+
+      osdev = hwloc_levelzero_get_sysman_device_osdev(topology, sdvh[j]);
+      assert(osdev);
+
+      ancestor = hwloc_get_non_io_ancestor_obj(topology, osdev);
+
+      printf("found OSDev %s\n", osdev->name);
+      err = strncmp(osdev->name, "ze", 2);
+      assert(!err);
+      assert(atoi(osdev->name+2) == (int) k);
+
+      assert(osdev->attr->osdev.types == (HWLOC_OBJ_OSDEV_COPROC|HWLOC_OBJ_OSDEV_GPU));
+
+      assert(has_levelzero_backend);
+
+      value = hwloc_obj_get_info_by_name(osdev, "LevelZeroDriverIndex");
+      assert(value);
+      assert(atoi(value) == (int) i);
+      value = hwloc_obj_get_info_by_name(osdev, "LevelZeroDriverDeviceIndex");
+      assert(value);
+      assert(atoi(value) == (int) j);
+
+      set = hwloc_bitmap_alloc();
+      err = hwloc_levelzero_get_sysman_device_cpuset(topology, sdvh[j], set);
+      if (err < 0) {
+        printf("failed to get cpuset for driver #%u device #%u\n", i, j);
+      } else {
+        char *cpuset_string = NULL;
+        hwloc_bitmap_asprintf(&cpuset_string, set);
+        printf("got cpuset %s for driver #%u device #%u\n", cpuset_string, j, i);
+        free(cpuset_string);
+        if (hwloc_bitmap_isequal(hwloc_topology_get_complete_cpuset(topology), hwloc_topology_get_topology_cpuset(topology)))
+          /* only compare if the topology is complete, otherwise things can be significantly different */
+          assert(hwloc_bitmap_isequal(set, ancestor->cpuset));
+      }
+      hwloc_bitmap_free(set);
+    }
+    free(sdvh);
+  }
+  free(sdrh);
 
   hwloc_topology_destroy(topology);
 

--- a/tests/hwloc/levelzero.c
+++ b/tests/hwloc/levelzero.c
@@ -37,17 +37,15 @@ int main(void)
   /* SKIP until zesInit() support is finalized in the core and helpers */
   return 77;
 
-  res = zesInit(0);
-  if (res != ZE_RESULT_SUCCESS) {
-    fprintf(stderr, "Failed to initialize LevelZero Sysman in zesInit(): %d\n", (int)res);
-    /* continuing, assuming ZES_ENABLE_SYSMAN=1 will be enough */
-  }
-
-  putenv((char *) "ZES_ENABLE_SYSMAN=1");
-
   res = zeInit(0);
   if (res != ZE_RESULT_SUCCESS) {
     fprintf(stderr, "Failed to initialize LevelZero in zeInit(): %d\n", (int)res);
+    return 0;
+  }
+
+  res = zesInit(0);
+  if (res != ZE_RESULT_SUCCESS) {
+    fprintf(stderr, "Failed to initialize LevelZero Sysman in zesInit(): %d\n", (int)res);
     return 0;
   }
 

--- a/tests/hwloc/levelzero.c
+++ b/tests/hwloc/levelzero.c
@@ -34,6 +34,9 @@ int main(void)
   int has_levelzero_backend;
   int err = 0;
 
+  /* SKIP until zesInit() support is finalized in the core and helpers */
+  return 77;
+
   res = zesInit(0);
   if (res != ZE_RESULT_SUCCESS) {
     fprintf(stderr, "Failed to initialize LevelZero Sysman in zesInit(): %d\n", (int)res);

--- a/tests/hwloc/levelzero.c
+++ b/tests/hwloc/levelzero.c
@@ -9,7 +9,6 @@
 #include <level_zero/ze_api.h>
 #include <level_zero/zes_api.h>
 
-#include "private/autogen/config.h" /* for HWLOC_HAVE_ZESINIT */
 #include "hwloc.h"
 #include "hwloc/levelzero.h"
 
@@ -35,13 +34,11 @@ int main(void)
   int has_levelzero_backend;
   int err = 0;
 
-#ifdef HWLOC_HAVE_ZESINIT
   res = zesInit(0);
   if (res != ZE_RESULT_SUCCESS) {
     fprintf(stderr, "Failed to initialize LevelZero Sysman in zesInit(): %d\n", (int)res);
     /* continuing, assuming ZES_ENABLE_SYSMAN=1 will be enough */
   }
-#endif
 
   putenv((char *) "ZES_ENABLE_SYSMAN=1");
 
@@ -50,7 +47,7 @@ int main(void)
     fprintf(stderr, "Failed to initialize LevelZero in zeInit(): %d\n", (int)res);
     return 0;
   }
-  
+
   hwloc_topology_init(&topology);
   hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
   hwloc_topology_load(topology);

--- a/tests/hwloc/ports/Makefile.am
+++ b/tests/hwloc/ports/Makefile.am
@@ -1,4 +1,4 @@
-# Copyright © 2009-2023 Inria.  All rights reserved.
+# Copyright © 2009-2024 Inria.  All rights reserved.
 # Copyright © 2009, 2011-2012, 2020 Université Bordeaux
 # Copyright © 2009-2014 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
@@ -178,8 +178,7 @@ libhwloc_port_levelzero_la_SOURCES = \
         include/levelzero/level_zero/zes_api.h
 libhwloc_port_levelzero_la_CPPFLAGS = $(common_CPPFLAGS) \
         -I$(HWLOC_top_srcdir)/tests/hwloc/ports/include/levelzero \
-        -DHWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT=1 \
-        -DHWLOC_HAVE_ZESINIT=1
+        -DHWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT=1
 
 nodist_libhwloc_port_gl_la_SOURCES = topology-gl.c
 libhwloc_port_gl_la_SOURCES = \

--- a/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
+++ b/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 Inria.  All rights reserved.
+ * Copyright © 2020-2024 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -8,6 +8,8 @@
 
 typedef int ze_result_t;
 #define ZE_RESULT_SUCCESS 0
+
+typedef int ze_bool_t;
 
 #define ZE_MAX_DEVICE_NAME 64
 

--- a/tests/hwloc/ports/include/levelzero/level_zero/zes_api.h
+++ b/tests/hwloc/ports/include/levelzero/level_zero/zes_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2023 Inria.  All rights reserved.
+ * Copyright © 2020-2024 Inria.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -10,7 +10,13 @@
 
 extern ze_result_t zesInit(int);
 
+typedef void * zes_driver_handle_t;
 typedef void * zes_device_handle_t;
+
+typedef ze_device_uuid_t zes_uuid_t;
+
+extern ze_result_t zesDriverGet(uint32_t *, zes_driver_handle_t *);
+extern ze_result_t zesDriverGetDeviceByUuidExp(zes_driver_handle_t, zes_uuid_t, zes_device_handle_t *, ze_bool_t *, uint32_t *);
 
 typedef struct {
   char *vendorName;


### PR DESCRIPTION
- only support implementations with zesDriverGetDeviceByUuidExp()
- the above means we may assume zesInit() is available and works
- remove the constructor that forces ZES_ENABLE_SYSMAN in the environment (FINALLY!!!)
- use different handles for ZE and ZES devices during discovery
- cleanup/update helpers and tests accordingly

Still needs to be tested on a machine with subdevices (PVC), but I don't have any such machine with a recent-enough L0 implementation.