### PR TITLE
xml: avoid NULL parent deref when importing v2 bridge/pcidev as root

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -976,7 +976,7 @@ hwloc__xml_import_object(hwloc_topology_t topology,
   /* generate PCI localities from top level bridges or pcidevs if importing from v2 */
   if (data->version_major < 3
       && obj->type == HWLOC_OBJ_BRIDGE && obj->attr->bridge.downstream_type == HWLOC_OBJ_BRIDGE_PCI
-      && obj->parent->cpuset) {
+      && obj->parent && obj->parent->cpuset) {
     hwloc_pci_xml_import_locality(topology,
                                   obj->attr->bridge.downstream.pci.domain,
                                   obj->attr->bridge.downstream.pci.secondary_bus,
@@ -985,7 +985,7 @@ hwloc__xml_import_object(hwloc_topology_t topology,
   }
   if (data->version_major < 3
       && obj->type == HWLOC_OBJ_PCI_DEVICE && obj->attr->bridge.downstream_type == HWLOC_OBJ_BRIDGE_PCI
-      && obj->parent->cpuset) {
+      && obj->parent && obj->parent->cpuset) {
     hwloc_pci_xml_import_locality(topology,
                                   obj->attr->pcidev.domain,
                                   obj->attr->pcidev.bus,


### PR DESCRIPTION
hwloc__xml_import_object() generates PCI localities for v2 topologies by reading obj->parent->cpuset, but never checks obj->parent for NULL. The loader doesn't force the root object to be a Machine, and Bridge/PCIDev are special types that skip the cpuset checks, so a crafted v2 document whose root is a Bridge with downstream PCI reaches this branch with a NULL parent and crashes at load (set_xml/set_xmlbuffer). Guard obj->parent like the checks just above.