### PR TITLE
xml/nolibxml: reject topology tag without closing bracket

### DIFF
--- a/hwloc/topology-xml-nolibxml.c
+++ b/hwloc/topology-xml-nolibxml.c
@@ -276,7 +276,10 @@ hwloc_nolibxml_look_init(struct hwloc_xml_backend_data_s *bdata,
   if (sscanf(buffer, "<topology version=\"%u.%u\">", &major, &minor) == 2) {
     bdata->version_major = major;
     bdata->version_minor = minor;
-    end = strchr(buffer, '>') + 1;
+    end = strchr(buffer, '>');
+    if (!end)
+      goto failed;
+    end++;
   } else
     goto failed;
 


### PR DESCRIPTION
hwloc_nolibxml_look_init() does `end = strchr(buffer, '>') + 1` after the version sscanf, but sscanf returns 2 even when the topology tag has no closing '>'. strchr then returns NULL, end becomes (char*)1, and the first find_child() dereferences it in strspn() at load time. A buffer like `<topology version="2.0"` passed to hwloc_topology_set_xmlbuffer() segfaults (verified with the nolibxml backend, EXC_BAD_ACCESS at address 0x1); bail out when there is no '>'.