### PR TITLE
use unsigned char for ctype calls on possibly-signed input

### DIFF
--- a/include/private/misc.h
+++ b/include/private/misc.h
@@ -371,7 +371,7 @@ static __hwloc_inline int hwloc_strncasecmp(const char *s1, const char *s2, size
   return strncasecmp(s1, s2, n);
 #else
   while (n) {
-    char c1 = tolower(*s1), c2 = tolower(*s2);
+    char c1 = tolower((unsigned char)*s1), c2 = tolower((unsigned char)*s2);
     if (!c1 || !c2 || c1 != c2)
       return c1-c2;
     n--; s1++; s2++;

--- a/utils/hwloc/hwloc-calc.h
+++ b/utils/hwloc/hwloc-calc.h
@@ -350,7 +350,7 @@ hwloc_calc_parse_range(const char *_string,
   memcpy(string, _string, len);
   string[len] = '\0';
 
-  if (!isdigit(*string)) {
+  if (!isdigit((unsigned char)*string)) {
     if (!strncmp(string, "all", 3)) {
       *firstp = 0;
       *amountp = -1;

--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -679,7 +679,7 @@ hwloc_utils_parse_flags(char * str, struct hwloc_utils_parsing_flag possible_fla
     return ul_flag;
 
   for(j=0; str[j]; j++)
-    str[j] = toupper(str[j]);
+    str[j] = toupper((unsigned char)str[j]);
 
   if(strcmp(str, "NONE") == 0)
     return 0;


### PR DESCRIPTION
hwloc_decode_from_base64() reads the encoded bytes from a signed char buffer and passes them straight to isspace(), so on platforms where char is signed any byte with the top bit set is sign-extended to a negative int. isspace() (and the other ctype functions) are only defined for EOF and values representable as unsigned char, so this is undefined and can index before the start of the ctype table on libc implementations that do not offset for negative indices. The bytes here are base64 object userdata coming from imported XML, so they are attacker-controlled. The same ctype-on-char pattern is in the hwloc_strncasecmp() fallback and in two of the command-line helpers, so I have cast the argument to unsigned char at each site to keep them consistent. No behaviour change for normal ASCII input.