### PR TITLE
linux: bound cxl uport busid parsing to link target length

### DIFF
--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -3128,10 +3128,11 @@ annotate_cxl_dax(hwloc_obj_t obj, unsigned region, int root_fd)
     if (!pcirootbus)
       break;
     slash = pcirootbus + 11; /* "/pciXXXX:YY/" */
-    if (*slash != '/')
+    if (slash > uportpath + err || *slash != '/') /* "/pci" may be near the end of the link target */
       break;
     pcibdf = NULL;
-    while (sscanf(slash, "/%x:%x:%x.%x/", &pcidomain, &pcibus, &pcidevice, &pcifunc) == 4) {
+    while (slash + 13 <= uportpath + err
+           && sscanf(slash, "/%x:%x:%x.%x/", &pcidomain, &pcibus, &pcidevice, &pcifunc) == 4) {
       pcibdf = slash+1;
       slash += 13;
     }


### PR DESCRIPTION
annotate_cxl_dax reads `*(pcirootbus+11)` (and may write `*slash`) past the uportpath buffer when a crafted CXL uport symlink is shorter than the assumed busid layout.