### PR TITLE
Support building shared library for Windows.

### DIFF
--- a/contrib/windows-cmake/CMakeLists.txt
+++ b/contrib/windows-cmake/CMakeLists.txt
@@ -108,7 +108,15 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/static-components.h.in include/static
 add_compile_definitions($<$<CONFIG:DEBUG>:HWLOC_DEBUG=1>)
 
 # FIXME dll soname
-add_library(hwloc
+if(HWLOC_BUILD_SHARED_LIBS)
+    add_library(hwloc SHARED)
+else()
+    add_library(hwloc)
+endif()
+
+target_sources(
+    hwloc
+    PRIVATE
     ${TOPDIR}/hwloc/topology.c
     ${TOPDIR}/hwloc/traversal.c
     ${TOPDIR}/hwloc/distances.c


### PR DESCRIPTION
Related: https://github.com/open-mpi/hwloc/issues/735

We need a shared object that Python can load. Output from `dumpbin` for `lstopo`:
```
dumpbin /dependents .\bin\lstopo.exe
Microsoft (R) COFF/PE Dumper Version 14.44.35214.0
Copyright (C) Microsoft Corporation.  All rights reserved.


Dump of file .\bin\lstopo.exe

File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    hwloc.dll
    KERNEL32.dll
    USER32.dll
    GDI32.dll
    VCRUNTIME140.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-environment-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-filesystem-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
    api-ms-win-crt-time-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll

  Summary

        1000 .00cfg
        2000 .data
        4000 .idata
        2000 .pdata
        A000 .rdata
        1000 .reloc
        1000 .rsrc
       1D000 .text
```