### PR TITLE
xml/libxml: avoid NULL SystemID deref when DTD has no system id

### DIFF
--- a/hwloc/topology-xml-libxml.c
+++ b/hwloc/topology-xml-libxml.c
@@ -188,10 +188,10 @@ hwloc_libxml_look_init(struct hwloc_xml_backend_data_s *bdata,
     if (state->global->show_errors)
       fprintf(stderr, "%s: Loading XML topology without DTD\n",
 	      state->global->msgprefix);
-  } else if (strcmp((char *) dtd->SystemID, "hwloc2.dtd")) {
+  } else if (!dtd->SystemID || strcmp((char *) dtd->SystemID, "hwloc2.dtd")) {
     if (state->global->show_errors)
       fprintf(stderr, "%s: Loading XML topology with wrong DTD SystemID (%s instead of %s)\n",
-	      state->global->msgprefix, (char *) dtd->SystemID, "hwloc2.dtd");
+	      state->global->msgprefix, dtd->SystemID ? (char *) dtd->SystemID : "none", "hwloc2.dtd");
   }
 
   root_node = xmlDocGetRootElement((xmlDocPtr) bdata->data);


### PR DESCRIPTION
libxml2 leaves dtd->SystemID NULL for a `<!DOCTYPE topology>` declared without a SYSTEM id, so hwloc_libxml_look_init() at topology-xml-libxml.c:191 hands NULL to strcmp and segfaults on load (reachable from hwloc_topology_set_xml{,buffer}). Treat a missing SystemID like a wrong one instead of dereferencing it.