### PR TITLE
[WIP DNM] stop using zeDevicePciGetPropertiesExt()

### DIFF
--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -1413,7 +1413,6 @@ return clGetDeviceIDs(0, 0, 0, NULL, NULL);
       HWLOC_PKG_CHECK_MODULES([LEVELZERO], [libze_loader], [zesDriverGetDeviceByUuidExp], [level_zero/zes_api.h],
                               [hwloc_levelzero_happy=yes
                                HWLOC_LEVELZERO_REQUIRES=libze_loader
-			       AC_CHECK_LIB([ze_loader], [zeDevicePciGetPropertiesExt], [AC_DEFINE(HWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT, 1, [Define to 1 if zeDevicePciGetPropertiesExt is available])])
                               ], [hwloc_levelzero_happy=no])
       if test x$hwloc_levelzero_happy = xno; then
         hwloc_levelzero_happy=yes
@@ -1423,7 +1422,6 @@ return clGetDeviceIDs(0, 0, 0, NULL, NULL);
               AC_CHECK_LIB([ze_loader],
 	                   [zesDriverGetDeviceByUuidExp],
 	                   [HWLOC_LEVELZERO_LIBS="-lze_loader"
-			    AC_CHECK_LIB([ze_loader], [zeDevicePciGetPropertiesExt], [AC_DEFINE(HWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT, 1, [Define to 1 if zeDevicePciGetPropertiesExt is available])])
                            ], [hwloc_levelzero_happy=no])
             ], [hwloc_levelzero_happy=no])
           ], [hwloc_levelzero_happy=no])

--- a/hwloc/topology-levelzero.c
+++ b/hwloc/topology-levelzero.c
@@ -555,26 +555,6 @@ hwloc__levelzero_devices_get(struct hwloc_topology *topology,
         hwloc__levelzero_ports_get(zesh, osdev, nr_subdevices, subosdevs, hports);
 
       parent = NULL;
-#ifdef HWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT
-      { /* try getting PCI BDF+speed from core extension */
-        ze_pci_ext_properties_t ext_pci;
-        ext_pci.stype =  ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES;
-        ext_pci.pNext = NULL;
-        res = zeDevicePciGetPropertiesExt(zeh, &ext_pci);
-        if (res == ZE_RESULT_SUCCESS) {
-          parent = hwloc_pci_find_parent_by_busid(topology,
-                                                  ext_pci.address.domain,
-                                                  ext_pci.address.bus,
-                                                  ext_pci.address.device,
-                                                  ext_pci.address.function);
-          if (parent && parent->type == HWLOC_OBJ_PCI_DEVICE) {
-            if (ext_pci.maxSpeed.maxBandwidth > 0)
-              parent->attr->pcidev.linkspeed = ((float)ext_pci.maxSpeed.maxBandwidth)/1000/1000/1000;
-          }
-        }
-      }
-#endif /* HWLOC_HAVE_LEVELZERO_CORE_PCI_EXT */
-      if (!parent) {
         /* try getting PCI BDF+speed from sysman */
         zes_pci_properties_t pci;
         res = zesDevicePciGetProperties(zesh, &pci);
@@ -589,7 +569,6 @@ hwloc__levelzero_devices_get(struct hwloc_topology *topology,
               parent->attr->pcidev.linkspeed = ((float)pci.maxSpeed.maxBandwidth)/1000/1000/1000;
           }
         }
-      }
       if (!parent)
         parent = hwloc_get_root_obj(topology);
 

--- a/tests/hwloc/ports/Makefile.am
+++ b/tests/hwloc/ports/Makefile.am
@@ -177,8 +177,7 @@ libhwloc_port_levelzero_la_SOURCES = \
         include/levelzero/level_zero/ze_api.h \
         include/levelzero/level_zero/zes_api.h
 libhwloc_port_levelzero_la_CPPFLAGS = $(common_CPPFLAGS) \
-        -I$(HWLOC_top_srcdir)/tests/hwloc/ports/include/levelzero \
-        -DHWLOC_HAVE_ZEDEVICEPCIGETPROPERTIESEXT=1
+        -I$(HWLOC_top_srcdir)/tests/hwloc/ports/include/levelzero
 
 nodist_libhwloc_port_gl_la_SOURCES = topology-gl.c
 libhwloc_port_gl_la_SOURCES = \

--- a/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
+++ b/tests/hwloc/ports/include/levelzero/level_zero/ze_api.h
@@ -57,25 +57,4 @@ extern ze_result_t zeDeviceGetCommandQueueGroupProperties(ze_driver_handle_t, ui
 
 extern ze_result_t zeDeviceGetSubDevices(ze_device_handle_t, uint32_t *, ze_device_handle_t*);
 
-typedef struct ze_pci_address_ext {
-  uint32_t domain, bus, device, function;
-} ze_pci_address_ext_t;
-
-typedef struct ze_pci_speed_ext {
-  int64_t maxBandwidth;
-} ze_pci_speed_ext_t;
-
-typedef int ze_structure_type_t;
-
-#define ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES 0x10008
-
-typedef struct ze_pci_ext_properties {
-  ze_structure_type_t stype;
-  void* pNext;
-  ze_pci_address_ext_t address;
-  ze_pci_speed_ext_t maxSpeed;
-} ze_pci_ext_properties_t;
-
-extern ze_result_t zeDevicePciGetPropertiesExt(ze_device_handle_t, ze_pci_ext_properties_t *);
-
 #endif /* HWLOC_PORT_L0_ZE_API_H */


### PR DESCRIPTION
Don't merge for now, zesDevicePciGetProperties() doesn't report PCI link speed as expected. Waiting for intel/compute-runtime#778