### PR TITLE
xml: reject imported object missing complete_cpuset/nodeset

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -866,9 +866,10 @@ hwloc__xml_import_object(hwloc_topology_t topology,
   }
 
   /* check special types vs cpuset+nodeset */
-  if ((!obj->cpuset || !obj->nodeset) && !hwloc__obj_type_is_special(obj->type)) {
+  if ((!obj->cpuset || !obj->complete_cpuset || !obj->nodeset || !obj->complete_nodeset)
+      && !hwloc__obj_type_is_special(obj->type)) {
     if (state->global->show_errors)
-      fprintf(stderr, "%s: invalid normal or memory object %s P#%u without cpuset and nodeset\n",
+      fprintf(stderr, "%s: invalid normal or memory object %s P#%u without cpuset, complete_cpuset, nodeset and complete_nodeset\n",
 	      state->global->msgprefix, hwloc_obj_type_string(obj->type), obj->os_index);
     goto error_with_object;
   }


### PR DESCRIPTION
Found while fuzzing hwloc_topology_set_xmlbuffer(). hwloc__xml_import_object() only requires cpuset and nodeset on normal/memory objects, but the sibling reorder right below it assumes complete_cpuset is set and hwloc_bitmap_compare_first() dereferences it. A crafted object with cpuset and nodeset but no complete_cpuset passes the check and then segfaults during load. The exporter always writes all four sets together, so require them all here.