### PR TITLE
xml: free imported object leaked on invalid child tag

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -754,7 +754,7 @@ hwloc__xml_import_object(hwloc_topology_t topology,
     tag = NULL;
     ret = state->global->find_child(state, &childstate, &tag);
     if (ret < 0)
-      goto error;
+      goto error_with_object;
     if (!ret)
       break;
 
@@ -784,7 +784,7 @@ hwloc__xml_import_object(hwloc_topology_t topology,
     }
 
     if (ret < 0)
-      goto error;
+      goto error_with_object;
 
     state->global->close_child(&childstate);
   }


### PR DESCRIPTION
hwloc__xml_import_object() leaks the not-yet-inserted object on an unknown child tag because the subnode loop uses `goto error` instead of `goto error_with_object`.