### PR TITLE
Add plugin support on Windows

### DIFF
--- a/contrib/windows-cmake/CMakeLists.txt
+++ b/contrib/windows-cmake/CMakeLists.txt
@@ -1,6 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright © 2021-2024 Inria.  All rights reserved.
+# Copyright © 2025 Siemens Corporation and/or its affiliates.  All rights reserved.
 # See COPYING in top-level directory.
 #
 
@@ -12,6 +13,7 @@ project(hwloc
 enable_testing()
 
 option(HWLOC_ENABLE_TESTING "Enable testing" ON)
+option(HWLOC_ENABLE_PLUGINS "Enable plugin support" OFF)
 option(HWLOC_SKIP_LSTOPO "don't build/install lstopo")
 option(HWLOC_SKIP_TOOLS "don't build/install other hwloc tools")
 option(HWLOC_SKIP_INCLUDES "don't install headers")
@@ -20,7 +22,10 @@ option(HWLOC_WITH_OPENCL "enable OpenCL support")
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
     option(HWLOC_WITH_CUDA "enable CUDA support")
 endif()
-option(HWLOC_BUILD_SHARED_LIBS "build shared libraries" ${BUILD_SHARED_LIBS})
+
+if(DEFINED HWLOC_BUILD_SHARED_LIBS)
+    message(FATAL_ERROR "The option HWLOC_BUILD_SHARED_LIBS has been removed. Please use BUILD_SHARED_LIBS instead.")
+endif()
 
 set(TOPDIR ${PROJECT_SOURCE_DIR}/../..)
 
@@ -82,19 +87,19 @@ HWLOC_HAVE_MSVC_CPUIDEX
 #   set(HAVE_DECL_STRTOULL 1)
 
 # --- optional external libraries
-set(HWLOC_HAVE_LIBXML2)
+set(HWLOC_HAVE_LIBXML2 0)
 if(HWLOC_WITH_LIBXML2)
     find_package(LibXml2 REQUIRED)
     set(HWLOC_HAVE_LIBXML2 1)
 endif()
 
-set(HWLOC_HAVE_OPENCL)
+set(HWLOC_HAVE_OPENCL 0)
 if(HWLOC_WITH_OPENCL)
     find_package(OpenCL REQUIRED)
     set(HWLOC_HAVE_OPENCL 1)
 endif()
 
-set(HAVE_CUDA)
+set(HAVE_CUDA 0)
 set(HAVE_CUDA_H)
 set(HAVE_CUDA_RUNTIME_API_H)
 set(HWLOC_HAVE_CUDART)
@@ -104,6 +109,33 @@ if(HWLOC_WITH_CUDA)
     set(HAVE_CUDA_H 1)
     set(HAVE_CUDA_RUNTIME_API_H 1)
     set(HWLOC_HAVE_CUDART 1)
+endif()
+
+set(HWLOC_HAVE_PLUGINS 0)
+set(HWLOC_ENABLED_PLUGINS_LIST)
+if(HWLOC_ENABLE_PLUGINS)
+    # this has to happen before the first add_library call
+    if(NOT DEFINED BUILD_SHARED_LIBS)
+        message(STATUS "HWLOC plugin support requires BUILD_SHARED_LIBS to be enabled, but it was not set. Setting BUILD_SHARED_LIBS to ON")
+        set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries" FORCE)
+    elseif(NOT BUILD_SHARED_LIBS)
+        message(FATAL_ERROR "HWLOC plugin support requires BUILD_SHARED_LIBS to be enabled, but BUILD_SHARED_LIBS is set to ${BUILD_SHARED_LIBS}.")
+    endif()
+
+    set(HWLOC_HAVE_PLUGINS 1)
+    set(HWLOC_PLUGINS_PATH ${CMAKE_INSTALL_PREFIX}/lib/hwloc)
+
+    if(HWLOC_HAVE_CUDART)
+        list(APPEND HWLOC_ENABLED_PLUGINS_LIST "cuda")
+    endif()
+
+    if(HWLOC_HAVE_OPENCL)
+        list(APPEND HWLOC_ENABLED_PLUGINS_LIST "opencl")
+    endif()
+
+    if(HWLOC_HAVE_LIBXML2)
+        list(APPEND HWLOC_ENABLED_PLUGINS_LIST "xml_libxml")
+    endif()
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/private_config.h.in include/private/autogen/config.h)
@@ -134,18 +166,18 @@ add_library(hwloc
     ${TOPDIR}/hwloc/topology-xml-nolibxml.c
     ${TOPDIR}/hwloc/topology-windows.c
     $<$<BOOL:${HWLOC_HAVE_X86_CPUID}>:${TOPDIR}/hwloc/topology-x86.c>
-    $<$<BOOL:${HWLOC_HAVE_LIBXML2}>:${TOPDIR}/hwloc/topology-xml-libxml.c>
-    $<$<BOOL:${HWLOC_HAVE_OPENCL}>:${TOPDIR}/hwloc/topology-opencl.c>
-    $<$<BOOL:${HAVE_CUDA}>:${TOPDIR}/hwloc/topology-cuda.c>
+    $<$<AND:$<BOOL:${HWLOC_HAVE_LIBXML2}>,$<NOT:$<BOOL:${HWLOC_HAVE_PLUGINS}>>>:${TOPDIR}/hwloc/topology-xml-libxml.c>
+    $<$<AND:$<BOOL:${HWLOC_HAVE_OPENCL}>,$<NOT:$<BOOL:${HWLOC_HAVE_PLUGINS}>>>:${TOPDIR}/hwloc/topology-opencl.c>
+    $<$<AND:$<BOOL:${HAVE_CUDA}>,$<NOT:$<BOOL:${HWLOC_HAVE_PLUGINS}>>>:${TOPDIR}/hwloc/topology-cuda.c>
 )
 
 target_link_libraries(hwloc PRIVATE
-    $<$<BOOL:${HWLOC_HAVE_LIBXML2}>:LibXml2::LibXml2>
-    $<$<BOOL:${HWLOC_HAVE_OPENCL}>:OpenCL::OpenCL>
-    "$<$<BOOL:${HAVE_CUDA}>:CUDA::cudart;CUDA::cuda_driver>"
+    $<$<AND:$<BOOL:${HWLOC_HAVE_LIBXML2}>,$<NOT:$<BOOL:${HWLOC_HAVE_PLUGINS}>>>:LibXml2::LibXml2>
+    $<$<AND:$<BOOL:${HWLOC_HAVE_OPENCL}>,$<NOT:$<BOOL:${HWLOC_HAVE_PLUGINS}>>>:OpenCL::OpenCL>
+    "$<$<AND:$<BOOL:${HAVE_CUDA}>,$<NOT:$<BOOL:${HWLOC_HAVE_PLUGINS}>>>:CUDA::cudart;CUDA::cuda_driver>"
 )
 
