### PR TITLE
linux: add cxi* osdev for Cray Slingshot devices

### DIFF
--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1675,7 +1675,7 @@ components when I/O discovery is enabled and supported.
 <li>Network interfaces (::HWLOC_OBJ_OSDEV_NETWORK)
  <ul>
  <li><em>eth0</em>, <em>wlan0</em>, <em>ib0</em> (Linux component)</li>
- <li><em>hsn0</em> with "Slingshot" subtype for HPE Cray HSNs (Linux component).</li>
+ <li><em>cxi0</em> and <em>hsn0</em> with "Slingshot" subtype for HPE Cray HSNs (Linux component).</li>
  <li><em>bxi0</em> with "BXI" subtype for Atos/Bull BXI HCAs (Linux component).</li>
  <li>OpenFabrics devices as explained below.
  </ul>
@@ -2308,6 +2308,10 @@ interface, such as <tt>eth4</tt> on Linux.
 the state of a port #1 (value is 4 when active),
 the LID and LID mask count of port #2,
 and GID #1 of port #3.
+</dd>
+<dt>CassiniVersion=1.1</dt>
+<dt>NID=0x6913</dt>
+<dd>The version of the Cassini NIC and the node ID for a Slingshot CXI interface.
 </dd>
 <dt>BXIUUID=0x720109782dfd (Network BXI OS devices)</dt>
 <dd>The UUID of an Atos/Bull BXI HCA.

--- a/utils/hwloc/hwloc-gather-topology.in
+++ b/utils/hwloc/hwloc-gather-topology.in
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright © 2009 CNRS
-# Copyright © 2009-2025 Inria.  All rights reserved.
+# Copyright © 2009-2026 Inria.  All rights reserved.
 # Copyright © 2009-2012 Université Bordeaux
 # Copyright © 2014 Cisco Systems, Inc.  All rights reserved.
 # See COPYING in top-level directory.
@@ -317,6 +317,7 @@ if [ x$gatherio = x1 ]; then
   saveclassdir "$destdir/$basename" net
   saveclassdir "$destdir/$basename" ve
   saveclassdir "$destdir/$basename" bxi
+  saveclassdir "$destdir/$basename" cxi
   saveclassdir "$destdir/$basename" mic
   # udev block data
   ls -d /run/udev/data/b* 2>/dev/null | while read -r path ; do savefile "$destdir/$basename" "$path" ; done


### PR DESCRIPTION
We already have hsi*/hsn* devices for network interfaces. libfabric rather uses CXI devices. Add those devices too, so that we don't have to make sure whether cxiX matches hsnX on machines with multiple NICs (quite common).

Add with CassiniVersion and NID attributes.

Gather the cxi class in hwloc-gather-topology

Example of output on a Cray EX255a:
$ lstopo --only osdev -v | grep Slings
OSDev[Network](Slingshot) L#0 (Address=02:00:00:00:68:63) "hsn0" OSDev[Network](Slingshot) L#1 (CassiniVersion=1.1 NID=0x6863) "cxi0" OSDev[Network](Slingshot) L#4 (Address=02:00:00:00:68:62) "hsn1" OSDev[Network](Slingshot) L#5 (CassiniVersion=1.1 NID=0x6862) "cxi1" OSDev[Network](Slingshot) L#7 (Address=02:00:00:00:68:a3) "hsn2" OSDev[Network](Slingshot) L#8 (CassiniVersion=1.1 NID=0x68a3) "cxi2" OSDev[Network](Slingshot) L#10 (Address=02:00:00:00:68:a2) "hsn3" OSDev[Network](Slingshot) L#11 (CassiniVersion=1.1 NID=0x68a2) "cxi3"

Thanks to Edgar Leon for the suggestion