### PR TITLE
Optional XML output from doxygen.

### DIFF
--- a/doc/doxygen.cfg
+++ b/doc/doxygen.cfg
@@ -2137,7 +2137,7 @@ MAN_LINKS              = YES
 # captures the structure of the code including all documentation.
 # The default value is: NO.
 
-GENERATE_XML           = NO
+GENERATE_XML           = $(HWLOC_DOXYGEN_GENERATE_XML)
 
 # The XML_OUTPUT tag is used to specify where the XML pages will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
To generate XML output using doxygen, specify the environment variable `HWLOC_DOXYGEN_GENERATE_XML=YES` when running doxygen:

```sh
HWLOC_DOXYGEN_GENERATE_XML=YES doxygen ./doxygen.cfg
```

If the environment variable is not set, doxygen will use the default `NO`.