### PR TITLE
pci: check duplicated cpuset for NULL in hwloc_pci_dup

### DIFF
--- a/hwloc/pci-common.c
+++ b/hwloc/pci-common.c
@@ -587,7 +587,7 @@ hwloc_pci_dup(hwloc_topology_t new, hwloc_topology_t old)
       goto error;
     memcpy(newcur, oldcur, sizeof(*newcur));
     newcur->cpuset = hwloc_bitmap_tma_dup(tma, oldcur->cpuset);
-    if (!newcur) {
+    if (!newcur->cpuset) {
       assert(!tma || !tma->dontfree); /* this tma cannot fail to allocate */
       free(newcur);
       goto error;


### PR DESCRIPTION
Noticed the NULL check right after hwloc_bitmap_tma_dup in hwloc_pci_dup tests newcur, which was already verified one line above, instead of the just-assigned newcur->cpuset. On the non-tma hwloc_topology_dup path the bitmap dup can return NULL, so a locality with a NULL cpuset gets inserted and is then dereferenced during the refresh (hwloc_bitmap_and on cur->cpuset). Check newcur->cpuset.