### PR TITLE
synthetic: set last level arity sentinel before processing indexes

### DIFF
--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -840,6 +840,12 @@ hwloc_backend_synthetic_init(struct hwloc_synthetic_backend_data_s *data,
     count++;
   }
 
+  /* the deepest level has no children, mark its arity sentinel before
+   * hwloc_synthetic_process_indexes() runs since the index interleaving
+   * loop scans data->level[] until it finds arity==0 (backend data is
+   * malloc'ed, not zeroed) */
+  data->level[count-1].arity = 0;
+
   /* set default attributes that depend on the depth/hierarchy of levels */
   for (i=0; i<count; i++) {
     struct hwloc_synthetic_attached_s *attached;
@@ -853,7 +859,6 @@ hwloc_backend_synthetic_init(struct hwloc_synthetic_backend_data_s *data,
   hwloc_synthetic_process_indexes(data, &data->numa_attached_indexes, data->numa_attached_nr, show_errors);
 
   data->string = strdup(description);
-  data->level[count-1].arity = 0;
   return 0;
 
  error:


### PR DESCRIPTION
hwloc_synthetic_process_indexes() scans data->level[] until it finds arity==0, but the deepest level's arity sentinel is only set after these calls run and the backend data comes from a plain malloc(), not zeroed. A synthetic description that interleaves indexes by a type which isn't matched before the last level (an absent type, reachable via hwloc_topology_set_synthetic and HWLOC_SYNTHETIC) then reads the uninitialized arity and can walk past data->level[]. Move the sentinel assignment ahead of the process_indexes loop.