### PR TITLE
xml/diff: free partial diff list when import fails

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -1879,7 +1879,7 @@ hwloc__xml_import_diff(hwloc__xml_import_state_t state,
 
     ret = state->global->find_child(state, &childstate, &tag);
     if (ret < 0)
-      return -1;
+      goto out_with_diff;
     if (!ret)
       break;
 
@@ -1889,13 +1889,17 @@ hwloc__xml_import_diff(hwloc__xml_import_state_t state,
       ret = -1;
 
     if (ret < 0)
-      return ret;
+      goto out_with_diff;
 
     state->global->close_child(&childstate);
   }
 
   *firstdiffp = firstdiff;
   return 0;
+
+ out_with_diff:
+  hwloc_topology_diff_destroy(firstdiff);
+  return -1;
 }
 
 /***********************************


### PR DESCRIPTION
hwloc__xml_import_diff() returns -1 when find_child errors out or a non-"diff" child is hit, but if some <diff> entries were already accepted, firstdiff (and the strdup'd name/oldvalue/newvalue inside each entry) is leaked: the caller sees *firstdiffp still NULL and has no way to free it.

Reproduced with hwloc_topology_diff_load_xmlbuffer() on a `<topologydiff>` containing two valid `<diff type="0" obj_attr_type="2" .../>` entries followed by a `<bogus/>` element. `leaks --atExit` reports 8 leaks / 224 bytes before the patch, 0 after.