-if(HWLOC_BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS)
     target_compile_definitions(hwloc PRIVATE $<$<BOOL:${MSVC}>:_USRDLL>)
 endif()
 
@@ -153,6 +185,38 @@ target_include_directories(hwloc PUBLIC
     "$<BUILD_INTERFACE:${TOPDIR}/include;${CMAKE_CURRENT_BINARY_DIR}/include>"
     $<INSTALL_INTERFACE:include>
 )
+
+# plugin support
+foreach(plugin IN LISTS HWLOC_ENABLED_PLUGINS_LIST)
+    # custom settings per plugin
+    if(plugin STREQUAL "cuda")
+        add_library(hwloc_${plugin} MODULE ${TOPDIR}/hwloc/topology-${plugin}.c)
+        target_link_libraries(hwloc_${plugin} PRIVATE hwloc CUDA::cudart CUDA::cuda_driver)
+    elseif(plugin STREQUAL "opencl")
+        add_library(hwloc_${plugin} MODULE ${TOPDIR}/hwloc/topology-${plugin}.c)
+        target_link_libraries(hwloc_${plugin} PRIVATE hwloc OpenCL::OpenCL)
+    elseif(plugin STREQUAL "xml_libxml")
+        add_library(hwloc_${plugin} MODULE ${TOPDIR}/hwloc/topology-xml-libxml.c)
+        target_link_libraries(hwloc_${plugin} PRIVATE hwloc LibXml2::LibXml2)
+    endif()
+
+    # common settings for all plugins
+    target_compile_definitions(hwloc_${plugin} PRIVATE "HWLOC_INSIDE_PLUGIN")
+
+    target_compile_definitions(hwloc_${plugin} PRIVATE $<$<BOOL:${MSVC}>:_USRDLL>)
+
+    target_include_directories(hwloc_${plugin} PUBLIC
+        "$<BUILD_INTERFACE:${TOPDIR}/include;${CMAKE_CURRENT_BINARY_DIR}/include>"
+        $<INSTALL_INTERFACE:include>
+    )
+endforeach()
+
+if(HWLOC_ENABLE_PLUGINS)
+    message(STATUS "Enabled plugins:")
+    foreach(plugin IN LISTS HWLOC_ENABLED_PLUGINS_LIST)
+        message(STATUS "  - ${plugin}")
+    endforeach()
+endif()
 
 # Tools under utils/hwloc
 
