### PR TITLE
rsmi: fix the PCI locality of partitioned devices

### DIFF
--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -1304,8 +1304,9 @@ return rsmi_init(0);
                          hwloc_rsmi_warning=no],
                         [AC_MSG_RESULT([no])
                          hwloc_rsmi_warning=yes],
-                        [AC_MSG_RESULT([don't know (cross-compiling)])])],
-                      [hwloc_rsmi_happy=no])
+                        [AC_MSG_RESULT([don't know (cross-compiling)])])
+		      AC_CHECK_DECLS([rsmi_dev_partition_id_get],,[:],[[#include <rocm_smi/rocm_smi.h>]])
+		     ], [hwloc_rsmi_happy=no])
         LDFLAGS="$LDFLAGS_save"
         LIBS="$LIBS_save"
       ], [hwloc_rsmi_happy=no])

--- a/tests/hwloc/ports/Makefile.am
+++ b/tests/hwloc/ports/Makefile.am
@@ -170,7 +170,8 @@ nodist_libhwloc_port_rsmi_la_SOURCES = topology-rsmi.c
 libhwloc_port_rsmi_la_SOURCES = \
         include/rsmi/rocm_smi/rocm_smi.h
 libhwloc_port_rsmi_la_CPPFLAGS = $(common_CPPFLAGS) \
-        -I$(HWLOC_top_srcdir)/tests/hwloc/ports/include/rsmi
+        -I$(HWLOC_top_srcdir)/tests/hwloc/ports/include/rsmi \
+	-DHAVE_DECL_RSMI_DEV_PARTITION_ID_GET=1
 
 nodist_libhwloc_port_levelzero_la_SOURCES = topology-levelzero.c
 libhwloc_port_levelzero_la_SOURCES = \

--- a/tests/hwloc/ports/include/rsmi/rocm_smi/rocm_smi.h
+++ b/tests/hwloc/ports/include/rsmi/rocm_smi/rocm_smi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2013-2021 Inria.  All rights reserved.
+ * Copyright © 2013-2024 Inria.  All rights reserved.
  * Copyright (c) 2020, Advanced Micro Devices, Inc. All rights reserved.
  * Written by Advanced Micro Devices,
  * See COPYING in top-level directory.
@@ -79,6 +79,7 @@ rsmi_status_t rsmi_dev_name_get(uint32_t dv_ind, char *name, size_t len);
 rsmi_status_t rsmi_dev_serial_number_get(uint32_t dv_ind, char *serial_num, uint32_t len);
 rsmi_status_t rsmi_dev_unique_id_get(uint32_t dv_ind, uint64_t *id);
 rsmi_status_t rsmi_dev_pci_bandwidth_get(uint32_t dv_ind, rsmi_pcie_bandwidth_t *bandwidth);
+rsmi_status_t rsmi_dev_partition_id_get(uint32_t dv_ind, uint32_t *partition_id);
 rsmi_status_t rsmi_dev_xgmi_hive_id_get(uint32_t dv_ind, uint64_t *hive_id);
 rsmi_status_t rsmi_topo_get_link_type(uint32_t dv_ind_src, uint32_t dv_ind_dst,
                                       uint64_t *hops, RSMI_IO_LINK_TYPE *type);


### PR DESCRIPTION
rsmi_dev_pci_id_get() returns the GPU "partition ID" inside the PCI BDF function, but this virtual function isn't actually exposed to the OS. See ROCm/rocm_smi_lib#208 for details.

When hwloc fails to find the corresponding PCI device, if the BDF function is > 0, get the RSMI partition ID, compare it with the BDF function, and try to get the PCI device with func = 0 instead.

Thanks to Edgar Leon for reporting the issue.