### PR TITLE
xml: reject distances2 nbobjs whose square overflows unsigned

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -1232,6 +1232,15 @@ hwloc__xml_import_distances(hwloc_topology_t topology,
     goto out;
   }
 
+  /* the nbobjs*nbobjs values matrix is allocated and indexed using unsigned
+   * arithmetic below, reject nbobjs whose square would overflow. */
+  if (nbobjs > UINT_MAX / nbobjs) {
+    if (state->global->show_errors)
+      fprintf(stderr, "%s: %s with too many objects (%u)\n",
+	      state->global->msgprefix, _TAG_NAME, nbobjs);
+    goto out;
+  }
+
   indexes = malloc(nbobjs*sizeof(*indexes));
   u64values = malloc(nbobjs*nbobjs*sizeof(*u64values));
   if (heterotypes)


### PR DESCRIPTION
`nbobjs*nbobjs` at topology-xml.c:1236 is computed in 32-bit unsigned, so a `<distances2>` with nbobjs >= 65536 in untrusted XML wraps it to a tiny or zero malloc while the values matrix is still indexed over the full nbobjs. Reject nbobjs whose square overflows before allocating.