### PR TITLE
xml: avoid NULL name deref when importing v2 distances2

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -1426,7 +1426,7 @@ hwloc__xml_import_distances(hwloc_topology_t topology,
 
   if (data->version_major < 3) {
     /* XGMIHops was latency in v2 */
-    if ((kind & HWLOC_DISTANCES_KIND_VALUE_LATENCY) && !strcmp(name, "XGMIHops"))
+    if ((kind & HWLOC_DISTANCES_KIND_VALUE_LATENCY) && name && !strcmp(name, "XGMIHops"))
       kind = (kind & ~HWLOC_DISTANCES_KIND_VALUE_LATENCY) | HWLOC_DISTANCES_KIND_VALUE_HOPS;
   }
 


### PR DESCRIPTION
The name attribute is optional on `distances2` and the exporter only writes it when set, so a v2 `distances2` without name reaches `strcmp(name, "XGMIHops")` at topology-xml.c:1429 and segfaults on load. Skip the compare when name is NULL.