### PR TITLE
hwloc: Fix heap buffer overflow when inserting synthetic NUMA level

### DIFF
--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -826,13 +826,7 @@ hwloc_backend_synthetic_init(struct hwloc_synthetic_backend_data_s *data,
     /* insert a NUMA level below the automatic machine root */
     if (show_errors)
       fprintf(stderr, "hwloc/synthetic: Inserting a NUMA level with a single object at depth 1\n");
-    /* move existing levels by one.
-     * Only levels [1..count-1] need shifting to [2..count] (the level[0] machine
-     * root stays in place), i.e. count-1 elements. Using "count" here copied one
-     * extra (uninitialized) element and, when count reached its maximum of
-     * HWLOC_SYNTHETIC_MAX_DEPTH-1, wrote one struct past the end of the fixed-size
-     * data->level[] array (a heap buffer overflow reachable from an untrusted
-     * HWLOC_SYNTHETIC string / hwloc_topology_set_synthetic() input). */
+    /* move existing levels by one (count includes the root level which we are not memmov'ing) */
     memmove(&data->level[2], &data->level[1], (count-1)*sizeof(struct hwloc_synthetic_level_data_s));
     data->level[1].attr.type = HWLOC_OBJ_NUMANODE;
     data->level[1].indexes.string = NULL;

--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -826,8 +826,14 @@ hwloc_backend_synthetic_init(struct hwloc_synthetic_backend_data_s *data,
     /* insert a NUMA level below the automatic machine root */
     if (show_errors)
       fprintf(stderr, "hwloc/synthetic: Inserting a NUMA level with a single object at depth 1\n");
-    /* move existing levels by one */
-    memmove(&data->level[2], &data->level[1], count*sizeof(struct hwloc_synthetic_level_data_s));
+    /* move existing levels by one.
+     * Only levels [1..count-1] need shifting to [2..count] (the level[0] machine
+     * root stays in place), i.e. count-1 elements. Using "count" here copied one
+     * extra (uninitialized) element and, when count reached its maximum of
+     * HWLOC_SYNTHETIC_MAX_DEPTH-1, wrote one struct past the end of the fixed-size
+     * data->level[] array (a heap buffer overflow reachable from an untrusted
+     * HWLOC_SYNTHETIC string / hwloc_topology_set_synthetic() input). */
+    memmove(&data->level[2], &data->level[1], (count-1)*sizeof(struct hwloc_synthetic_level_data_s));
     data->level[1].attr.type = HWLOC_OBJ_NUMANODE;
     data->level[1].indexes.string = NULL;
     data->level[1].indexes.array = NULL;

--- a/tests/synthetic-numa-insert-overflow.c
+++ b/tests/synthetic-numa-insert-overflow.c
@@ -1,0 +1,62 @@
+/*
+ * Reproducer for a heap buffer overflow in the synthetic topology parser.
+ *
+ * Root cause (hwloc/topology-synthetic.c, "enforce a NUMA level" block):
+ *   when an all-explicit, non-NUMA synthetic description reaches the maximum
+ *   number of levels (HWLOC_SYNTHETIC_MAX_DEPTH-1 == 127), the memmove that
+ *   shifts levels up to make room for an inserted NUMA level moved "count"
+ *   elements instead of "count-1", writing one struct past the end of the
+ *   fixed-size data->level[HWLOC_SYNTHETIC_MAX_DEPTH] array (which is the last
+ *   member of the heap-allocated backend data).
+ *
+ * The description below has 125 Group levels + 1 PU level (= 126 parsed levels,
+ * count reaches 127), contains no NUMA level, and uses only explicit types so
+ * the auto-fill path that would otherwise insert a NUMA node is skipped. This
+ * makes the buggy memmove run with count == 127 and write data->level[128].
+ *
+ * Build against an ASan-instrumented hwloc, e.g.:
+ *   ./configure CC=clang CFLAGS="-fsanitize=address -g -O1"
+ *   make
+ *   clang -fsanitize=address -g tests/synthetic-numa-insert-overflow.c \
+ *         -Iinclude hwloc/.libs/libhwloc.a -o repro   # (link flags vary)
+ *   ./repro
+ *
+ * Before the fix: AddressSanitizer reports a heap-buffer-overflow WRITE inside
+ * hwloc_backend_synthetic_init (the memmove). After the fix: clean exit.
+ */
+
+#include "hwloc.h"
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+  char desc[1024];
+  hwloc_topology_t topology;
+  size_t off = 0;
+  int i, err;
+
+  /* 125 explicit Group levels, then the mandatory PU level. */
+  for (i = 0; i < 125; i++)
+    off += (size_t) snprintf(desc + off, sizeof(desc) - off, "Group:1 ");
+  snprintf(desc + off, sizeof(desc) - off, "PU:1");
+
+  if (hwloc_topology_init(&topology) < 0) {
+    fprintf(stderr, "topology_init failed\n");
+    return 2;
+  }
+
+  err = hwloc_topology_set_synthetic(topology, desc);
+  if (err < 0) {
+    fprintf(stderr, "set_synthetic rejected the string (unexpected)\n");
+    hwloc_topology_destroy(topology);
+    return 2;
+  }
+
+  /* The parse (and the buggy memmove) happens during load(). */
+  err = hwloc_topology_load(topology);
+  printf("load returned %d (no overflow detected)\n", err);
+
+  hwloc_topology_destroy(topology);
+  return 0;
+}


### PR DESCRIPTION
Fix a heap buffer overflow in the synthetic topology parser when inserting an implicit NUMA level into a synthetic topology description that reaches the maximum supported depth.

## Root Cause

In `hwloc_backend_synthetic_init()`, the NUMA-level insertion path shifts existing levels upward using:

```c
memmove(&data->level[2],
        &data->level[1],
        count * sizeof(struct hwloc_synthetic_level_data_s));
```

When parsing reaches the maximum valid depth (`count == HWLOC_SYNTHETIC_MAX_DEPTH - 1`), this copies one element too many.

Only levels `[1 .. count-1]` need to be shifted because the machine root at index 0 remains in place. Copying `count` elements writes one structure past the end of the fixed-size `data->level[]` array.

## Fix

Change the move count from `count` to `count - 1` and document the invariant with an explanatory comment.

## Reproducer

A standalone reproducer has been added that constructs an all-explicit synthetic topology description with 125 `Group` levels followed by a `PU` level, causing the NUMA insertion path to execute with `count == 127`.

When built with AddressSanitizer:

* Before this patch: ASan reports a heap-buffer-overflow write in `hwloc_backend_synthetic_init()`.
* After this patch: the reproducer exits cleanly.

## Impact

This issue is reachable through attacker-controlled synthetic topology descriptions supplied via:

* `HWLOC_SYNTHETIC`
* `hwloc_topology_set_synthetic()`

and results in heap memory corruption during `hwloc_topology_load()`.