### PR TITLE
hwloc_type_sscanf: fix test when host has several levels with same type

### DIFF
--- a/tests/hwloc/hwloc_type_sscanf.c
+++ b/tests/hwloc/hwloc_type_sscanf.c
@@ -44,7 +44,7 @@ static void _check(hwloc_topology_t topology, hwloc_obj_t obj, const char *buffe
   }
 
   depth = hwloc_get_type_depth_with_attr(topology, type, &attr, sizeof(attr));
-  assert(depth == (int) obj->depth);
+  assert((depth == HWLOC_TYPE_DEPTH_MULTIPLE && !checkattrs) || depth == (int) obj->depth);
 }
 
 static void check(hwloc_topology_t topology, hwloc_obj_t obj)


### PR DESCRIPTION
E.g. with

HWLOC_SYNTHETIC="group:2 group:2 pu:2" ./tests/hwloc/hwloc_type_sscanf

The presence of the two group levels makes the check for level depth fail for the hwloc_obj_type_string case which does not expose attributes which allow to distinguish them.