### PR TITLE
memtiers: free imported per-tier infos to avoid leak

### DIFF
--- a/hwloc/memattrs.c
+++ b/hwloc/memattrs.c
@@ -2098,6 +2098,12 @@ hwloc_internal_memtiers_dup(hwloc_topology_t new, hwloc_topology_t old)
       new->nr_memtiers = i;
       goto failed;
     }
+    if (hwloc__tma_dup_infos(tma, &tiers[i].infos, &old->memtiers[i].infos) < 0) {
+      assert(!tma || !tma->dontfree); /* this tma cannot fail to allocate */
+      hwloc_bitmap_free(tiers[i].nodeset);
+      new->nr_memtiers = i;
+      goto failed;
+    }
   }
 
   return 0;
@@ -2117,6 +2123,7 @@ hwloc_internal_memtiers_restrict(struct hwloc_topology *topology)
     hwloc_bitmap_and(tier->nodeset, tier->nodeset, hwloc_get_root_obj(topology)->nodeset);
     if (hwloc_bitmap_iszero(tier->nodeset)) {
       hwloc_bitmap_free(tier->nodeset);
+      hwloc__free_infos(&tier->infos);
       memmove(tier, tier+1, (topology->nr_memtiers - i - 1)*sizeof(*tier));
       i--;
       topology->nr_memtiers--;
@@ -2134,8 +2141,10 @@ void
 hwloc_internal_memtiers_destroy(struct hwloc_topology *topology)
 {
   unsigned i;
-  for(i=0; i<topology->nr_memtiers; i++)
+  for(i=0; i<topology->nr_memtiers; i++) {
     hwloc_bitmap_free(topology->memtiers[i].nodeset);
+    hwloc__free_infos(&topology->memtiers[i].infos);
+  }
   free(topology->memtiers);
 }
 


### PR DESCRIPTION
The memory tier structures carry a set of info attributes that get populated when a topology is imported from XML, since a <memtier> element may contain <info> children. Those infos are heap allocated and handed over to the tier, but the teardown and restrict paths only release each tier's nodeset and never the infos, so the name/value strings and the array behind them are leaked on every load followed by destroy of such a topology. The duplication path has the matching gap, it copies the infos pointers from the old topology straight into the new one without duplicating them, which would turn into a double free once teardown started releasing them. I noticed it while comparing against the cpukinds code next door, which already frees and dups its infos in the same three places. The fix brings the memtier lifecycle in line: release the infos in destroy and in restrict, and deep copy them during dup, freeing the freshly duped nodeset if the infos copy fails. Checked on macOS with leaks, a topology whose XML has a memtier with an info child leaked 208 bytes before and is clean afterwards, and the test suite still passes.