### PR TITLE
xml/libxml: avoid NULL SystemID deref in diff import

### DIFF
--- a/hwloc/topology-xml-libxml.c
+++ b/hwloc/topology-xml-libxml.c
@@ -291,10 +291,10 @@ hwloc_libxml_import_diff(struct hwloc__xml_import_state_s *state, const char *xm
     if (state->global->show_errors)
       fprintf(stderr, "%s: Loading XML topologydiff without DTD\n",
 	      state->global->msgprefix);
-  } else if (strcmp((char *) dtd->SystemID, "hwloc2-diff.dtd")) {
+  } else if (!dtd->SystemID || strcmp((char *) dtd->SystemID, "hwloc2-diff.dtd")) {
     if (state->global->show_errors)
       fprintf(stderr, "%s: Loading XML topologydiff with wrong DTD SystemID (%s instead of %s)\n",
-	      state->global->msgprefix, (char *) dtd->SystemID, "hwloc2-diff.dtd");
+	      state->global->msgprefix, dtd->SystemID ? (char *) dtd->SystemID : "none", "hwloc2-diff.dtd");
   }
 
   root_node = xmlDocGetRootElement(doc);


### PR DESCRIPTION
Sibling of #786 in the libxml diff path: hwloc_libxml_import_diff also strcmps dtd->SystemID directly, so a topologydiff XML with `<!DOCTYPE topologydiff>` (no SYSTEM id) makes libxml2 return SystemID==NULL and hwloc_topology_diff_load_xml{,buffer}() segfaults. Guard the same way and print "none" when SystemID is NULL.