### PR TITLE
synthetic: reject description whose total object count overflows

### DIFF
--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -634,6 +634,12 @@ hwloc_backend_synthetic_init(struct hwloc_synthetic_backend_data_s *data,
       errno = EINVAL;
       goto error;
     }
+    if (item > ULONG_MAX / totalarity) {
+      if (show_errors)
+	fprintf(stderr,"hwloc/synthetic: Total number of objects too large at '%s'\n", pos);
+      errno = EINVAL;
+      goto error;
+    }
 
     totalarity *= item;
     data->level[count].totalwidth = totalarity;


### PR DESCRIPTION
Noticed `totalarity *= item` in hwloc_backend_synthetic_init has no overflow check, while the `item > UINT_MAX` guard just below only caps a single level. A description like "65536 65536 65536 65536" wraps the unsigned long product to 0, and that wrapped value becomes the level totalwidth that sizes the indexes= array via calloc, so the generator then reads it out of bounds. UBSan flags the multiply at topology-synthetic.c:638 via hwloc_topology_set_synthetic(). Reject it before the product overflows, like the existing arity cap.