### PR TITLE
distances: zero-init duped entry to avoid bad free on error

### DIFF
--- a/hwloc/distances.c
+++ b/hwloc/distances.c
@@ -130,7 +130,7 @@ static int hwloc_internal_distances_dup_one(struct hwloc_topology *new, struct h
   struct hwloc_internal_distances_s *newdist;
   unsigned nbobjs = olddist->nbobjs;
 
-  newdist = hwloc_tma_malloc(tma, sizeof(*newdist));
+  newdist = hwloc_tma_calloc(tma, sizeof(*newdist));
   if (!newdist)
     return -1;
   if (olddist->name) {


### PR DESCRIPTION
hwloc_internal_distances_dup_one() at hwloc/distances.c:133 uses hwloc_tma_malloc and only assigns newdist->name before potentially calling hwloc_internal_distances_free on early failure (hwloc_tma_strdup of the name, or hwloc_tma_malloc of different_types). The free path then runs free() on uninitialized different_types/indexes/objs/values. Switch to hwloc_tma_calloc so the error path frees NULL pointers instead.