@@ -232,6 +296,15 @@ endforeach(target)
 # Install
 
 install(TARGETS hwloc)
+
+# install plugins
+foreach(plugin IN LISTS HWLOC_ENABLED_PLUGINS_LIST)
+    install(TARGETS hwloc_${plugin}
+        LIBRARY DESTINATION lib/hwloc
+        ARCHIVE DESTINATION lib/hwloc
+        RUNTIME DESTINATION bin/hwloc
+    )
+endforeach()
 
 if(NOT HWLOC_SKIP_TOOLS)
     install(TARGETS ${TOOLS})

--- a/contrib/windows-cmake/private_config.h.in
+++ b/contrib/windows-cmake/private_config.h.in
@@ -4,6 +4,7 @@
  * Copyright © 2009-2022 Inria.  All rights reserved.
  * Copyright © 2009, 2011, 2012, 2015 Université Bordeaux.  All rights reserved.
  * Copyright © 2009-2020 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2025 Siemens Corporation and/or its affiliates.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -492,9 +493,11 @@
 /* Define to 1 if you have the `OpenCL' library. */
 #cmakedefine HWLOC_HAVE_OPENCL @HWLOC_HAVE_OPENCL@
 
-/* Define to 1 if the hwloc library should support dynamically-loaded plugins
-   */
-/* #undef HWLOC_HAVE_PLUGINS */
+/* Define to 1 if the hwloc library should support dynamically-loaded plugins */
+#cmakedefine HWLOC_HAVE_PLUGINS @HWLOC_HAVE_PLUGINS@
+
+/* The hwloc plugins path */
+#cmakedefine HWLOC_PLUGINS_PATH "@HWLOC_PLUGINS_PATH@"
 
 /* `Define to 1 if you have pthread_getthrds_np' */
 /* #undef HWLOC_HAVE_PTHREAD_GETTHRDS_NP */

--- a/contrib/windows-cmake/static-components.h.in
+++ b/contrib/windows-cmake/static-components.h.in
@@ -1,3 +1,6 @@
+/*
+ * Copyright © 2025 Siemens Corporation and/or its affiliates.  All rights reserved.
+ */
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_noos_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_xml_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_synthetic_component;
@@ -6,13 +9,13 @@ HWLOC_DECLSPEC extern const struct hwloc_component hwloc_windows_component;
 #ifdef HWLOC_HAVE_X86_CPUID
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_x86_component;
 #endif
-#ifdef HWLOC_HAVE_LIBXML2
+#if !defined(HWLOC_HAVE_PLUGINS) && defined(HWLOC_HAVE_LIBXML2)
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_xml_libxml_component;
 #endif
-#ifdef HWLOC_HAVE_OPENCL
+#if !defined(HWLOC_HAVE_PLUGINS) && defined(HWLOC_HAVE_OPENCL)
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_opencl_component;
 #endif
-#ifdef HWLOC_HAVE_CUDART
+#if !defined(HWLOC_HAVE_PLUGINS) && defined(HWLOC_HAVE_CUDART)
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_cuda_component;
 #endif
 
