### PR TITLE
xml/nolibxml: reject zero or negative input buffer length

### DIFF
--- a/hwloc/topology-xml-nolibxml.c
+++ b/hwloc/topology-xml-nolibxml.c
@@ -400,6 +400,12 @@ hwloc_nolibxml_backend_init(struct hwloc_xml_backend_data_s *bdata,
   bdata->data = nbdata;
 
   if (xmlbuffer) {
+    if (xmlbuflen < 1) {
+      if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_XML|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+        fprintf(stderr, "hwloc/nolibxml: Invalid input buffer length %d.\n", xmlbuflen);
+      errno = EINVAL;
+      goto out_with_nbdata;
+    }
     nbdata->buffer = malloc(xmlbuflen);
     if (!nbdata->buffer) {
       if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_XML|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
@@ -445,6 +451,12 @@ hwloc_nolibxml_import_diff(struct hwloc__xml_import_state_s *state,
   HWLOC_BUILD_ASSERT(sizeof(*nstate) <= sizeof(state->data));
 
   if (xmlbuffer) {
+    if (xmlbuflen < 1) {
+      if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_XML|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+        fprintf(stderr, "hwloc/nolibxml: Invalid input diff buffer length %d.\n", xmlbuflen);
+      errno = EINVAL;
+      goto out;
+    }
     buffer = malloc(xmlbuflen);
     if (!buffer) {
       if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_XML|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))


### PR DESCRIPTION
hwloc_nolibxml_backend_init() and hwloc_nolibxml_import_diff() do `buffer[xmlbuflen-1] = '\0'` after `malloc(xmlbuflen)` of the caller-supplied buffer. When hwloc_topology_set_xmlbuffer() or hwloc_topology_diff_load_xmlbuffer() is called with `size <= 0`, malloc returns a non-NULL 0-byte chunk on macOS/glibc and the write lands one byte before it. Reject with EINVAL before the allocation.