### PR TITLE
Set the `obj` pointer of `iloc` in `to_internal_location()`

### DIFF
--- a/hwloc/memattrs.c
+++ b/hwloc/memattrs.c
@@ -379,6 +379,7 @@ to_internal_location(struct hwloc_internal_location_s *iloc,
       errno = EINVAL;
       return -1;
     }
+    iloc->location.object.obj = location->location.object;
     iloc->location.object.gp_index = location->location.object->gp_index;
     iloc->location.object.type = location->location.object->type;
     return 0;


### PR DESCRIPTION
When adding values to a memory attribute, `hwloc_memattr_set_value()` converts the user-provided initiator `hwloc_location` to `hwloc_internal_location_s` using the `to_internal_location()` utility. When the initiator is a topology object, this utility sets the `gp_index` and the `type` fields of the internal location, but crucially not its `obj` field, which remains uninitialized.

This _could_ be fine if the memory attribute was then marked as needing a refresh, but that is not done, and the way `to_internal_location()` is currently designed, it cannot be done without adding an `hwloc_internal_memattr_s*` parameter which would only be used for this purpose (which feels somewhat ugly from an API design perspective), or pessimistically marking the memory attribute as always needing a refresh in the caller of `to_internal_location()`.

In any case, the end result is that unless something else (such as a previously unseen target object) marks the memory attribute as needing a refresh, the next memory attribute query that returns an initiator is going to call `from_internal_location()`, which will use the still uninitialized `obj` field of the internal location as the object pointer of the user-returned location, and thus a garbage `hwloc_obj_t` pointer will be returned to the caller.

You can reproduce this bug with a test that creates a memory attribute with two different object initiators that point to the same target, then uses an hwloc query to get the initiator locations. The second returned initiator location will be invalid garbage.

In my opinion, the simple and effective fix here is that since we have a valid `hwloc_obj_t` pointer at the time `hwloc_memattr_set_value()` is called, we should use it to set the `obj` field of the internal initiator so that it is properly initialized. This is what this PR proposes to do.

An alternate valid strategy would be to set the `obj` field to `NULL` and mark the memory attribute as needing a refresh, but that is a bigger refactor and I'm not sure why it's better (we force an expensive-ish refresh when we actually know what object pointer that refresh is going to yield).