### PR TITLE
linux: reject nbnodes whose square overflows the distance matrix size

### DIFF
--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -3424,6 +3424,13 @@ look_sysfsnode(struct hwloc_topology *topology,
   if (!indexes)
     return 0;
 
+  if (nbnodes > UINT_MAX / nbnodes) {
+    /* the distance matrix below is nbnodes*nbnodes uint64_t, computed in
+     * unsigned int; reject sizes whose square would wrap before reaching malloc */
+    free(indexes);
+    return 0;
+  }
+
   nodes = calloc(nbnodes, sizeof(hwloc_obj_t));
   trees = calloc(nbnodes, sizeof(hwloc_obj_t));
   distances = malloc(nbnodes*nbnodes*sizeof(*distances));


### PR DESCRIPTION
look_sysfsnode() sizes the NUMA distance matrix with nbnodes*nbnodes*sizeof(uint64_t), but nbnodes*nbnodes is evaluated as unsigned int and wraps before the widening to size_t. A crafted sysfs root (HWLOC_FSROOT) whose /sys/devices/system/node/online lists 65536 nodes makes the product 0, so malloc hands back a tiny buffer that hwloc_parse_nodes_distances() then overruns with nbnodes*nbnodes uint64 writes. Guard the square before allocating, like the other matrix-sizing paths.