### PR TITLE
xml: reject pci_locality without required domain/bus_min/bus_max

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -1722,7 +1722,9 @@ hwloc__xml_import_pcilocality(hwloc_topology_t topology,
                               hwloc__xml_import_state_t state)
 {
   hwloc_bitmap_t cpuset = NULL;
-  unsigned domain, bus_min, bus_max;
+  unsigned domain = (unsigned) -1;
+  unsigned bus_min = (unsigned) -1;
+  unsigned bus_max = (unsigned) -1;
 
   while (1) {
     char *attrname, *attrvalue;
@@ -1750,6 +1752,12 @@ hwloc__xml_import_pcilocality(hwloc_topology_t topology,
   if (!cpuset) {
     if (state->global->show_errors)
       fprintf(stderr, "%s: ignoring pci_locality without cpuset\n",
+              state->global->msgprefix);
+    goto error;
+  }
+  if (domain == (unsigned) -1 || bus_min == (unsigned) -1 || bus_max == (unsigned) -1) {
+    if (state->global->show_errors)
+      fprintf(stderr, "%s: ignoring pci_locality without domain/bus_min/bus_max\n",
               state->global->msgprefix);
     goto error;
   }


### PR DESCRIPTION
Noticed hwloc__xml_import_pcilocality leaves domain, bus_min and bus_max
uninitialized and only writes them if the attribute is present, so a
<pci_locality cpuset="..."/> imported via hwloc_topology_set_xml{,buffer}
stores stack garbage as the bus range. Round-tripping such a topology
exports e.g. bus_min="0xf20520" bus_max="0xffffffff". The DTD already
marks all three as #REQUIRED; reject the element when any is missing.