### PR TITLE
bitmap: avoid one-byte overread on empty sscanf input

### DIFF
--- a/hwloc/bitmap.c
+++ b/hwloc/bitmap.c
@@ -383,8 +383,9 @@ int hwloc_bitmap_sscanf(struct hwloc_bitmap_s *set, const char * __hwloc_restric
 
   /* count how many substrings there are */
   count++;
-  while ((current = strchr(current+1, ',')) != NULL)
-    count++;
+  if (*current)
+    while ((current = strchr(current+1, ',')) != NULL)
+      count++;
 
   current = string;
   if (!strncmp("0xf...f", current, 7)) {


### PR DESCRIPTION
hwloc_bitmap_sscanf counts comma-separated substrings with strchr(current+1, ','), but for an empty string current points at the terminating NUL so current+1 reads one byte past it. Skip the scan when the input is empty; non-empty strings keep the existing first-byte skip and parse identically. Reachable from the public API and from an empty cpuset/nodeset attribute in imported XML.