### PR TITLE
Do not treat INTERSECT_LOCALITY as a superset of LARGER and SMALLER

### DIFF
--- a/hwloc/memattrs.c
+++ b/hwloc/memattrs.c
@@ -1159,8 +1159,9 @@ match_local_obj_cpuset(hwloc_obj_t node, hwloc_cpuset_t cpuset, unsigned long fl
 {
   if (flags & HWLOC_LOCAL_NUMANODE_FLAG_ALL)
     return 1;
-  if (flags & HWLOC_LOCAL_NUMANODE_FLAG_INTERSECT_LOCALITY)
-    return hwloc_bitmap_intersects(node->cpuset, cpuset);
+  if ((flags & HWLOC_LOCAL_NUMANODE_FLAG_INTERSECT_LOCALITY)
+      && hwloc_bitmap_intersects(node->cpuset, cpuset))
+    return 1;
   if ((flags & HWLOC_LOCAL_NUMANODE_FLAG_LARGER_LOCALITY)
       && hwloc_bitmap_isincluded(cpuset, node->cpuset))
     return 1;


### PR DESCRIPTION
To be fair, it is a superset for almost all cpusets. But there is one exception to this rule, which is the empty cpuset.

- It passes the LARGER_LOCALITY test for all NUMA nodes.
- It passes the INTERSECT_LOCALITY test for no NUMA node.

As a result, we get to a situation where for this particular cpuset, adding an `hwloc_local_numanode_flag_e` (INTERSECT_LOCALITY) results in a smaller number of NUMA nodes being matched, which violates normal user expectations about `hwloc_get_local_numanode_objs()`.