### PR TITLE
Make hwloc_distances_get_by_name accept empty kinds

### DIFF
--- a/hwloc/distances.c
+++ b/hwloc/distances.c
@@ -1037,7 +1037,7 @@ hwloc_distances_get_by_name(hwloc_topology_t topology, const char *name,
     return -1;
   }
 
-  return hwloc__distances_get(topology, name, HWLOC_OBJ_TYPE_NONE, nrp, distancesp, HWLOC_DISTANCES_KIND_ALL, flags);
+  return hwloc__distances_get(topology, name, HWLOC_OBJ_TYPE_NONE, nrp, distancesp, 0, flags);
 }
 
 int


### PR DESCRIPTION
I did not see any other use of `HWLOC_DISTANCES_KIND_ALL` for filtering purposes, so I think only `hwloc_distances_get_by_name()` needed fixing here.

Fixes #730.