### PR TITLE
pci: only read 16-bit link status to avoid config space overread

### DIFF
--- a/hwloc/pci-common.c
+++ b/hwloc/pci-common.c
@@ -1217,9 +1217,12 @@ int
 hwloc_pcicommon_configspace_find_linkspeed(const unsigned char *config,
                                            unsigned offset, float *linkspeed)
 {
-  unsigned linksta, speed, width;
+  unsigned short linksta;
+  unsigned speed, width;
 
-  memcpy(&linksta, &config[offset + HWLOC_PCI_EXP_LNKSTA], 4);
+  /* the link status is a single 16-bit register, only read those two bytes
+   * so we don't run past the 256-byte config space when offset is near the end */
+  memcpy(&linksta, &config[offset + HWLOC_PCI_EXP_LNKSTA], 2);
   speed = linksta & HWLOC_PCI_EXP_LNKSTA_SPEED; /* PCIe generation */
   width = (linksta & HWLOC_PCI_EXP_LNKSTA_WIDTH) >> 4; /* how many lanes */
 


### PR DESCRIPTION
hwloc_pcicommon_configspace_find_linkspeed reads the PCIe link status register with a 4-byte memcpy, but link status is a single 16-bit register and the callers only check that offset+20 fits in the 256-byte config space cache. A device whose PCIe capability sits near the end of config space (offset up to 236) makes that 4-byte read run two bytes past the buffer. Reading only the two bytes the register actually occupies keeps the speed/width result identical and stays in bounds.