### PR TITLE
misc: reactivate GNUC conditional

### DIFF
--- a/include/private/misc.h
+++ b/include/private/misc.h
@@ -186,7 +186,7 @@ hwloc_ffsl_from_ffs32(unsigned long x)
 /**
  * flsl helpers.
  */
-#ifdef __GNUC_____
+#ifdef __GNUC__
 
 #  if (__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4))
 #    define hwloc_flsl(x) ((x) ? (8*sizeof(long) - __builtin_clzl(x)) : 0)


### PR DESCRIPTION
This avoids use of the custom hwloc_flsl_manual() implementation if a recent GCC is in use.
It is not clear why the erroneous underscores, with which the macro does not seem to be defined anywhere, were introduced, as the commit introducing the line only references an SVN import. Older source releases however do not contain the change.

This was discovered as hwloc_flsl_manual() returns zero and as a result a division by zero exception with recent versions of GCC on certain CPU configurations, whereas the native functionality behaves correctly on both tested versions.
The manual implementation being defective is technically still an issue, however the logic under the __GNUC__ conditional is deemed to be preferable in any case.

Fixes: 3ac17a230d2a ("topo_cpuset_last")
Link: https://bugzilla.opensuse.org/show_bug.cgi?id=1236038
Signed-off-by: Georg Pfuetzenreuter <mail@georg-pfuetzenreuter.net>