@@ -25,13 +28,13 @@ static const struct hwloc_component * hwloc_static_components[] = {
 #ifdef HWLOC_HAVE_X86_CPUID
   &hwloc_x86_component,
 #endif
-#ifdef HWLOC_HAVE_OPENCL
+#if !defined(HWLOC_HAVE_PLUGINS) && defined(HWLOC_HAVE_OPENCL)
   &hwloc_opencl_component,
 #endif
-#ifdef HWLOC_HAVE_CUDART
+#if !defined(HWLOC_HAVE_PLUGINS) && defined(HWLOC_HAVE_CUDART)
   &hwloc_cuda_component,
 #endif
-#ifdef HWLOC_HAVE_LIBXML2
+#if !defined(HWLOC_HAVE_PLUGINS) && defined(HWLOC_HAVE_LIBXML2)
   &hwloc_xml_libxml_component,
 #endif
   NULL

--- a/include/hwloc/plugins.h
+++ b/include/hwloc/plugins.h
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * Copyright © 2013-2024 Inria.  All rights reserved.
  * Copyright © 2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright © 2025 Siemens Corporation and/or its affiliates.  All rights reserved.
  * See COPYING in top-level directory.
  */
 
@@ -20,7 +21,7 @@ struct hwloc_backend;
 /* needed for hwloc_plugin_check_namespace() */
 #ifdef HWLOC_HAVE_LTDL
 #include <ltdl.h>
-#else
+#elif !defined(HWLOC_WIN_SYS)
 #include <dlfcn.h>
 #endif
 #endif
@@ -334,6 +335,8 @@ hwloc_plugin_check_namespace(const char *pluginname __hwloc_attribute_unused, co
   void *sym;
 #ifdef HWLOC_HAVE_LTDL
   lt_dlhandle handle = lt_dlopen(NULL);
+#elif defined(HWLOC_WIN_SYS)
+  HMODULE handle = GetModuleHandleA(NULL);
 #else
   void *handle = dlopen(NULL, RTLD_NOW|RTLD_LOCAL);
 #endif
@@ -343,6 +346,9 @@ hwloc_plugin_check_namespace(const char *pluginname __hwloc_attribute_unused, co
 #ifdef HWLOC_HAVE_LTDL
   sym = lt_dlsym(handle, symbol);
   lt_dlclose(handle);
+#elif defined(HWLOC_WIN_SYS)
+  sym = GetModuleHandleA("hwloc.dll");
+  FreeLibrary(handle);
 #else
   sym = dlsym(handle, symbol);
   dlclose(handle);


### PR DESCRIPTION
This pull request introduces plugin support for Windows, mirroring the existing functionality available on Linux.

**Enabling Plugin Support**:
To enable plugin support during CMake configuration, use the following flag: `-DHWLOC_ENABLE_PLUGINS=true`

**Supported Plugins**:
Currently supported plugins include:

* libxml2 (for XML output/input)
* cuda (for NVIDIA GPUs)
* opencl (for AMD and Intel GPUs)

**Plugin Installation and Configuration**:
Plugins are installed to `.../lib/hwloc/` by default, consistent with the Linux installation path. To ensure plugins are discovered and loaded, this path must be added to the `HWLOC_PLUGINS_PATH` environment variable.

**Demonstration Examples**:
The following examples illustrate successful plugin loading and hardware detection on various Windows systems. In these examples, the libxml2 plugin is shown failing to load (Failed to load plugin: The specified module could not be found.) to demonstrate the behavior when a plugin is built but its path is not correctly configured or available to `HWLOC_PLUGINS_PATH`.

* NVIDIA GPU (via `cuda` plugin):
```
hwloc: Starting plugin dlforeach in C:\Users\<omitted>\hwloc\lib\hwloc
hwloc: Looking under C:\Users\<omitted>\hwloc\lib\hwloc
hwloc: Plugin dlforeach found `C:\Users\<omitted>\hwloc\lib\hwloc\hwloc_cuda'
hwloc: Plugin contains expected symbol `hwloc_cuda_component'
hwloc: Plugin descriptor `hwloc_cuda' ready
hwloc: Plugin descriptor `hwloc_cuda' queued
hwloc: Plugin dlforeach found `C:\Users\<omitted>\hwloc\lib\hwloc\hwloc_opencl'
hwloc: Plugin contains expected symbol `hwloc_opencl_component'
hwloc: Plugin descriptor `hwloc_opencl' ready
hwloc: Plugin descriptor `hwloc_opencl' queued
hwloc: Plugin dlforeach found `C:\Users\<omitted>\hwloc\lib\hwloc\hwloc_xml_libxml'
hwloc: Failed to load plugin: The specified module could not be found.
...
    <object type="OSDev" gp_index="200" name="cuda0" subtype="CUDA" osdev_type="5">
      <info name="Backend" value="CUDA"/>
      <info name="GPUVendor" value="NVIDIA Corporation"/>
      <info name="GPUModel" value="Quadro RTX 5000"/>
      <info name="CUDAGlobalMemorySize" value="16597632"/>
      <info name="CUDAL2CacheSize" value="4096"/>
      <info name="CUDAMultiProcessors" value="48"/>
      <info name="CUDASharedMemorySizePerMP" value="48"/>
    </object>
    <object type="OSDev" gp_index="201" name="opencl0d0" subtype="OpenCL" osdev_type="5">
      <info name="Backend" value="OpenCL"/>
      <info name="OpenCLDeviceType" value="GPU"/>
      <info name="GPUVendor" value="NVIDIA Corporation"/>
      <info name="GPUModel" value="Quadro RTX 5000"/>
      <info name="OpenCLPlatformIndex" value="0"/>
      <info name="OpenCLPlatformName" value="NVIDIA CUDA"/>
      <info name="OpenCLPlatformDeviceIndex" value="0"/>
      <info name="OpenCLComputeUnits" value="48"/>
      <info name="OpenCLGlobalMemorySize" value="16597632"/>
    </object>
```

* AMD GPU (via `opencl` plugin):
```
hwloc: Starting plugin dlforeach in C:\Users\<omitted>\hwloc\lib\hwloc
hwloc: Looking under C:\Users\<omitted>\hwloc\lib\hwloc
hwloc: Plugin dlforeach found `C:\Users\<omitted>\hwloc\lib\hwloc\hwloc_cuda'
hwloc: Failed to load plugin: The specified module could not be found.
hwloc: Plugin dlforeach found `C:\Users\<omitted>\hwloc\lib\hwloc\hwloc_opencl'
hwloc: Plugin contains expected symbol `hwloc_opencl_component'
hwloc: Plugin descriptor `hwloc_opencl' ready
hwloc: Plugin descriptor `hwloc_opencl' queued
hwloc: Plugin dlforeach found `C:\Users\<omitted>\hwloc\lib\hwloc\hwloc_xml_libxml'
hwloc: Failed to load plugin: The specified module could not be found.
...
    <object type="OSDev" gp_index="268" name="opencl0d0" subtype="OpenCL" osdev_type="5">
      <info name="Backend" value="OpenCL"/>
      <info name="OpenCLDeviceType" value="GPU"/>
      <info name="GPUVendor" value="Advanced Micro Devices, Inc."/>
      <info name="GPUModel" value="AMD Radeon PRO W6800"/>
      <info name="OpenCLPlatformIndex" value="0"/>
      <info name="OpenCLPlatformName" value="AMD Accelerated Parallel Processing"/>
      <info name="OpenCLPlatformDeviceIndex" value="0"/>
      <info name="OpenCLComputeUnits" value="30"/>
      <info name="OpenCLGlobalMemorySize" value="31440896"/>
    </object>
```
* Intel GPU (via `opencl` plugin):
```
hwloc: Starting plugin dlforeach in C:\Users\<omitted>\hwloc\lib\hwloc
hwloc: Looking under C:\Users\<omitted>\hwloc\lib\hwloc
hwloc: Plugin dlforeach found `C:\Users\<omitted>\hwloc\lib\hwloc\hwloc_cuda'
hwloc: Failed to load plugin: The specified module could not be found.
hwloc: Plugin dlforeach found `C:\Users\<omitted>\hwloc\lib\hwloc\hwloc_opencl'
hwloc: Plugin contains expected symbol `hwloc_opencl_component'
hwloc: Plugin descriptor `hwloc_opencl' ready
hwloc: Plugin descriptor `hwloc_opencl' queued
hwloc: Plugin dlforeach found `C:\Users\<omitted>\hwloc\lib\hwloc\hwloc_xml_libxml'
hwloc: Failed to load plugin: The specified module could not be found.
...
    <object type="OSDev" gp_index="60" name="opencl0d0" subtype="OpenCL" osdev_type="5">
      <info name="Backend" value="OpenCL"/>
      <info name="OpenCLDeviceType" value="GPU"/>
      <info name="GPUVendor" value="Intel(R) Corporation"/>
      <info name="GPUModel" value="Intel(R) Graphics"/>
      <info name="OpenCLPlatformIndex" value="0"/>
      <info name="OpenCLPlatformName" value="Intel(R) OpenCL Graphics"/>
      <info name="OpenCLPlatformDeviceIndex" value="0"/>
      <info name="OpenCLComputeUnits" value="64"/>
      <info name="OpenCLGlobalMemorySize" value="17212992"/>
    </object>
```