### PR TITLE
linux: check strchr result when iterating PCI busids in find_osdev_parent

### DIFF
--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -5700,7 +5700,7 @@ hwloc_linuxfs_find_osdev_parent(struct hwloc_topology *topology, int root_fd,
   int foundpci;
   unsigned pcidomain = 0, pcibus = 0, pcidev = 0, pcifunc = 0;
   unsigned _pcidomain, _pcibus, _pcidev, _pcifunc;
-  const char *tmp;
+  const char *tmp, *next;
   hwloc_obj_t parent;
   int err;
 
@@ -5744,8 +5744,11 @@ hwloc_linuxfs_find_osdev_parent(struct hwloc_topology *topology, int root_fd,
     pcibus = _pcibus;
     pcidev = _pcidev;
     pcifunc = _pcifunc;
-    tmp = strchr(tmp+4, ':')+9; /* tmp points to at least 4 digits for domain, then a ':' */
-    goto nextpci;
+    next = strchr(tmp+4, ':'); /* tmp points to at least 4 digits for domain, then a ':' */
+    if (next) {
+      tmp = next+9;
+      goto nextpci;
+    }
   }
   if (sscanf(tmp, "%x:%x.%x", &_pcibus, &_pcidev, &_pcifunc) == 3) {
     foundpci = 1;


### PR DESCRIPTION
hwloc_linuxfs_find_osdev_parent() advances along the PCI busid chain of a sysfs device link with `tmp = strchr(tmp+4, ':')+9` (topology-linux.c:5747), assuming the domain is always 4 hex digits. With a sysfs root taken from a container or HWLOC_FSROOT, a link target like `.../pci0000:00/0:0:0.0` still matches the `%x:%x:%x.%x` sscanf but makes strchr return NULL, so the next iteration parses from `(char*)0x9`. Keep the result in a temporary and only advance when a ':' is actually found.