### PR TITLE
diff: report name appearing/disappearing as too complex

### DIFF
--- a/hwloc/diff.c
+++ b/hwloc/diff.c
@@ -156,8 +156,12 @@ hwloc_diff_trees(hwloc_topology_t topo1, hwloc_obj_t obj1,
 
 	/* gp_index don't have to be strictly identical */
 
-	if ((!obj1->name) != (!obj2->name)
-	    || (obj1->name && strcmp(obj1->name, obj2->name))) {
+	if ((!obj1->name) != (!obj2->name))
+		/* the NAME diff requires both old and new values; name appearing
+		 * or disappearing cannot be represented and won't round-trip
+		 * through XML import/export or apply */
+		goto out_too_complex;
+	if (obj1->name && strcmp(obj1->name, obj2->name)) {
                 err = hwloc_append_diff_obj_attr_string(topo1, obj1,
 						       HWLOC_TOPOLOGY_DIFF_OBJ_ATTR_NAME,
 						       NULL,


### PR DESCRIPTION
With two topologies where the same object has a name on one side and not on the other, `hwloc_diff_trees()` emits a `HWLOC_TOPOLOGY_DIFF_OBJ_ATTR_NAME` entry with either `oldvalue` or `newvalue` set to NULL. The XML export then dereferences NULL:

```
* thread #1, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  * frame #0: libsystem_platform.dylib`_platform_strlen + 4
    frame #1: hwloc__nolibxml_export_escape_string(src=0x0) at topology-xml-nolibxml.c:565
    frame #2: hwloc__nolibxml_export_new_prop(state, name="obj_attr_newvalue", value=0x0) at topology-xml-nolibxml.c:641
    frame #3: hwloc__xml_export_diff(parentstate, diff) at topology-xml.c:2917
    frame #4: hwloc_topology_diff_export_xmlbuffer(diff, ...)
```

The XML diff schema and `hwloc_apply_diff_one()` both require non-NULL old/new values, so a name appearing or disappearing cannot round-trip; report it as too_complex like the surrounding subtype/os_index/cpuset mismatches already do.