### PR TITLE
CMake: add proper win-arm64 architecture detection

### DIFF
--- a/contrib/windows-cmake/CMakeLists.txt
+++ b/contrib/windows-cmake/CMakeLists.txt
@@ -50,15 +50,20 @@ set(SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
 set(HWLOC_X86_32_ARCH)
 set(HWLOC_X86_64_ARCH)
 set(HWLOC_HAVE_X86_CPUID 1)
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "(^AMD64$|^x86_64$)")
-    # "AMD64" on Windows, "x86_64" on Linux
+if(CMAKE_C_COMPILER_ARCHITECTURE_ID MATCHES "^(x64|x86_64)$")
+    # "x64"    for Windows (MSVC)
+    # "x86_64" for Windows (MinGW), Linux, macOS
     set(HWLOC_X86_64_ARCH 1)
-elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "(^x86$|i.86)")
-    # "x86" on Windows, "i.86" on Linux
+elseif(CMAKE_C_COMPILER_ARCHITECTURE_ID MATCHES "^(X86|i[3-6]86)$")
+    # "X86"      for Windows (MSVC)
+    # "i[3-6]86" for Windows (MinGW), Linux, macOS
     set(HWLOC_X86_32_ARCH 1)
 else()
+    # For "arm64", "aarch64", "ARM64"...
     set(HWLOC_HAVE_X86_CPUID 0)
 endif()
+message(STATUS "Target Arch ID = ${CMAKE_C_COMPILER_ARCHITECTURE_ID}")
+message(STATUS "HWLOC_HAVE_X86_CPUID = ${HWLOC_HAVE_X86_CPUID}")
 
 check_c_source_compiles("int main(void) {int cpuinfo[4]; __cpuidex(cpuinfo,0,0); return 0;}"
 HWLOC_HAVE_MSVC_CPUIDEX
@@ -122,7 +127,7 @@ add_library(hwloc
     ${TOPDIR}/hwloc/topology-xml.c
     ${TOPDIR}/hwloc/topology-xml-nolibxml.c
     ${TOPDIR}/hwloc/topology-windows.c
-    ${TOPDIR}/hwloc/topology-x86.c
+    $<$<BOOL:${HWLOC_HAVE_X86_CPUID}>:${TOPDIR}/hwloc/topology-x86.c>
     $<$<BOOL:${HWLOC_HAVE_LIBXML2}>:${TOPDIR}/hwloc/topology-xml-libxml.c>
     $<$<BOOL:${HWLOC_HAVE_OPENCL}>:${TOPDIR}/hwloc/topology-opencl.c>
     $<$<BOOL:${HAVE_CUDA}>:${TOPDIR}/hwloc/topology-cuda.c>


### PR DESCRIPTION
#726 

## Main changes:
in `contrib/windows-cmake/CMakeLists.txt`

## Problem:
The existing code relies on `CMAKE_SYSTEM_PROCESSOR` to distinguish the target architecture, which is not reliable on Windows (see CMake discussions [here](https://gitlab.kitware.com/cmake/cmake/-/issues/15170)). This can cause compilation failures, because source file(`topology-x86.c`) will be wrongly included in ARM64 builds.

## Solution:
Inspired by the discussions, [CMAKE_C_COMPILER_ARCHITECTURE_ID](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ARCHITECTURE_ID.html) is here to replace `CMAKE_SYSTEM_PROCESSOR`. And then, conditionally add `topology-x86.c` to the library.

This should enable successful native & cross compiling.