### PR TITLE
x86 isn't a main backend anymore

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -65,6 +65,12 @@ for more details.
       command-line.
   + Cache objects now have a "inclusive" field in the hwloc_cache_attr_s
     structure, instead of an "Inclusive" info attribute.
+* Core changes
+  + x86 CPUID discovery is not its own component anymore, it is called by
+    operating system component internally when needed.
+    It should be controlled with the new environment variable HWLOC_X86,
+    see "Environment variables for changing the source of topology information"
+    in the documentation.
 * Tools
   + lstopo has a new --osf option to tune the displaying of object
     attributes and units.

--- a/NEWS
+++ b/NEWS
@@ -17,7 +17,7 @@ Version 3.0.0
 -------------
 See the section "Upgrading to the hwloc 3.0 API" in the documentation
 for more details.
-* API
+* API functions
   + hwloc_get_type_depth_with_attr() generalizes hwloc_get_type_depth() by
     using object attributes to disambiguate multiple levels with same type.
     - hwloc_type_sscanf_as_depth() is deprecated in favor of
@@ -31,6 +31,8 @@ for more details.
     anymore. They have a dedicated API hwloc_memtiers_get_nr() and
     hwloc_memtiers_get_info() in hwloc/memattrs.h
     - NUMA nodes now have a memory_tier integer attribute.
+  + Add hwloc_get_pci_busid_cpuset() in hwloc/helpers.h.
+* Objects and data structures
   + PCI domains are now always 32bits.
   + The "programming interface" of PCI devices is now exposed
     in PCI object attributes.
@@ -57,7 +59,6 @@ for more details.
       infos as such a structure.
   + Distances structure "MEANS" kinds are renamed to "VALUE", and the new
     "HOPS" kind is used for the XGMIHops matrix instead of "LATENCY.
-  + Add hwloc_get_pci_busid_cpuset() in hwloc/helpers.h.
   + Core objects now have a "cpukind" field in the hwloc_core_attr_s
     structure to report the index of their CPU kind.
     - core[cpukind=1] may now be used to filter core objects on the

--- a/NEWS
+++ b/NEWS
@@ -86,6 +86,8 @@ for more details.
     - hwloc_cpuset_to_nodeset_strict()
     - hwloc_cpuset_from_nodeset_strict()
 * Misc
+  + The HWLOC_CPUKINDS environment variable replaces HWLOC_LINUX_CPUKINDS
+    and HWLOC_CPUKINDS_MAXFREQ.
   + The HWLOC_CPUKINDS_HOMOGENEOUS environment variable is removed.
     HWLOC_LINUX_CPUKINDS may be used instead if ever needed.
   + The HWLOC_SHOW_ERRORS environment variable replaces HWLOC_HIDE_ERRORS,

--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -1638,9 +1638,6 @@ return clGetDeviceIDs(0, 0, 0, NULL, NULL);
          AC_SUBST(HWLOC_HAVE_X86_CPUID, 1)
 	 hwloc_have_x86_cpuid=yes],
 	[AC_MSG_RESULT([no])])
-	if test "x$hwloc_have_x86_cpuid" = xyes; then
-	    hwloc_components="$hwloc_components x86"
-	fi
 	CPPFLAGS="$old_CPPFLAGS"
 
       echo "**** end of x86 CPUID configuration"

--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -1635,9 +1635,6 @@ return clGetDeviceIDs(0, 0, 0, NULL, NULL);
          AC_SUBST(HWLOC_HAVE_X86_CPUID, 1)
 	 hwloc_have_x86_cpuid=yes],
 	[AC_MSG_RESULT([no])])
-	if test "x$hwloc_have_x86_cpuid" = xyes; then
-	    hwloc_components="$hwloc_components x86"
-	fi
 	CPPFLAGS="$old_CPPFLAGS"
 
       echo "**** end of x86 CPUID configuration"

--- a/contrib/windows-cmake/static-components.h.in
+++ b/contrib/windows-cmake/static-components.h.in
@@ -7,9 +7,6 @@ HWLOC_DECLSPEC extern const struct hwloc_component hwloc_xml_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_synthetic_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_xml_nolibxml_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_windows_component;
-#ifdef HWLOC_HAVE_X86_CPUID
-HWLOC_DECLSPEC extern const struct hwloc_component hwloc_x86_component;
-#endif
 #if !defined(HWLOC_HAVE_PLUGINS) && defined(HWLOC_HAVE_LIBXML2)
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_xml_libxml_component;
 #endif
@@ -26,9 +23,6 @@ static const struct hwloc_component * hwloc_static_components[] = {
   &hwloc_synthetic_component,
   &hwloc_xml_nolibxml_component,
   &hwloc_windows_component,
-#ifdef HWLOC_HAVE_X86_CPUID
-  &hwloc_x86_component,
-#endif
 #if !defined(HWLOC_HAVE_PLUGINS) && defined(HWLOC_HAVE_OPENCL)
   &hwloc_opencl_component,
 #endif

--- a/contrib/windows/static-components.h
+++ b/contrib/windows/static-components.h
@@ -3,13 +3,11 @@ HWLOC_DECLSPEC extern const struct hwloc_component hwloc_xml_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_synthetic_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_xml_nolibxml_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_windows_component;
-HWLOC_DECLSPEC extern const struct hwloc_component hwloc_x86_component;
 static const struct hwloc_component * hwloc_static_components[] = {
   &hwloc_noos_component,
   &hwloc_xml_component,
   &hwloc_synthetic_component,
   &hwloc_xml_nolibxml_component,
   &hwloc_windows_component,
-  &hwloc_x86_component,
   NULL
 };

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1022,21 +1022,46 @@ following environment variables.
   </dd>
 
 <dt>HWLOC_CPUID_PATH=/path/to/cpuid/</dt>
-  <dd>Force the x86 backend to read dumped CPUIDs from the given directory
+  <dd>Force the x86 sub-backend to read dumped CPUIDs from the given directory
   instead of executing actual x86 CPUID instructions.
   This directory may have been saved previously from another machine
   with <tt>hwloc-gather-cpuid</tt>.
 
-  One should likely also set <tt>HWLOC_COMPONENTS=x86,stop</tt>
-  so that non-x86 backends are disabled
-  (the <tt>-i</tt> option of command-line tools takes care of both).
+  One should likely also set <tt>HWLOC_X86=only</tt>
+  so that non-x86 backends are disabled (see below).
+  The <tt>-i</tt> option of command-line tools takes care of both.
 
   It causes hwloc_topology_is_thissystem() to return 0.
-  For convenience, this backend provides empty binding hooks which just
+  For convenience, the OS backend provides empty binding hooks which just
   return success.  To have hwloc still actually call OS-specific hooks,
   HWLOC_THISSYSTEM should be set 1 in the environment too, to assert that
   the loaded CPUID dump is really the underlying system.
   </dd>
+
+<dt>HWLOC_X86=default</dt>
+  <dd>Change the way operating system backends use x86 CPUID to improve
+  their detection of CPUs.
+
+  If the variable is set to <tt>last</tt>, x86 CPUID-based detection is
+  used last after the operating system-based detection.
+  This is the default for operating systems with CPU topology query APIs
+  and x86 support (Linux, Windows and Solaris).
+
+  If the variable is set to <tt>first</tt>, x86 is used first before
+  adding OS-detected CPU topology.
+  This is the default for operating systems that don't provide CPU topology
+  detection (FreeBSD, NetBSD, etc.).
+
+  If the variable is set to <tt>only</tt>, x86 is used first and the OS
+  APIs are disabled, including for NUMA detection for instance.
+
+  If the variable is set to <tt>none</tt>, x86 detection is disabled.
+
+  This is useful for understanding whether a topology issue comes
+  from the native operating system backend or from the x86 detection:
+  Setting to <tt>none</tt> or <tt>only</tt> will test one code without
+  the other.
+</dd>
 
 <dt>HWLOC_ANNOTATE_GLOBAL_COMPONENTS=0</dt>
   <dd>Allow components to annotate the topology even if they are
@@ -1287,11 +1312,6 @@ following environment variables.
   list.
   If <tt>stop</tt> is met, the enabling loop immediately stops, no
   more component is enabled.
-
-  This is useful for understanding whether a topology issue comes
-  from the native operating system backend or from the x86 backend:
-  Setting to <tt>x86,stop</tt> or <tt>linux,stop</tt> will test
-  one backend without the other.
 
   If <tt>xml</tt> or <tt>synthetic</tt> components are selected,
   the corresponding XML filename or synthetic description string
@@ -3379,8 +3399,6 @@ some will be ignored.
 The usual default is to enable the native operating system component,
 (e.g. <tt>linux</tt> or <tt>solaris</tt>) and the
 <tt>pci</tt> one.
-If available, an architecture-specific component (such as <tt>x86</tt>)
-may also improve the topology detection.
 Finally, some hardware-specific components (such as <tt>cuda</tt> or <tt>rsmi</tt>)
 may add information about GPUs, accelerators, etc.
 
@@ -3393,15 +3411,12 @@ will be used instead of all other components.
 The hwloc core contains a list of components sorted by priority.
 Each one is enabled as long as it does not conflict with the
 previously enabled ones.
-This includes native operating system components,
-architecture-specific ones, and if available, I/O components
-such as <tt>pci</tt> or <tt>cuda</tt>.
+This includes native operating system components
+and if available, I/O components such as <tt>pci</tt> or <tt>cuda</tt>.
 
 Usually the native operating system component
 (when it exists, e.g. <tt>linux</tt> or <tt>aix</tt>)
 is enabled first.
-Then hwloc looks for an architecture specific component
-(e.g. <tt>x86</tt>).
 As a fallback, there is also a basic component (<tt>no_os</tt>)
 that just tries to discover the number of PUs in the system.
 It is used for operating systems that do not
@@ -3418,8 +3433,6 @@ Default priorities ensure that clever components are invoked first.
 Native operating system components have higher priorities,
 and are therefore invoked first, because they likely offer
 very detailed topology information.
-If needed, it will be later extended by architecture-specific
-information (e.g. from the <tt>x86</tt> component).
 
 If any configuration function such as hwloc_topology_set_xml()
 is used before loading the topology, the corresponding component
@@ -3456,18 +3469,19 @@ If the variable is set and empty (or set to a single comma separating nothing,
 since some operating systems do not accept empty variables),
 the normal component priority order is used.
 
-If the variable is set to <tt>x86</tt>, it will cause
-the <tt>x86</tt> component to take precedence over any other component,
+If the variable is set to <tt>pci</tt>, it will cause
+the <tt>pci</tt> component to take precedence over any other component,
 including the native operating system component.
 It is therefore loaded first, before hwloc tries to load all remaining
 non-conflicting components.
-In this case, <tt>x86</tt> would take care of discovering everything
-it supports, instead of only completing what the native OS information.
 This may be useful if the native component is buggy on some platforms.
+In this case, during the PCI discovery phase, the <tt>pci</tt> component
+would take care of discovering everything PCI related instead of
+having the <tt>linux</tt> component do it first.
 
 It is possible to prevent some components from being loaded by prefixing their
-name with <tt>-</tt> in the list. For instance <tt>x86,-pci</tt> will load the
-<tt>x86</tt> component, then let hwloc load all the usual components except
+name with <tt>-</tt> in the list. For instance <tt>linux,-pci</tt> will load the
+<tt>linux</tt> component, then let hwloc load all the usual components except
 <tt>pci</tt>.
 A single component phase may also be blacklisted, for instance with <tt>-linux:io</tt>.
 
@@ -3536,12 +3550,6 @@ environment variable (see \ref envvar_verbose).
 <dd>
  Each officially supported operating system has its own native component,
  which is statically built when supported, and which is used by default.
-</dd>
-<dt>x86</dt>
-<dd>
- The x86 architecture (either 32 or 64 bits) has its own component
- that may complete or replace the previously-found CPU information.
- It is statically built when supported.
 </dd>
 <dt>no_os</dt>
 <dd>
@@ -3630,7 +3638,12 @@ environment variable (see \ref envvar_verbose).
 </dd>
 </dl>
 
-
+Before hwloc 3.0, the x86 architecture (either 32 or 64 bits) had its own component
+that could complete or replace the previously-found CPU information.
+It is now called by operating system backend explicitly to complete their detection.
+See <tt>HWLOC_X86</tt> in \ref envvar_source for controlling this behavior.
+hwloc_topology_set_components() may also still be used to disable this "x86"
+CPUID-based detection.
 
 
 \page embed Embedding hwloc in Other Software
@@ -3903,7 +3916,7 @@ hwloc_topology_load(topology);
 <br/>
 Finally it is possible to prevent some hwloc components from being
 loaded and queried.
-If you are sure that the Linux (or x86) component is enough to discover
+If you are sure that the Linux component is enough to discover
 everything you need, you may ask hwloc to disable all other components
 by setting something like <tt>HWLOC_COMPONENTS=linux,stop</tt>
 in the environment.
@@ -4048,9 +4061,9 @@ hwloc currently uses Groups for the following reasons:
 <li>NUMA parents when memory locality does not match any existing object.</li>
 <li>I/O parents when I/O locality does not match any existing object.</li>
 <li>Distance-based groups made of close objects.</li>
-<li>AMD Core Complex (CCX) (<tt>subtype</tt> is <tt>Complex</tt>, in the x86 backend),
+<li>AMD Core Complex (CCX) (<tt>subtype</tt> is <tt>Complex</tt>, in the x86 detection),
  but these objects are usually merged with the L3 caches or Dies.</li>
-<li>AMD Bulldozer dual-core compute units (<tt>subtype</tt> is <tt>ComputeUnit</tt>, in the x86 backend),
+<li>AMD Bulldozer dual-core compute units (<tt>subtype</tt> is <tt>ComputeUnit</tt>, in the x86 detection),
  but these objects are usually merged with the L2 caches.</li>
 <li>Intel Extended Topology Enumeration levels such as Module and Tile
  (in the x86 and Windows backends).</li>
@@ -4507,7 +4520,7 @@ this error (and hide it by setting HWLOC_SHOW_ERRORS=none in your environment).
 
 Some platforms report similar warnings about conflicting Packages and NUMANodes.
 
-On x86 hosts, passing <tt>HWLOC_COMPONENTS=x86</tt> in the environment may
+On x86 hosts, passing <tt>HWLOC_X86=first</tt> in the environment may
 workaround some of these issues by switching to a different way to discover the topology.
 
 Upgrading the BIOS and/or the operating system may help.
@@ -4674,8 +4687,7 @@ hwloc also comes with an example of <b>Microsoft Visual Studio solution</b>
 
 \subsection faq_netbsd_bind How to get useful topology information on NetBSD?
 
-The NetBSD (and FreeBSD) backend uses x86-specific topology discovery
-(through the x86 component).
+The NetBSD (and FreeBSD) backend uses x86-specific topology discovery.
 This implementation requires CPU binding so as to query topology
 information from each individual processor.
 This means that hwloc cannot find any useful topology information
@@ -5142,6 +5154,13 @@ and HWLOC_CPUKINDS_MAXFREQ, see \ref envvar_heuristics.
 
 The HWLOC_CPUKINDS_HOMOGENEOUS environment variable is removed.
 HWLOC_LINUX_CPUKINDS may be used to disable cpukinds if ever needed.
+
+x86 CPUID discovery is not its own component anymore, it is called by
+operating system component internally when needed.
+Hence it shouldn't be controlled with the <tt>HWLOC_COMPONENTS</tt> environment
+variable but rather with <tt>HWLOC_X86</tt>, see \ref envvar_source.
+hwloc_topology_set_components() may still be used to disable this "x86"
+CPUID-based detection.
 
 The HWLOC_HIDE_ERRORS, HWLOC_XML_VERBOSE and HWLOC_SYNTHETIC_VERBOSE
 environment variables are now obsolete

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1209,31 +1209,35 @@ following environment variables.
   <tt>default</tt>, or <tt>none</tt>.
   </dd>
 
-<dt>HWLOC_CPUKINDS_MAXFREQ=adjust=10</dt>
-  <dd>Change the use of the max frequency in the Linux backend.
+<dt>HWLOC_CPUKINDS=-1</dt>
+  <dd>Try to enable the discovery of CPU kinds on Linux.
+  This is enabled by default except on old AMD CPUs known to be homogeneous.
+  Setting to <tt>0</tt> always disables it while any other value enables it.
+
+  A comma-separated list of key-value pairs maybe given, including
+  <tt>cppc=0</tt> for disabling the use of ACPI CPPC nominal frequencies,
+  <tt>midr=0</tt> for disabling the use of ARM MIDR registers.
+
+  Keywords <tt>maxfreq</tt> and <tt>freqadjust</tt>
+  may also be given to configure the frequency-based heuristics.
   hwloc tries to read the base and max frequencies of each core on Linux.
   Some hardware features such as Intel Turbo Boost Max 3.0 make some cores
   report slightly higher max frequencies than others in the same CPU package.
   Despite having slightly different frequencies, these cores are considered
   identical instead of exposing an hybrid CPU.
-  Hence, by default (<tt>adjust=10</tt>), hwloc uniformizes the max frequencies of cores
+  Hence, by default, hwloc uniformizes the max frequencies of cores
   that have the same base frequency (higher values are downgraded by up
-  to 10%).
+  to 10% by default).
   When available, the CPU capacity value is also adjusted accordingly.
 
-  If this environment variable is set to <tt>adjust=X</tt>,
-  the 10% threshold is replaced with X.
-  If set to 1, max frequencies are not adjusted anymore,
+  If the HWLOC_CPUKINDS environment variable contains <tt>freqadjust=X</tt>,
+  the default 10% threshold is replaced with X.
+  If <tt>maxfreq=1</tt>, max frequencies are not adjusted anymore,
   some homogeneous processors may appear hybrid because of this.
-  If set to 0, max frequencies are entirely ignored.
-  </dd>
+  If <tt>maxfreq=0</tt>, max frequencies are entirely ignored.
 
-<dt>HWLOC_LINUX_CPUKINDS=-1</dt>
-  <dd>Try to enable the discovery of CPU kinds on Linux.
-  This is enabled by default except on old AMD CPUs known to be homogeneous.
-  Setting to <tt>1</tt> always enables it, while <tt>0</tt> always disables it.
-  Setting to <tt>cppc=0</tt> enables it without using ACPI CPPC nominal frequency.
-  Setting to <tt>midr=0</tt> enables it without using the ARM MIDR register.
+  This environment variable replaces the former HWLOC_LINUX_CPUKINDS
+  and HWLOC_CPUKINDS_MAXFREQ in hwloc 2.0.
   </dd>
 
 
@@ -5133,8 +5137,11 @@ removed since their non-strict variants are sufficient.
 
 \section upgrade_to_api_3x_envvar Changes to environment variables in 3.0
 
+The HWLOC_CPUKINDS environment variable replaces HWLOC_LINUX_CPUKINDS
+and HWLOC_CPUKINDS_MAXFREQ, see \ref envvar_heuristics.
+
 The HWLOC_CPUKINDS_HOMOGENEOUS environment variable is removed.
-HWLOC_LINUX_CPUKINDS may be used to disabled cpukinds if ever needed.
+HWLOC_LINUX_CPUKINDS may be used to disable cpukinds if ever needed.
 
 The HWLOC_HIDE_ERRORS, HWLOC_XML_VERBOSE and HWLOC_SYNTHETIC_VERBOSE
 environment variables are now obsolete

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1046,6 +1046,8 @@ following environment variables.
   used last after the operating system-based detection.
   This is the default for operating systems with CPU topology query APIs
   and x86 support (Linux, Windows and Solaris).
+  Note that Linux also queries x86 CPUID to enable/disable hardware-specific
+  features such as hybrid CPU detection.
 
   If the variable is set to <tt>first</tt>, x86 is used first before
   adding OS-detected CPU topology.
@@ -1241,7 +1243,8 @@ following environment variables.
 
   A comma-separated list of key-value pairs maybe given, including
   <tt>cppc=0</tt> for disabling the use of ACPI CPPC nominal frequencies,
-  <tt>midr=0</tt> for disabling the use of ARM MIDR registers.
+  <tt>midr=0</tt> for disabling the use of ARM MIDR registers,
+  <tt>x86cpuid=0</tt> for disabling the use of x86 CPUID registers.
 
   Keywords <tt>maxfreq</tt> and <tt>freqadjust</tt>
   may also be given to configure the frequency-based heuristics.

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1022,21 +1022,46 @@ following environment variables.
   </dd>
 
 <dt>HWLOC_CPUID_PATH=/path/to/cpuid/</dt>
-  <dd>Force the x86 backend to read dumped CPUIDs from the given directory
+  <dd>Force the x86 sub-backend to read dumped CPUIDs from the given directory
   instead of executing actual x86 CPUID instructions.
   This directory may have been saved previously from another machine
   with <tt>hwloc-gather-cpuid</tt>.
 
-  One should likely also set <tt>HWLOC_COMPONENTS=x86,stop</tt>
-  so that non-x86 backends are disabled
-  (the <tt>-i</tt> option of command-line tools takes care of both).
+  One should likely also set <tt>HWLOC_X86=only</tt>
+  so that non-x86 backends are disabled (see below).
+  The <tt>-i</tt> option of command-line tools takes care of both.
 
   It causes hwloc_topology_is_thissystem() to return 0.
-  For convenience, this backend provides empty binding hooks which just
+  For convenience, the OS backend provides empty binding hooks which just
   return success.  To have hwloc still actually call OS-specific hooks,
   HWLOC_THISSYSTEM should be set 1 in the environment too, to assert that
   the loaded CPUID dump is really the underlying system.
   </dd>
+
+<dt>HWLOC_X86=default</dt>
+  <dd>Change the way operating system backends use x86 CPUID to improve
+  their detection of CPUs.
+
+  If the variable is set to <tt>last</tt>, x86 CPUID-based detection is
+  used last after the operating system-based detection.
+  This is the default for operating systems with CPU topology query APIs
+  and x86 support (Linux, Windows and Solaris).
+
+  If the variable is set to <tt>first</tt>, x86 is used first before
+  adding OS-detected CPU topology.
+  This is the default for operating systems that don't provide CPU topology
+  detection (FreeBSD, NetBSD, etc.).
+
+  If the variable is set to <tt>only</tt>, x86 is used first and the OS
+  APIs are disabled, including for NUMA detection for instance.
+
+  If the variable is set to <tt>none</tt>, x86 detection is disabled.
+
+  This is useful for understanding whether a topology issue comes
+  from the native operating system backend or from the x86 detection:
+  Setting to <tt>none</tt> or <tt>only</tt> will test one code without
+  the other.
+</dd>
 
 <dt>HWLOC_ANNOTATE_GLOBAL_COMPONENTS=0</dt>
   <dd>Allow components to annotate the topology even if they are
@@ -1287,11 +1312,6 @@ following environment variables.
   list.
   If <tt>stop</tt> is met, the enabling loop immediately stops, no
   more component is enabled.
-
-  This is useful for understanding whether a topology issue comes
-  from the native operating system backend or from the x86 backend:
-  Setting to <tt>x86,stop</tt> or <tt>linux,stop</tt> will test
-  one backend without the other.
 
   If <tt>xml</tt> or <tt>synthetic</tt> components are selected,
   the corresponding XML filename or synthetic description string
@@ -3372,8 +3392,6 @@ some will be ignored.
 The usual default is to enable the native operating system component,
 (e.g. <tt>linux</tt> or <tt>solaris</tt>) and the
 <tt>pci</tt> one.
-If available, an architecture-specific component (such as <tt>x86</tt>)
-may also improve the topology detection.
 Finally, some hardware-specific components (such as <tt>cuda</tt> or <tt>rsmi</tt>)
 may add information about GPUs, accelerators, etc.
 
@@ -3386,15 +3404,12 @@ will be used instead of all other components.
 The hwloc core contains a list of components sorted by priority.
 Each one is enabled as long as it does not conflict with the
 previously enabled ones.
-This includes native operating system components,
-architecture-specific ones, and if available, I/O components
-such as <tt>pci</tt> or <tt>cuda</tt>.
+This includes native operating system components
+and if available, I/O components such as <tt>pci</tt> or <tt>cuda</tt>.
 
 Usually the native operating system component
 (when it exists, e.g. <tt>linux</tt> or <tt>aix</tt>)
 is enabled first.
-Then hwloc looks for an architecture specific component
-(e.g. <tt>x86</tt>).
 As a fallback, there is also a basic component (<tt>no_os</tt>)
 that just tries to discover the number of PUs in the system.
 It is used for operating systems that do not
@@ -3411,8 +3426,6 @@ Default priorities ensure that clever components are invoked first.
 Native operating system components have higher priorities,
 and are therefore invoked first, because they likely offer
 very detailed topology information.
-If needed, it will be later extended by architecture-specific
-information (e.g. from the <tt>x86</tt> component).
 
 If any configuration function such as hwloc_topology_set_xml()
 is used before loading the topology, the corresponding component
@@ -3449,18 +3462,19 @@ If the variable is set and empty (or set to a single comma separating nothing,
 since some operating systems do not accept empty variables),
 the normal component priority order is used.
 
-If the variable is set to <tt>x86</tt>, it will cause
-the <tt>x86</tt> component to take precedence over any other component,
+If the variable is set to <tt>pci</tt>, it will cause
+the <tt>pci</tt> component to take precedence over any other component,
 including the native operating system component.
 It is therefore loaded first, before hwloc tries to load all remaining
 non-conflicting components.
-In this case, <tt>x86</tt> would take care of discovering everything
-it supports, instead of only completing what the native OS information.
 This may be useful if the native component is buggy on some platforms.
+In this case, during the PCI discovery phase, the <tt>pci</tt> component
+would take care of discovering everything PCI related instead of
+having the <tt>linux</tt> component do it first.
 
 It is possible to prevent some components from being loaded by prefixing their
-name with <tt>-</tt> in the list. For instance <tt>x86,-pci</tt> will load the
-<tt>x86</tt> component, then let hwloc load all the usual components except
+name with <tt>-</tt> in the list. For instance <tt>linux,-pci</tt> will load the
+<tt>linux</tt> component, then let hwloc load all the usual components except
 <tt>pci</tt>.
 A single component phase may also be blacklisted, for instance with <tt>-linux:io</tt>.
 
@@ -3529,12 +3543,6 @@ environment variable (see \ref envvar_verbose).
 <dd>
  Each officially supported operating system has its own native component,
  which is statically built when supported, and which is used by default.
-</dd>
-<dt>x86</dt>
-<dd>
- The x86 architecture (either 32 or 64 bits) has its own component
- that may complete or replace the previously-found CPU information.
- It is statically built when supported.
 </dd>
 <dt>no_os</dt>
 <dd>
@@ -3623,7 +3631,12 @@ environment variable (see \ref envvar_verbose).
 </dd>
 </dl>
 
-
+Before hwloc 3.0, the x86 architecture (either 32 or 64 bits) had its own component
+that could complete or replace the previously-found CPU information.
+It is now called by operating system backend explicitly to complete their detection.
+See <tt>HWLOC_X86</tt> in \ref envvar_source for controlling this behavior.
+hwloc_topology_set_components() may also still be used to disable this "x86"
+CPUID-based detection.
 
 
 \page embed Embedding hwloc in Other Software
@@ -3896,7 +3909,7 @@ hwloc_topology_load(topology);
 <br/>
 Finally it is possible to prevent some hwloc components from being
 loaded and queried.
-If you are sure that the Linux (or x86) component is enough to discover
+If you are sure that the Linux component is enough to discover
 everything you need, you may ask hwloc to disable all other components
 by setting something like <tt>HWLOC_COMPONENTS=linux,stop</tt>
 in the environment.
@@ -4041,9 +4054,9 @@ hwloc currently uses Groups for the following reasons:
 <li>NUMA parents when memory locality does not match any existing object.</li>
 <li>I/O parents when I/O locality does not match any existing object.</li>
 <li>Distance-based groups made of close objects.</li>
-<li>AMD Core Complex (CCX) (<tt>subtype</tt> is <tt>Complex</tt>, in the x86 backend),
+<li>AMD Core Complex (CCX) (<tt>subtype</tt> is <tt>Complex</tt>, in the x86 detection),
  but these objects are usually merged with the L3 caches or Dies.</li>
-<li>AMD Bulldozer dual-core compute units (<tt>subtype</tt> is <tt>ComputeUnit</tt>, in the x86 backend),
+<li>AMD Bulldozer dual-core compute units (<tt>subtype</tt> is <tt>ComputeUnit</tt>, in the x86 detection),
  but these objects are usually merged with the L2 caches.</li>
 <li>Intel Extended Topology Enumeration levels such as Module and Tile
  (in the x86 and Windows backends).</li>
@@ -4500,7 +4513,7 @@ this error (and hide it by setting HWLOC_SHOW_ERRORS=none in your environment).
 
 Some platforms report similar warnings about conflicting Packages and NUMANodes.
 
-On x86 hosts, passing <tt>HWLOC_COMPONENTS=x86</tt> in the environment may
+On x86 hosts, passing <tt>HWLOC_X86=first</tt> in the environment may
 workaround some of these issues by switching to a different way to discover the topology.
 
 Upgrading the BIOS and/or the operating system may help.
@@ -4666,8 +4679,7 @@ hwloc also comes with an example of <b>Microsoft Visual Studio solution</b>
 
 \subsection faq_netbsd_bind How to get useful topology information on NetBSD?
 
-The NetBSD (and FreeBSD) backend uses x86-specific topology discovery
-(through the x86 component).
+The NetBSD (and FreeBSD) backend uses x86-specific topology discovery.
 This implementation requires CPU binding so as to query topology
 information from each individual processor.
 This means that hwloc cannot find any useful topology information
@@ -5134,6 +5146,13 @@ and HWLOC_CPUKINDS_MAXFREQ, see \ref envvar_heuristics.
 
 The HWLOC_CPUKINDS_HOMOGENEOUS environment variable is removed.
 HWLOC_LINUX_CPUKINDS may be used to disable cpukinds if ever needed.
+
+x86 CPUID discovery is not its own component anymore, it is called by
+operating system component internally when needed.
+Hence it shouldn't be controlled with the <tt>HWLOC_COMPONENTS</tt> environment
+variable but rather with <tt>HWLOC_X86</tt>, see \ref envvar_source.
+hwloc_topology_set_components() may still be used to disable this "x86"
+CPUID-based detection.
 
 The HWLOC_HIDE_ERRORS, HWLOC_XML_VERBOSE and HWLOC_SYNTHETIC_VERBOSE
 environment variables are now obsolete

--- a/hwloc/components.c
+++ b/hwloc/components.c
@@ -787,6 +787,12 @@ hwloc_topology_set_components(struct hwloc_topology *topology,
     return 0;
   }
 
+  /* backward compat with x86 component in 2.x */
+  if (!strcmp(name, "x86")) {
+    topology->x86_mode = HWLOC_X86_MODE_NONE;
+    return 0;
+  }
+
   return hwloc_disc_component_blacklist_one(topology, name);
 }
 
@@ -882,6 +888,17 @@ hwloc_disc_components_enable_others(struct hwloc_topology *topology)
   _env = getenv("HWLOC_COMPONENTS");
   env = _env ? strdup(_env) : NULL;
 
+  if (env && !strcmp(env, "x86,stop")) {
+    /* backward compat with x86 component in 2.x */
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc: HWLOC_COMPONENTS=x86,stop deprecated, replacing with no_os,stop and HWLOC_X86=only\n");
+    topology->x86_mode = HWLOC_X86_MODE_ONLY;
+    comp = hwloc_disc_component_find("no_os", NULL);
+    assert(comp);
+    hwloc_disc_component_try_enable(topology, comp, 1 /* envvar forced */, 0);
+    goto done;
+  }
+
   /* blacklist disabled components */
   if (env) {
     char *curenv = env;
@@ -899,8 +916,15 @@ hwloc_disc_components_enable_others(struct hwloc_topology *topology)
 	c = curenv[s];
 	curenv[s] = '\0';
 
-	/* blacklist it, and just ignore failures to allocate */
-	hwloc_disc_component_blacklist_one(topology, curenv+1);
+        if (!strcmp(curenv+1, "x86")) {
+          /* backward compat with x86 component in 2.x */
+          if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER))
+            fprintf(stderr, "hwloc: HWLOC_COMPONENTS=-x86 deprecated, replacing with HWLOC_X86=none\n");
+          topology->x86_mode = HWLOC_X86_MODE_NONE;
+        } else {
+          /* blacklist it, and just ignore failures to allocate */
+          hwloc_disc_component_blacklist_one(topology, curenv+1);
+        }
 
 	/* remove that blacklisted name from the string */
 	for(i=0; i<s; i++)
@@ -955,7 +979,17 @@ hwloc_disc_components_enable_others(struct hwloc_topology *topology)
 	    }
 	  if (comp->phases & ~blacklisted_phases)
 	    hwloc_disc_component_try_enable(topology, comp, 1 /* envvar forced */, blacklisted_phases);
-	} else {
+	} else if (!strcmp(name, "x86")) {
+          /* backward compat with x86 component in 2.x */
+          if (curenv == env) {
+            if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER))
+              fprintf(stderr, "hwloc: HWLOC_COMPONENTS starting with x86 is deprecated, replacing with HWLOC_X86=first\n");
+            topology->x86_mode = HWLOC_X86_MODE_FIRST;
+          } else {
+            if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER|HWLOC_SHOWMSG_CRITICAL))
+              fprintf(stderr, "hwloc: HWLOC_COMPONENTS with x86 is deprecated, falling back to default x86 configuration, use HWLOC_X86 to change it.\n");
+          }
+        } else {
           if (hwloc_show_component_errors || HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
             fprintf(stderr, "hwloc: Cannot find discovery component `%s'\n", name);
 	}
@@ -1008,6 +1042,7 @@ nextcomp:
     }
   }
 
+ done:
   if (hwloc_components_verbose) {
     /* print a summary */
     int first = 1;

--- a/hwloc/components.c
+++ b/hwloc/components.c
@@ -1078,7 +1078,6 @@ hwloc_backend_alloc(struct hwloc_topology *topology,
   backend->discover = NULL;
   backend->get_pci_busid_cpuset = NULL;
   backend->disable = NULL;
-  backend->is_thissystem = -1;
   backend->next = NULL;
   backend->envvar_forced = 0;
   return backend;
@@ -1134,57 +1133,6 @@ hwloc_backend_enable(struct hwloc_backend *backend)
   topology->backend_phases |= backend->component->phases;
   topology->backend_excluded_phases |= backend->component->excluded_phases;
   return 0;
-}
-
-void
-hwloc_backends_is_thissystem(struct hwloc_topology *topology)
-{
-  struct hwloc_backend *backend;
-  const char *local_env;
-  int is_thissystem;
-
-  /*
-   * If the application changed the backend with set_foo(),
-   * it may use set_flags() update the is_thissystem flag here.
-   * If it changes the backend with environment variables below,
-   * it may use HWLOC_THISSYSTEM envvar below as well.
-   */
-
-  is_thissystem = 1;
-
-  /* apply thissystem from normally-given backends (envvar_forced=0, either set_foo() or defaults) */
-  backend = topology->backends;
-  while (backend != NULL) {
-    if (backend->envvar_forced == 0 && backend->is_thissystem != -1) {
-      assert(backend->is_thissystem == 0);
-      is_thissystem = 0;
-    }
-    backend = backend->next;
-  }
-
-  /* override set_foo() with flags */
-  if (topology->flags & HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM)
-    is_thissystem = 1;
-
-  /* now apply envvar-forced backend (envvar_forced=1) */
-  backend = topology->backends;
-  while (backend != NULL) {
-    if (backend->envvar_forced == 1 && backend->is_thissystem != -1) {
-      assert(backend->is_thissystem == 0);
-      is_thissystem = 0;
-    }
-    backend = backend->next;
-  }
-
-  /* override with envvar-given flag */
-  local_env = getenv("HWLOC_THISSYSTEM");
-  if (local_env)
-    is_thissystem = atoi(local_env);
-
-  if (is_thissystem)
-    topology->state |= HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM;
-  else
-    topology->state &= ~HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM;
 }
 
 void

--- a/hwloc/topology-freebsd.c
+++ b/hwloc/topology-freebsd.c
@@ -567,6 +567,19 @@ hwloc_look_freebsd(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
   struct hwloc_freebsd_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
 
   if (dstatus->phase == HWLOC_DISC_PHASE_CPU) {
+    enum hwloc_x86_mode_e x86_mode = topology->x86_mode;
+    if (x86_mode == HWLOC_X86_MODE_CUSTOM) {
+      if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER|HWLOC_SHOWMSG_X86))
+        fprintf(stderr, "hwloc/freebsd: no custom x86 mode, using default.");
+      x86_mode = HWLOC_X86_MODE_DEFAULT;
+    }
+    if (x86_mode == HWLOC_X86_MODE_DEFAULT)
+      x86_mode = HWLOC_X86_MODE_FIRST;
+    if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+      hwloc_x86_discover_all(topology);
+    if (x86_mode == HWLOC_X86_MODE_ONLY)
+      return 0;
+
     if (!topology->levels[0][0]->cpuset) {
       /* Nobody (even the x86 backend) created objects yet, setup basic objects */
       int nbprocs = hwloc_fallback_nbprocessors(0);
@@ -577,6 +590,10 @@ hwloc_look_freebsd(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
       hwloc_alloc_root_sets(topology->levels[0][0]);
       hwloc_setup_pu_level(topology, nbprocs);
     }
+
+    if (x86_mode == HWLOC_X86_MODE_LAST)
+      hwloc_x86_discover_all(topology);
+
   } else if (dstatus->phase == HWLOC_DISC_PHASE_MEMORY) {
       int64_t memsize;
 #ifdef CPU_WHICH_DOMAIN

--- a/hwloc/topology-freebsd.c
+++ b/hwloc/topology-freebsd.c
@@ -567,16 +567,30 @@ hwloc_look_freebsd(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
   struct hwloc_freebsd_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
 
   if (dstatus->phase == HWLOC_DISC_PHASE_CPU) {
-    if (!topology->levels[0][0]->cpuset) {
+    enum hwloc_x86_mode_e x86_mode;
+
+    hwloc_alloc_root_sets(topology->levels[0][0]);
+
+    x86_mode = hwloc_x86_fixup_mode(topology, HWLOC_X86_MODE_FIRST, 0, "freebsd");
+
+    if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+      hwloc_x86_discover_all(topology);
+    if (x86_mode == HWLOC_X86_MODE_ONLY)
+      return 0;
+
+    if (hwloc_bitmap_iszero(topology->levels[0][0]->cpuset)) {
       /* Nobody (even the x86 backend) created objects yet, setup basic objects */
       int nbprocs = hwloc_fallback_nbprocessors(0);
       if (nbprocs >= 1)
         topology->support.discovery->pu = 1;
       else
         nbprocs = 1;
-      hwloc_alloc_root_sets(topology->levels[0][0]);
       hwloc_setup_pu_level(topology, nbprocs);
     }
+
+    if (x86_mode == HWLOC_X86_MODE_LAST)
+      hwloc_x86_discover_all(topology);
+
   } else if (dstatus->phase == HWLOC_DISC_PHASE_MEMORY) {
       int64_t memsize;
 #ifdef CPU_WHICH_DOMAIN

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -7165,31 +7165,28 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
         if (!hwloc_access("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1", R_OK, data->root_fd))
           data->cpukinds_use_midr = 1;
       }
-      env = getenv("HWLOC_LINUX_CPUKINDS");
+      env = getenv("HWLOC_CPUKINDS");
       if (env) {
         if (!strcmp(env, "none") || !strcmp(env, "0")) {
           data->cpukinds_enabled = 0;
           hwloc_debug("linux/cpukinds: disabled by HWLOC_LINUX_CPUKINDS envvar\n");
         } else {
+          const char *str;
           /* if variable is given, assume anything else means enabled */
           data->cpukinds_enabled = 1;
           hwloc_debug("linux/cpukinds: enabled by HWLOC_LINUX_CPUKINDS envvar\n");
-          if (!strncmp(env, "cppc=", 5))
-            data->cpukinds_use_cppc = atoi(env+5);
-          else if (!strncmp(env, "midr=", 5))
-            data->cpukinds_use_midr = atoi(env+5);
-        }
-      }
-      if (data->cpukinds_enabled) {
-        env = getenv("HWLOC_CPUKINDS_MAXFREQ");
-        if (env) {
-          if (!strcmp(env, "0")) {
-            data->cpukinds_maxfreq_enabled = 0;
-          } else if (!strcmp(env, "1")) {
-            data->cpukinds_maxfreq_enabled = 1;
-          } else if (!strncmp(env, "adjust=", 7)) {
-            data->cpukinds_maxfreq_adjust = atoi(env+7);
-          }
+          str = strstr(env, "cppc=");
+          if (str)
+            data->cpukinds_use_cppc = atoi(str+5);
+          str = strstr(env, "midr=");
+          if (str)
+            data->cpukinds_use_midr = atoi(str+5);
+          str = strstr(env, "maxfreq=");
+          if (str)
+            data->cpukinds_maxfreq_enabled = atoi(str+8);
+          str = strstr(env, "freqadjust=");
+          if (str)
+            data->cpukinds_maxfreq_adjust = atoi(str+11);
         }
       }
       if (data->cpukinds_enabled) {

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -7346,7 +7346,8 @@ hwloc_linux_component_instantiate(struct hwloc_topology *topology,
     if (root < 0)
       goto out_with_data;
 
-    backend->is_thissystem = 0;
+    HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
+
     data->is_real_fsroot = 0;
     data->root_path = strdup(fsroot_path);
 

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -60,6 +60,7 @@ struct hwloc_linux_backend_data_s {
   char is_amd_with_CU;
   signed char cpukinds_enabled; /* -1 if not decided yet */
   char cpukinds_use_midr;
+  char cpukinds_use_x86cpuid;
   signed char cpukinds_use_cppc; /* -1 means try, 0 no, 1 yes */
   signed char cpukinds_maxfreq_enabled; /* -1 means adjust (default), 0 means ignore, 1 means enforce */
   unsigned cpukinds_maxfreq_adjust;
@@ -7165,6 +7166,9 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
         if (!hwloc_access("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1", R_OK, data->root_fd))
           data->cpukinds_use_midr = 1;
       }
+      data->cpukinds_use_x86cpuid = 1;
+      if (topology->x86_mode == HWLOC_X86_MODE_NONE)
+        data->cpukinds_use_x86cpuid = 0;
       env = getenv("HWLOC_CPUKINDS");
       if (env) {
         if (!strcmp(env, "none") || !strcmp(env, "0")) {
@@ -7181,6 +7185,9 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
           str = strstr(env, "midr=");
           if (str)
             data->cpukinds_use_midr = atoi(str+5);
+          str = strstr(env, "x86cpuid=");
+          if (str)
+            data->cpukinds_use_x86cpuid = atoi(str+9);
           str = strstr(env, "maxfreq=");
           if (str)
             data->cpukinds_maxfreq_enabled = atoi(str+8);
@@ -7189,11 +7196,16 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
             data->cpukinds_maxfreq_adjust = atoi(str+11);
         }
       }
+      if (data->cpukinds_enabled == -1 && data->cpukinds_use_x86cpuid) {
+        data->cpukinds_enabled = hwloc_x86_maybe_hybrid(topology);
+        hwloc_debug("linux/cpukinds: set to %d from x86 cpuid\n", data->cpukinds_enabled);
+      }
       if (data->cpukinds_enabled) {
-        hwloc_debug("linux/cpukinds: enabled to %d with cppc %d midr %d maxfreq %d adjust %d\n",
+        hwloc_debug("linux/cpukinds: enabled to %d with cppc %d midr %d x86cpuid %d maxfreq %d adjust %d\n",
                     data->cpukinds_enabled,
                     data->cpukinds_use_cppc,
                     data->cpukinds_use_midr,
+                    data->cpukinds_use_x86cpuid,
                     data->cpukinds_maxfreq_enabled,
                     data->cpukinds_maxfreq_adjust);
       }
@@ -7339,6 +7351,7 @@ hwloc_linux_component_instantiate(struct hwloc_topology *topology,
   data->arch = HWLOC_LINUX_ARCH_UNKNOWN;
   data->cpukinds_enabled = -1; /* not decided yet */
   data->cpukinds_use_midr = 0; /* disabled until files are found */
+  data->cpukinds_use_x86cpuid = -1; /* use if available */
   data->cpukinds_use_cppc = -1; /* try */
   data->cpukinds_maxfreq_enabled =  -1; /* adjust */
   data->cpukinds_maxfreq_adjust = 10;

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -7201,7 +7201,22 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
   }
 
   if (dstatus->phase == HWLOC_DISC_PHASE_CPU) {
-    hwloc_linuxfs_look_cpu(topology, data, dstatus);
+    enum hwloc_x86_mode_e x86_mode = topology->x86_mode;
+    if (x86_mode == HWLOC_X86_MODE_CUSTOM) {
+      if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER|HWLOC_SHOWMSG_X86))
+        fprintf(stderr, "hwloc/linux: no custom x86 mode, using default.");
+      x86_mode = HWLOC_X86_MODE_DEFAULT;
+    }
+    if (x86_mode == HWLOC_X86_MODE_DEFAULT)
+      x86_mode = HWLOC_X86_MODE_LAST;
+    if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+      hwloc_x86_discover_all(topology);
+
+    if (x86_mode != HWLOC_X86_MODE_ONLY)
+      hwloc_linuxfs_look_cpu(topology, data, dstatus);
+
+    if (x86_mode == HWLOC_X86_MODE_LAST)
+      hwloc_x86_discover_all(topology);
   }
 
 #ifdef HWLOC_HAVE_LINUXIO

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -5453,7 +5453,7 @@ hwloc_linuxfs_look_cpu(struct hwloc_topology *topology,
            * This will avoid looking at AMD CPPC which may be slow on Zen2/3 (see #756)
            */
           if (data->cpukinds_enabled == -1) {
-            hwloc_debug("ignoring linux sysfs CPU kind detection on pre-Zen5 AMD CPUs\n");
+            hwloc_debug("linux/cpukinds: ignoring on pre-Zen5 AMD CPUs\n");
             data->cpukinds_enabled = 0;
           }
         }
@@ -7157,6 +7157,7 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
     /* initialize cpukinds config */
     if (topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS) {
       data->cpukinds_enabled = 0;
+      hwloc_debug("linux/cpukinds: disabled by topology flags\n");
     } else {
       data->cpukinds_use_midr = 0;
       if (data->arch == HWLOC_LINUX_ARCH_ARM /* was set in hwloc_gather_system_info() */) {
@@ -7168,9 +7169,11 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
       if (env) {
         if (!strcmp(env, "none") || !strcmp(env, "0")) {
           data->cpukinds_enabled = 0;
+          hwloc_debug("linux/cpukinds: disabled by HWLOC_LINUX_CPUKINDS envvar\n");
         } else {
           /* if variable is given, assume anything else means enabled */
           data->cpukinds_enabled = 1;
+          hwloc_debug("linux/cpukinds: enabled by HWLOC_LINUX_CPUKINDS envvar\n");
           if (!strncmp(env, "cppc=", 5))
             data->cpukinds_use_cppc = atoi(env+5);
           else if (!strncmp(env, "midr=", 5))
@@ -7188,6 +7191,14 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
             data->cpukinds_maxfreq_adjust = atoi(env+7);
           }
         }
+      }
+      if (data->cpukinds_enabled) {
+        hwloc_debug("linux/cpukinds: enabled to %d with cppc %d midr %d maxfreq %d adjust %d\n",
+                    data->cpukinds_enabled,
+                    data->cpukinds_use_cppc,
+                    data->cpukinds_use_midr,
+                    data->cpukinds_maxfreq_enabled,
+                    data->cpukinds_maxfreq_adjust);
       }
     }
   }

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -60,6 +60,7 @@ struct hwloc_linux_backend_data_s {
   char is_amd_with_CU;
   signed char cpukinds_enabled; /* -1 if not decided yet */
   char cpukinds_use_midr;
+  char cpukinds_use_x86cpuid;
   signed char cpukinds_use_cppc; /* -1 means try, 0 no, 1 yes */
   signed char cpukinds_maxfreq_enabled; /* -1 means adjust (default), 0 means ignore, 1 means enforce */
   unsigned cpukinds_maxfreq_adjust;
@@ -7165,6 +7166,9 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
         if (!hwloc_access("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1", R_OK, data->root_fd))
           data->cpukinds_use_midr = 1;
       }
+      data->cpukinds_use_x86cpuid = 1;
+      if (topology->x86_mode == HWLOC_X86_MODE_NONE)
+        data->cpukinds_use_x86cpuid = 0;
       env = getenv("HWLOC_CPUKINDS");
       if (env) {
         if (!strcmp(env, "none") || !strcmp(env, "0")) {
@@ -7181,6 +7185,9 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
           str = strstr(env, "midr=");
           if (str)
             data->cpukinds_use_midr = atoi(str+5);
+          str = strstr(env, "x86cpuid=");
+          if (str)
+            data->cpukinds_use_x86cpuid = atoi(str+9);
           str = strstr(env, "maxfreq=");
           if (str)
             data->cpukinds_maxfreq_enabled = atoi(str+8);
@@ -7189,11 +7196,16 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
             data->cpukinds_maxfreq_adjust = atoi(str+11);
         }
       }
+      if (data->cpukinds_enabled == -1 && data->cpukinds_use_x86cpuid) {
+        data->cpukinds_enabled = hwloc_x86_maybe_hybrid(topology);
+        hwloc_debug("linux/cpukinds: set to %d from x86 cpuid\n", data->cpukinds_enabled);
+      }
       if (data->cpukinds_enabled) {
-        hwloc_debug("linux/cpukinds: enabled to %d with cppc %d midr %d maxfreq %d adjust %d\n",
+        hwloc_debug("linux/cpukinds: enabled to %d with cppc %d midr %d x86cpuid %d maxfreq %d adjust %d\n",
                     data->cpukinds_enabled,
                     data->cpukinds_use_cppc,
                     data->cpukinds_use_midr,
+                    data->cpukinds_use_x86cpuid,
                     data->cpukinds_maxfreq_enabled,
                     data->cpukinds_maxfreq_adjust);
       }
@@ -7335,6 +7347,7 @@ hwloc_linux_component_instantiate(struct hwloc_topology *topology,
   data->arch = HWLOC_LINUX_ARCH_UNKNOWN;
   data->cpukinds_enabled = -1; /* not decided yet */
   data->cpukinds_use_midr = 0; /* disabled until files are found */
+  data->cpukinds_use_x86cpuid = -1; /* use if available */
   data->cpukinds_use_cppc = -1; /* try */
   data->cpukinds_maxfreq_enabled =  -1; /* adjust */
   data->cpukinds_maxfreq_adjust = 10;

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -5415,12 +5415,10 @@ hwloc_linuxfs_look_cpu(struct hwloc_topology *topology,
     return -1;
   }
 
-  already_pus = (topology->levels[0][0]->complete_cpuset != NULL
-		 && !hwloc_bitmap_iszero(topology->levels[0][0]->complete_cpuset));
+  already_pus = !hwloc_bitmap_iszero(topology->levels[0][0]->complete_cpuset);
   /* if there are PUs, still look at memory information
    * since x86 misses NUMA node information memory size.
    */
-  hwloc_alloc_root_sets(topology->levels[0][0]);
 
   /**********************
    * /proc/cpuinfo
@@ -7148,6 +7146,8 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
   if (data->need_global_infos) {
     char *env;
 
+    hwloc_x86_fixup_mode(topology, HWLOC_X86_MODE_LAST, 0, "linux");
+
     /* gather some info in data without actually adding them to the topology yet */
     hwloc_gather_system_info(topology, data);
     hwloc_linuxfs_check_kernel_cmdline(data);
@@ -7201,7 +7201,18 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
   }
 
   if (dstatus->phase == HWLOC_DISC_PHASE_CPU) {
-    hwloc_linuxfs_look_cpu(topology, data, dstatus);
+    enum hwloc_x86_mode_e x86_mode = topology->x86_mode;
+
+    hwloc_alloc_root_sets(topology->levels[0][0]);
+
+    if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+      hwloc_x86_discover_all(topology);
+
+    if (x86_mode != HWLOC_X86_MODE_ONLY)
+      hwloc_linuxfs_look_cpu(topology, data, dstatus);
+
+    if (x86_mode == HWLOC_X86_MODE_LAST)
+      hwloc_x86_discover_all(topology);
   }
 
 #ifdef HWLOC_HAVE_LINUXIO

--- a/hwloc/topology-netbsd.c
+++ b/hwloc/topology-netbsd.c
@@ -145,8 +145,21 @@ hwloc_look_netbsd(struct hwloc_backend *backend, struct hwloc_disc_status *dstat
 
   struct hwloc_topology *topology = backend->topology;
   int64_t memsize;
+  enum hwloc_x86_mode_e x86_mode = topology->x86_mode;
 
   assert(dstatus->phase == HWLOC_DISC_PHASE_CPU);
+
+  if (x86_mode == HWLOC_X86_MODE_CUSTOM) {
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER|HWLOC_SHOWMSG_X86))
+      fprintf(stderr, "hwloc/netbsd: no custom x86 mode, using default.");
+    x86_mode = HWLOC_X86_MODE_DEFAULT;
+  }
+  if (x86_mode == HWLOC_X86_MODE_DEFAULT)
+    x86_mode = HWLOC_X86_MODE_FIRST;
+  if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+    hwloc_x86_discover_all(topology);
+  if (x86_mode == HWLOC_X86_MODE_ONLY)
+    return 0;
 
   if (!topology->levels[0][0]->cpuset) {
     /* Nobody (even the x86 backend) created objects yet, setup basic objects */
@@ -166,6 +179,10 @@ hwloc_look_netbsd(struct hwloc_backend *backend, struct hwloc_disc_status *dstat
   /* Add NetBSD specific information */
   hwloc__add_info(&topology->infos, "Backend", "NetBSD");
   hwloc_add_uname_info(topology, NULL);
+
+  if (x86_mode == HWLOC_X86_MODE_LAST)
+    hwloc_x86_discover_all(topology);
+
   return 0;
 }
 

--- a/hwloc/topology-netbsd.c
+++ b/hwloc/topology-netbsd.c
@@ -145,17 +145,26 @@ hwloc_look_netbsd(struct hwloc_backend *backend, struct hwloc_disc_status *dstat
 
   struct hwloc_topology *topology = backend->topology;
   int64_t memsize;
+  enum hwloc_x86_mode_e x86_mode;
 
   assert(dstatus->phase == HWLOC_DISC_PHASE_CPU);
 
-  if (!topology->levels[0][0]->cpuset) {
+  hwloc_alloc_root_sets(topology->levels[0][0]);
+
+  x86_mode = hwloc_x86_fixup_mode(topology, HWLOC_X86_MODE_FIRST, 0, "netbsd");
+
+  if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+    hwloc_x86_discover_all(topology);
+  if (x86_mode == HWLOC_X86_MODE_ONLY)
+    return 0;
+
+  if (hwloc_bitmap_iszero(topology->levels[0][0]->cpuset)) {
     /* Nobody (even the x86 backend) created objects yet, setup basic objects */
     int nbprocs = hwloc_fallback_nbprocessors(0);
     if (nbprocs >= 1)
       topology->support.discovery->pu = 1;
     else
       nbprocs = 1;
-    hwloc_alloc_root_sets(topology->levels[0][0]);
     hwloc_setup_pu_level(topology, nbprocs);
   }
 
@@ -166,6 +175,10 @@ hwloc_look_netbsd(struct hwloc_backend *backend, struct hwloc_disc_status *dstat
   /* Add NetBSD specific information */
   hwloc__add_info(&topology->infos, "Backend", "NetBSD");
   hwloc_add_uname_info(topology, NULL);
+
+  if (x86_mode == HWLOC_X86_MODE_LAST)
+    hwloc_x86_discover_all(topology);
+
   return 0;
 }
 

--- a/hwloc/topology-noos.c
+++ b/hwloc/topology-noos.c
@@ -22,8 +22,21 @@ hwloc_look_noos(struct hwloc_backend *backend, struct hwloc_disc_status *dstatus
 
   struct hwloc_topology *topology = backend->topology;
   int64_t memsize;
+  enum hwloc_x86_mode_e x86_mode = topology->x86_mode;
 
   assert(dstatus->phase == HWLOC_DISC_PHASE_CPU);
+
+  if (x86_mode == HWLOC_X86_MODE_CUSTOM) {
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER|HWLOC_SHOWMSG_X86))
+      fprintf(stderr, "hwloc/no_os: no custom x86 mode, using default.");
+    x86_mode = HWLOC_X86_MODE_DEFAULT;
+  }
+  if (x86_mode == HWLOC_X86_MODE_DEFAULT)
+    x86_mode = HWLOC_X86_MODE_FIRST;
+  if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+    hwloc_x86_discover_all(topology);
+  if (x86_mode == HWLOC_X86_MODE_ONLY)
+    return 0;
 
   if (!topology->levels[0][0]->cpuset) {
     int nbprocs;
@@ -45,6 +58,10 @@ hwloc_look_noos(struct hwloc_backend *backend, struct hwloc_disc_status *dstatus
 
   hwloc_add_uname_info(topology, NULL);
   hwloc_fallback_add_pagesize_info(topology);
+
+  if (x86_mode == HWLOC_X86_MODE_LAST)
+    hwloc_x86_discover_all(topology);
+
   return 0;
 }
 

--- a/hwloc/topology-noos.c
+++ b/hwloc/topology-noos.c
@@ -22,10 +22,20 @@ hwloc_look_noos(struct hwloc_backend *backend, struct hwloc_disc_status *dstatus
 
   struct hwloc_topology *topology = backend->topology;
   int64_t memsize;
+  enum hwloc_x86_mode_e x86_mode;
 
   assert(dstatus->phase == HWLOC_DISC_PHASE_CPU);
 
-  if (!topology->levels[0][0]->cpuset) {
+  hwloc_alloc_root_sets(topology->levels[0][0]);
+
+  x86_mode = hwloc_x86_fixup_mode(topology, HWLOC_X86_MODE_FIRST, 0, "no_os");
+
+  if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+    hwloc_x86_discover_all(topology);
+  if (x86_mode == HWLOC_X86_MODE_ONLY)
+    return 0;
+
+  if (hwloc_bitmap_iszero(topology->levels[0][0]->cpuset)) {
     int nbprocs;
     /* Nobody (even the x86 backend) created objects yet, setup basic objects */
 
@@ -34,7 +44,6 @@ hwloc_look_noos(struct hwloc_backend *backend, struct hwloc_disc_status *dstatus
       topology->support.discovery->pu = 1;
     else
       nbprocs = 1;
-    hwloc_alloc_root_sets(topology->levels[0][0]);
     hwloc_setup_pu_level(topology, nbprocs);
     hwloc__add_info(&topology->infos, "Backend", "noOS");
   }
@@ -45,6 +54,10 @@ hwloc_look_noos(struct hwloc_backend *backend, struct hwloc_disc_status *dstatus
 
   hwloc_add_uname_info(topology, NULL);
   hwloc_fallback_add_pagesize_info(topology);
+
+  if (x86_mode == HWLOC_X86_MODE_LAST)
+    hwloc_x86_discover_all(topology);
+
   return 0;
 }
 

--- a/hwloc/topology-solaris.c
+++ b/hwloc/topology-solaris.c
@@ -1007,6 +1007,7 @@ hwloc_look_solaris(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
    */
 
   struct hwloc_topology *topology = backend->topology;
+  enum hwloc_x86_mode_e x86_mode = topology->x86_mode;
   int alreadypus = 0;
 
   assert(dstatus->phase == HWLOC_DISC_PHASE_CPU);
@@ -1014,6 +1015,18 @@ hwloc_look_solaris(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
   if (topology->levels[0][0]->cpuset)
     /* somebody discovered things */
     alreadypus = 1;
+
+  if (x86_mode == HWLOC_X86_MODE_CUSTOM) {
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER|HWLOC_SHOWMSG_X86))
+      fprintf(stderr, "hwloc/solaris: no custom x86 mode, using default.");
+    x86_mode = HWLOC_X86_MODE_DEFAULT;
+  }
+  if (x86_mode == HWLOC_X86_MODE_DEFAULT)
+    x86_mode = HWLOC_X86_MODE_LAST;
+  if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+    hwloc_x86_discover_all(topology);
+  if (x86_mode == HWLOC_X86_MODE_ONLY)
+    return 0;
 
   if (!alreadypus) {
     hwloc_alloc_root_sets(topology->levels[0][0]);
@@ -1023,6 +1036,9 @@ hwloc_look_solaris(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
       alreadypus = 1;
 #endif /* HAVE_LIBKSTAT */
   }
+
+  if (x86_mode == HWLOC_X86_MODE_LAST)
+    hwloc_x86_discover_all(topology);
 
   if (!alreadypus) {
     int nbprocs = hwloc_fallback_nbprocessors(0);

--- a/hwloc/topology-solaris.c
+++ b/hwloc/topology-solaris.c
@@ -1043,22 +1043,34 @@ hwloc_look_solaris(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
    */
 
   struct hwloc_topology *topology = backend->topology;
+  enum hwloc_x86_mode_e x86_mode;
   int alreadypus = 0;
 
   assert(dstatus->phase == HWLOC_DISC_PHASE_CPU);
 
-  if (topology->levels[0][0]->cpuset)
+  hwloc_alloc_root_sets(topology->levels[0][0]);
+
+  x86_mode = hwloc_x86_fixup_mode(topology, HWLOC_X86_MODE_LAST, 0, "solaris");
+
+  if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+    hwloc_x86_discover_all(topology);
+  if (x86_mode == HWLOC_X86_MODE_ONLY)
+    return 0;
+
+  if (!hwloc_bitmap_iszero(topology->levels[0][0]->cpuset))
     /* somebody discovered things */
     alreadypus = 1;
 
   if (!alreadypus) {
-    hwloc_alloc_root_sets(topology->levels[0][0]);
 #ifdef HAVE_LIBKSTAT
     /* look_kstat() could still add Solaris-specific groups but it's not easy to implement */
     if (hwloc_look_kstat(topology) > 0)
       alreadypus = 1;
 #endif /* HAVE_LIBKSTAT */
   }
+
+  if (x86_mode == HWLOC_X86_MODE_LAST)
+    hwloc_x86_discover_all(topology);
 
   if (!alreadypus) {
     int nbprocs = hwloc_fallback_nbprocessors(0);

--- a/hwloc/topology-synthetic.c
+++ b/hwloc/topology-synthetic.c
@@ -1115,7 +1115,8 @@ hwloc_synthetic_component_instantiate(struct hwloc_topology *topology,
 
   backend->discover = hwloc_look_synthetic;
   backend->disable = hwloc_synthetic_backend_disable;
-  backend->is_thissystem = 0;
+
+  HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
 
   return backend;
 

--- a/hwloc/topology-windows.c
+++ b/hwloc/topology-windows.c
@@ -993,6 +993,7 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
    */
 
   struct hwloc_topology *topology = backend->topology;
+  enum hwloc_x86_mode_e x86_mode = topology->x86_mode;
   hwloc_bitmap_t groups_pu_set = NULL;
   DWORD length;
   int gotnuma = 0;
@@ -1016,6 +1017,18 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
   if (topology->levels[0][0]->cpuset)
     /* somebody discovered things, only detect NUMA nodes and Windows-specific things */
     already_cpus = 1;
+
+  if (x86_mode == HWLOC_X86_MODE_CUSTOM) {
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER|HWLOC_SHOWMSG_X86))
+      fprintf(stderr, "hwloc/windows: no custom x86 mode, using default.");
+    x86_mode = HWLOC_X86_MODE_DEFAULT;
+  }
+  if (x86_mode == HWLOC_X86_MODE_DEFAULT)
+    x86_mode = HWLOC_X86_MODE_LAST;
+  if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+    hwloc_x86_discover_all(topology);
+  if (x86_mode == HWLOC_X86_MODE_ONLY)
+    return 0;
 
   ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
   osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
@@ -1303,6 +1316,9 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
  out:
   if (has_efficiencyclass)
     hwloc_win_efficiency_classes_destroy(&eclasses);
+
+  if (x86_mode == HWLOC_X86_MODE_LAST)
+    hwloc_x86_discover_all(topology);
 
   /* emulate uname instead of calling hwloc_add_uname_info() */
   hwloc__add_info(&topology->infos, "Backend", "Windows");

--- a/hwloc/topology-windows.c
+++ b/hwloc/topology-windows.c
@@ -993,6 +993,7 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
    */
 
   struct hwloc_topology *topology = backend->topology;
+  enum hwloc_x86_mode_e x86_mode;
   hwloc_bitmap_t groups_pu_set = NULL;
   DWORD length;
   int gotnuma = 0;
@@ -1013,7 +1014,16 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
 
   assert(dstatus->phase == HWLOC_DISC_PHASE_CPU);
 
-  if (topology->levels[0][0]->cpuset)
+  hwloc_alloc_root_sets(topology->levels[0][0]);
+
+  x86_mode = hwloc_x86_fixup_mode(topology, HWLOC_X86_MODE_LAST, 0, "windows");
+
+  if (x86_mode == HWLOC_X86_MODE_FIRST || x86_mode == HWLOC_X86_MODE_ONLY)
+    hwloc_x86_discover_all(topology);
+  if (x86_mode == HWLOC_X86_MODE_ONLY)
+    return 0;
+
+  if (!hwloc_bitmap_iszero(topology->levels[0][0]->cpuset))
     /* somebody discovered things, only detect NUMA nodes and Windows-specific things */
     already_cpus = 1;
 
@@ -1035,8 +1045,6 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
     has_efficiencyclass = 1;
     hwloc_win_efficiency_classes_init(&eclasses);
   }
-
-  hwloc_alloc_root_sets(topology->levels[0][0]);
 
   /* initialize once per topology */
   GetSystemInfo(&SystemInfo);
@@ -1303,6 +1311,9 @@ hwloc_look_windows(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
  out:
   if (has_efficiencyclass)
     hwloc_win_efficiency_classes_destroy(&eclasses);
+
+  if (x86_mode == HWLOC_X86_MODE_LAST)
+    hwloc_x86_discover_all(topology);
 
   /* emulate uname instead of calling hwloc_add_uname_info() */
   hwloc__add_info(&topology->infos, "Backend", "Windows");

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -2112,6 +2112,40 @@ hwloc_x86_exit(hwloc_topology_t topology)
   hwloc_x86_init(topology);
 }
 
+static void
+hwloc__x86_do_until(hwloc_topology_t topology,
+                    struct hwloc_x86_backend_data_s *data,
+                    unsigned long until_state)
+{
+  assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
+  assert(data);
+  assert(data->state & HWLOC_X86_STATE_INIT);
+
+  if ((until_state & HWLOC_X86_STATE_FEATURES)
+      && !(data->state & (HWLOC_X86_STATE_FEATURES|HWLOC_X86_STATE_FEATURES_FAILED))) {
+    /* query features from current CPU (or CPU#0 dump) */
+    hwloc_x86_get_features(data);
+  }
+
+  if ((until_state & HWLOC_X86_STATE_QUERIED)
+      && !(data->state & (HWLOC_X86_STATE_QUERIED|HWLOC_X86_STATE_QUERY_FAILED))) {
+    /* query all CPUs, requires features */
+    hwloc_x86_query_all(topology, data);
+  }
+
+  if ((until_state & HWLOC_X86_STATE_OBJECTS)
+      && !(data->state & HWLOC_X86_STATE_OBJECTS)) {
+    /* build/insert objects, requires query */
+    hwloc_x86_build_objects(topology, data);
+  }
+
+  if ((until_state & HWLOC_X86_STATE_CPUKINDS)
+      && !(data->state & HWLOC_X86_STATE_CPUKINDS)) {
+    /* build cpukinds, require query*/
+    hwloc_x86_build_cpukinds(topology, data);
+  }
+}
+
 int
 hwloc_x86_discover_all(hwloc_topology_t topology)
 {
@@ -2121,13 +2155,7 @@ hwloc_x86_discover_all(hwloc_topology_t topology)
   assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
   assert(topology->x86_mode != HWLOC_X86_MODE_DONE);
 
-  /* query features from current CPU (or CPU#0 dump) */
-  hwloc_x86_get_features(data);
-
-  hwloc_x86_query_all(topology, data);
-
-  hwloc_x86_build_objects(topology, data);
-  hwloc_x86_build_cpukinds(topology, data);
+  hwloc__x86_do_until(topology, data, HWLOC_X86_STATE_FEATURES|HWLOC_X86_STATE_QUERIED|HWLOC_X86_STATE_OBJECTS|HWLOC_X86_STATE_CPUKINDS);
 
   topology->x86_mode = HWLOC_X86_MODE_DONE;
   return 0;

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1826,15 +1826,11 @@ out:
 }
 
 static int
-hwloc_x86_discover(struct hwloc_backend *backend, struct hwloc_disc_status *dstatus)
+hwloc_x86_discover(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
 {
-  struct hwloc_x86_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
-  struct hwloc_topology *topology = backend->topology;
   unsigned long flags = 0;
   int alreadypus = 0;
   int ret;
-
-  assert(dstatus->phase == HWLOC_DISC_PHASE_CPU);
 
   if (data->nbprocs > 1 && !data->src_cpuiddump_path && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING)) {
     return 0;
@@ -1850,7 +1846,7 @@ hwloc_x86_discover(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
 #endif
 
   if (data->src_cpuiddump_path) {
-    assert(data->nbprocs > 0); /* enforced by hwloc_x86_component_instantiate() */
+    assert(data->nbprocs > 0); /* enforced by hwloc_x86_init() */
     topology->support.discovery->pu = 1;
   } else {
     int nbprocs = hwloc_fallback_nbprocessors(HWLOC_FALLBACK_NBPROCESSORS_INCLUDE_OFFLINE);
@@ -1981,6 +1977,15 @@ hwloc_x86_check_cpuiddump_input(const char *src_cpuiddump_path, hwloc_bitmap_t s
   return -1;
 }
 
+void
+hwloc_x86_init(struct hwloc_topology *topology)
+{
+  topology->x86_env = NULL;
+  topology->x86_mode = HWLOC_X86_MODE_DEFAULT;
+  topology->x86_data = NULL;
+}
+
+#ifdef HWLOC_HAVE_X86_CPUID
 static int
 hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
 {
@@ -2020,67 +2025,81 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
   return 0;
 }
 
-static void
-hwloc_x86_exit(struct hwloc_x86_backend_data_s *data)
+void
+hwloc_x86_prepare(struct hwloc_topology *topology)
 {
-  hwloc_bitmap_free(data->apicid_set);
-  free(data->src_cpuiddump_path);
-}
-
-static void
-hwloc_x86_backend_disable(struct hwloc_backend *backend)
-{
-  struct hwloc_x86_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
-  hwloc_x86_exit(data);
-}
-
-static struct hwloc_backend *
-hwloc_x86_component_instantiate(struct hwloc_topology *topology,
-				struct hwloc_disc_component *component,
-				unsigned excluded_phases __hwloc_attribute_unused,
-				const void *_data1 __hwloc_attribute_unused,
-				const void *_data2 __hwloc_attribute_unused,
-				const void *_data3 __hwloc_attribute_unused)
-{
-  struct hwloc_backend *backend;
   struct hwloc_x86_backend_data_s *data;
+  const char *env;
 
-  backend = hwloc_backend_alloc(topology, component, sizeof(*data));
-  if (!backend)
+  env = getenv("HWLOC_X86");
+  if (env) {
+    topology->x86_env = env;
+    if (!strcmp(env, "none")) {
+      topology->x86_mode = HWLOC_X86_MODE_NONE;
+      return;
+    }
+    else if (!strcmp(env, "last"))
+      topology->x86_mode = HWLOC_X86_MODE_LAST;
+    else if (!strcmp(env, "first"))
+      topology->x86_mode = HWLOC_X86_MODE_FIRST;
+    else if (!strcmp(env, "only"))
+      topology->x86_mode = HWLOC_X86_MODE_ONLY;
+    else
+      topology->x86_mode = HWLOC_X86_MODE_CUSTOM;
+  }
+
+  data = malloc(sizeof(*data));
+  if (!data)
     goto out;
-
-  backend->discover = hwloc_x86_discover;
-  backend->disable = hwloc_x86_backend_disable;
-
-  /* default values */
-  data = HWLOC_BACKEND_PRIVATE_DATA(backend);
   if (hwloc_x86_setup(data) < 0)
-    goto out_with_backend;
+    goto out_with_data;
+  topology->x86_data = data;
+
   if (data->src_cpuiddump_path)
-    HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
+    HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, 1 /* forced cpuid is always by envvar */);
 
-  return backend;
+  return;
 
- out_with_backend:
-  free(backend);
+ out_with_data:
+  free(data);
  out:
-  return NULL;
+  topology->x86_mode = HWLOC_X86_MODE_NONE;
+  if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL))
+    fprintf(stderr, "hwloc/x86: failed to prepare backend data, disabling.\n");
+  return;
+}
+#else /* HWLOC_HAVE_X86_CPUID */
+void
+hwloc_x86_prepare(struct hwloc_topology *topology)
+{
+  topology->x86_mode = HWLOC_X86_MODE_NONE;
+  assert(!topology->x86_data);
+}
+#endif /* !HWLOC_HAVE_X86_CPUID */
+
+void
+hwloc_x86_exit(hwloc_topology_t topology)
+{
+  struct hwloc_x86_backend_data_s *data = topology->x86_data;
+  if (data) {
+    hwloc_bitmap_free(data->apicid_set);
+    free(data->src_cpuiddump_path);
+    free(data);
+  }
+  hwloc_x86_init(topology);
 }
 
-static struct hwloc_disc_component hwloc_x86_disc_component = {
-  "x86",
-  HWLOC_DISC_PHASE_CPU,
-  HWLOC_DISC_PHASE_GLOBAL,
-  hwloc_x86_component_instantiate,
-  45, /* between native and no_os */
-  1,
-  NULL
-};
+int
+hwloc_x86_discover_all(hwloc_topology_t topology)
+{
+  struct hwloc_x86_backend_data_s *data = topology->x86_data;
 
-const struct hwloc_component hwloc_x86_component = {
-  HWLOC_COMPONENT_ABI,
-  NULL, NULL,
-  HWLOC_COMPONENT_TYPE_DISC,
-  0,
-  &hwloc_x86_disc_component
-};
+  assert(data);
+  assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
+  assert(topology->x86_mode != HWLOC_X86_MODE_DONE);
+
+  hwloc_x86_discover(topology, data);
+
+  topology->x86_mode = HWLOC_X86_MODE_DONE;
+  return 0;
+}

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1981,35 +1981,12 @@ hwloc_x86_check_cpuiddump_input(const char *src_cpuiddump_path, hwloc_bitmap_t s
   return -1;
 }
 
-static void
-hwloc_x86_backend_disable(struct hwloc_backend *backend)
+static int
+hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
 {
-  struct hwloc_x86_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
-  hwloc_bitmap_free(data->apicid_set);
-  free(data->src_cpuiddump_path);
-}
-
-static struct hwloc_backend *
-hwloc_x86_component_instantiate(struct hwloc_topology *topology,
-				struct hwloc_disc_component *component,
-				unsigned excluded_phases __hwloc_attribute_unused,
-				const void *_data1 __hwloc_attribute_unused,
-				const void *_data2 __hwloc_attribute_unused,
-				const void *_data3 __hwloc_attribute_unused)
-{
-  struct hwloc_backend *backend;
-  struct hwloc_x86_backend_data_s *data;
   const char *src_cpuiddump_path;
 
-  backend = hwloc_backend_alloc(topology, component, sizeof(*data));
-  if (!backend)
-    goto out;
-
-  backend->discover = hwloc_x86_discover;
-  backend->disable = hwloc_x86_backend_disable;
-
   /* default values */
-  data = HWLOC_BACKEND_PRIVATE_DATA(backend);
   data->vendor = HWLOC_X86_VENDOR_UNKNOWN;
   data->highest_cpuid = 0;
   data->highest_ext_cpuid = 0;
@@ -2018,7 +1995,7 @@ hwloc_x86_component_instantiate(struct hwloc_topology *topology,
   data->is_hybrid = 0;
   data->apicid_set = hwloc_bitmap_alloc();
   if (!data->apicid_set)
-    goto out_with_backend;
+    return -1;
   data->apicid_unique = 1;
   data->src_cpuiddump_path = NULL;
   data->found_die_ids = 0;
@@ -2031,9 +2008,6 @@ hwloc_x86_component_instantiate(struct hwloc_topology *topology,
   if (src_cpuiddump_path) {
     hwloc_bitmap_t set = hwloc_bitmap_alloc();
     if (set && !hwloc_x86_check_cpuiddump_input(src_cpuiddump_path, set)) {
-
-      HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
-
       data->src_cpuiddump_path = strdup(src_cpuiddump_path);
       assert(!hwloc_bitmap_iszero(set)); /* enforced by hwloc_x86_check_cpuiddump_input() */
       data->nbprocs = hwloc_bitmap_weight(set);
@@ -2042,6 +2016,48 @@ hwloc_x86_component_instantiate(struct hwloc_topology *topology,
     }
     hwloc_bitmap_free(set);
   }
+
+  return 0;
+}
+
+static void
+hwloc_x86_exit(struct hwloc_x86_backend_data_s *data)
+{
+  hwloc_bitmap_free(data->apicid_set);
+  free(data->src_cpuiddump_path);
+}
+
+static void
+hwloc_x86_backend_disable(struct hwloc_backend *backend)
+{
+  struct hwloc_x86_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
+  hwloc_x86_exit(data);
+}
+
+static struct hwloc_backend *
+hwloc_x86_component_instantiate(struct hwloc_topology *topology,
+				struct hwloc_disc_component *component,
+				unsigned excluded_phases __hwloc_attribute_unused,
+				const void *_data1 __hwloc_attribute_unused,
+				const void *_data2 __hwloc_attribute_unused,
+				const void *_data3 __hwloc_attribute_unused)
+{
+  struct hwloc_backend *backend;
+  struct hwloc_x86_backend_data_s *data;
+
+  backend = hwloc_backend_alloc(topology, component, sizeof(*data));
+  if (!backend)
+    goto out;
+
+  backend->discover = hwloc_x86_discover;
+  backend->disable = hwloc_x86_backend_disable;
+
+  /* default values */
+  data = HWLOC_BACKEND_PRIVATE_DATA(backend);
+  if (hwloc_x86_setup(data) < 0)
+    goto out_with_backend;
+  if (data->src_cpuiddump_path)
+    HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
 
   return backend;
 

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -71,7 +71,7 @@ struct hwloc_x86_backend_data_s {
   int apicid_unique;
 
   int is_knl;
-  int is_hybrid;
+  int is_hybrid; /* -1 if unknown */
 
   int found_die_ids;
   int found_complex_ids;
@@ -1558,7 +1558,8 @@ hwloc_x86_build_cpukinds(struct hwloc_topology *topology, struct hwloc_x86_backe
     return 0;
   }
 
-  if (!data->is_hybrid || data->nbprocs == 1
+  if (data->is_hybrid < 1 /* either not hybrid, or we don't know and have no way to build cpukinds */
+      || data->nbprocs == 1
       || (topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
     data->state |= HWLOC_X86_STATE_CPUKINDS;
     return 0;
@@ -1738,6 +1739,11 @@ hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
     data->features[1] = edx;
     data->features[6] = ecx;
   }
+
+  if (on_intel() || on_amd())
+    /* AMD and Intel aren't "unknown", we'll get "hybrid" during query */
+    data->is_hybrid = 0;
+  /* other vendors don't have hybrid CPU yet, and we don't know where to check, keep "unknown" */
 
   data->state |= HWLOC_X86_STATE_FEATURES;
   return 0;
@@ -1974,6 +1980,7 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
   /* non-zero default values (data was calloc'ed) */
   data->vendor = HWLOC_X86_VENDOR_UNKNOWN;
   data->apicid_unique = 1;
+  data->is_hybrid = -1; /* unknown */
 
   data->apicid_set = hwloc_bitmap_alloc();
   if (!data->apicid_set)
@@ -2159,4 +2166,20 @@ hwloc_x86_discover_all(hwloc_topology_t topology)
 
   topology->x86_mode = HWLOC_X86_MODE_DONE;
   return 0;
+}
+
+int
+hwloc_x86_maybe_hybrid(hwloc_topology_t topology)
+{
+  struct hwloc_x86_backend_data_s *data = topology->x86_data;
+
+  if (!data)
+    /* we won't know */
+    return -1;
+  assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
+
+  if (topology->x86_mode != HWLOC_X86_MODE_DONE)
+    hwloc__x86_do_until(topology, data, HWLOC_X86_STATE_FEATURES|HWLOC_X86_STATE_QUERIED);
+
+  return data->is_hybrid;
 }

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1746,9 +1746,6 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     }
   }
 
-  if (!src_cpuiddump && !hwloc_have_x86_cpuid())
-    goto out;
-
   data->procinfos = infos = calloc(nbprocs, sizeof(struct procinfo));
   if (NULL == infos)
     goto out;
@@ -1948,7 +1945,7 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
 
   data->apicid_set = hwloc_bitmap_alloc();
   if (!data->apicid_set)
-    return -1;
+    goto out;
 
   src_cpuiddump_path = getenv("HWLOC_CPUID_PATH");
   if (src_cpuiddump_path) {
@@ -1975,13 +1972,15 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
   if (!data->cpuiddumps) {
     int nbprocs;
 
+    if (!hwloc_have_x86_cpuid())
+      goto out_with_apicid_set;
+
 #if HAVE_DECL_RUNNING_ON_VALGRIND
     if (RUNNING_ON_VALGRIND) {
       fprintf(stderr, "hwloc x86 backend cannot work under Valgrind, disabling.\n"
               "May be reenabled by dumping CPUIDs with hwloc-gather-cpuid\n"
               "and reloading them under Valgrind with HWLOC_CPUID_PATH.\n");
-      hwloc_bitmap_free(data->apicid_set);
-      return -1;
+      goto out_with_apicid_set;
     }
 #endif
 
@@ -1994,6 +1993,11 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
   }
 
   return 0;
+
+ out_with_apicid_set:
+  hwloc_bitmap_free(data->apicid_set);
+ out:
+  return -1;
 }
 
 void

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1697,7 +1697,6 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   int (*get_cpubind)(hwloc_topology_t topology, hwloc_cpuset_t set, int flags) = NULL;
   int (*set_cpubind)(hwloc_topology_t topology, hwloc_const_cpuset_t set, int flags) = NULL;
   hwloc_bitmap_t restrict_set = NULL;
-  struct cpuiddump *src_cpuiddump = NULL;
   int ret = -1;
 
   /* check if binding works */
@@ -1711,11 +1710,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
    * but that's the vast majority of cases anyway, and the overhead is very small.
    */
 
-  if (data->cpuiddumps) {
-    /* Just use cpuid from the dump (implies !topology->is_thissystem by default) */
-    src_cpuiddump = &data->cpuiddumps[0];
-
-  } else {
+  if (!data->cpuiddumps) {
     /* Using real hardware.
      * However we don't enforce topology->is_thissystem so that
      * we may still force use this backend when debugging with !thissystem.
@@ -1775,7 +1770,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
 
   if (nbprocs == 1) {
     /* only one processor, no need to bind */
-    look_proc(topology, data, &infos[0], src_cpuiddump);
+    look_proc(topology, data, &infos[0], data->cpuiddumps ? &data->cpuiddumps[0] : NULL);
     summarize(topology, data, flags);
     ret = 0;
   }

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -37,7 +37,8 @@
 struct hwloc_x86_backend_data_s {
   char *src_cpuiddump_path;
 
-  unsigned nbprocs; /* set during init if src_cpuiddump_path, otherwise during discover */
+  char pu_support;
+  unsigned nbprocs;
 
   unsigned highest_cpuid;
   unsigned highest_ext_cpuid;
@@ -1836,27 +1837,6 @@ hwloc_x86_discover(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     return 0;
   }
 
-#if HAVE_DECL_RUNNING_ON_VALGRIND
-  if (RUNNING_ON_VALGRIND && !data->src_cpuiddump_path) {
-    fprintf(stderr, "hwloc x86 backend cannot work under Valgrind, disabling.\n"
-	    "May be reenabled by dumping CPUIDs with hwloc-gather-cpuid\n"
-	    "and reloading them under Valgrind with HWLOC_CPUID_PATH.\n");
-    return 0;
-  }
-#endif
-
-  if (data->src_cpuiddump_path) {
-    assert(data->nbprocs > 0); /* enforced by hwloc_x86_init() */
-    topology->support.discovery->pu = 1;
-  } else {
-    int nbprocs = hwloc_fallback_nbprocessors(HWLOC_FALLBACK_NBPROCESSORS_INCLUDE_OFFLINE);
-    if (nbprocs >= 1)
-      topology->support.discovery->pu = 1;
-    else
-      nbprocs = 1;
-    data->nbprocs = (unsigned) nbprocs;
-  }
-
   if (topology->levels[0][0]->cpuset) {
     /* somebody else discovered things, reconnect levels so that we can look at them */
     hwloc__reconnect(topology, 0);
@@ -1897,6 +1877,8 @@ fulldiscovery:
 #endif
 #endif
   }
+  if (data->pu_support)
+    topology->support.discovery->pu = 1;
 
   return 1;
 }
@@ -2006,10 +1988,31 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
       data->src_cpuiddump_path = strdup(src_cpuiddump_path);
       assert(!hwloc_bitmap_iszero(set)); /* enforced by hwloc_x86_check_cpuiddump_input() */
       data->nbprocs = hwloc_bitmap_weight(set);
+      data->pu_support = 1;
     } else {
       fprintf(stderr, "hwloc/x86: Ignoring dumped cpuid directory (%s).\n", strerror(errno));
     }
     hwloc_bitmap_free(set);
+  }
+
+  if (!data->src_cpuiddump_path) {
+    int nbprocs;
+
+#if HAVE_DECL_RUNNING_ON_VALGRIND
+    if (RUNNING_ON_VALGRIND) {
+      fprintf(stderr, "hwloc x86 backend cannot work under Valgrind, disabling.\n"
+              "May be reenabled by dumping CPUIDs with hwloc-gather-cpuid\n"
+              "and reloading them under Valgrind with HWLOC_CPUID_PATH.\n");
+      return -1;
+    }
+#endif
+
+    nbprocs = hwloc_fallback_nbprocessors(HWLOC_FALLBACK_NBPROCESSORS_INCLUDE_OFFLINE);
+    if (nbprocs >= 1)
+      data->pu_support = 1;
+    else
+      nbprocs = 1;
+    data->nbprocs = (unsigned) nbprocs;
   }
 
   return 0;

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -2031,7 +2031,9 @@ hwloc_x86_component_instantiate(struct hwloc_topology *topology,
   if (src_cpuiddump_path) {
     hwloc_bitmap_t set = hwloc_bitmap_alloc();
     if (set && !hwloc_x86_check_cpuiddump_input(src_cpuiddump_path, set)) {
-      backend->is_thissystem = 0;
+
+      HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
+
       data->src_cpuiddump_path = strdup(src_cpuiddump_path);
       assert(!hwloc_bitmap_iszero(set)); /* enforced by hwloc_x86_check_cpuiddump_input() */
       data->nbprocs = hwloc_bitmap_weight(set);

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1578,8 +1578,9 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
 #define SH_ECX ('a' | ('i'<<8) | (' '<<16) | (' '<<24))
 
 static int
-hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data, struct cpuiddump *src_cpuiddump)
+hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
 {
+  struct cpuiddump *src_cpuiddump = data->cpuiddumps ? &data->cpuiddumps[0] : NULL;
   unsigned eax, ebx, ecx = 0, edx;
   unsigned highest_cpuid;
   unsigned highest_ext_cpuid;
@@ -1758,9 +1759,6 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     infos[i].ids[MODULE] = (unsigned) -1;
     infos[i].ids[DIE] = (unsigned) -1;
   }
-
-  if (hwloc_x86_get_features(data, src_cpuiddump)  < 0)
-    goto out;
 
   hwloc_x86_os_state_save(&os_state, src_cpuiddump);
 
@@ -2086,6 +2084,10 @@ hwloc_x86_discover_all(hwloc_topology_t topology)
   assert(data);
   assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
   assert(topology->x86_mode != HWLOC_X86_MODE_DONE);
+
+  /* query features from current CPU (or CPU#0 dump) */
+  if (hwloc_x86_get_features(data) < 0)
+    return -1;
 
   hwloc_x86_discover(topology, data);
 

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -71,6 +71,51 @@ struct hwloc_x86_backend_data_s {
   int found_unit_ids;
   int found_module_ids;
   int found_tile_ids;
+
+  struct procinfo {
+    unsigned present;
+    unsigned apicid;
+#define PKG 0
+#define CORE 1
+#define NODE 2 /* not used for building NUMA nodes, but still used to identify objects (e.g. same core ids in different NUMA nodes on Hygon Dhyana) */
+#define UNIT 3
+#define TILE 4
+#define MODULE 5
+#define DIE 6
+#define COMPLEX 7
+#define HWLOC_X86_PROCINFO_ID_NR 8
+    unsigned ids[HWLOC_X86_PROCINFO_ID_NR];
+    unsigned *otherids;
+    unsigned levels; /* total number of levels.
+                      * IDs are either stored in otherids[level]
+                      * or in ids[type] with otherids[level] = UINT_MAX
+                      */
+
+    char cpuvendor[13];
+    char cpumodel[3*4*4+1];
+    unsigned cpustepping;
+    unsigned cpumodelnumber;
+    unsigned cpufamilynumber;
+
+    unsigned hybridcoretype;
+    unsigned hybridnativemodel;
+    unsigned power_efficiency_ranking;
+
+    unsigned numcaches;
+    struct cacheinfo {
+      hwloc_obj_cache_type_t type;
+      unsigned level;
+      unsigned nbthreads_sharing;
+      unsigned cacheid;
+
+      unsigned linesize;
+      unsigned linepart;
+      int inclusive;
+      int ways;
+      unsigned sets;
+      unsigned long size;
+    } *cache;
+  } *procinfos;
 };
 
 /************************************
@@ -222,51 +267,6 @@ enum hwloc_x86_disc_flags {
 #define has_topoext() (features[6] & (1 << 22))
 #define has_x2apic() (features[4] & (1 << 21))
 #define has_hybrid() (features[18] & (1 << 15))
-
-struct cacheinfo {
-  hwloc_obj_cache_type_t type;
-  unsigned level;
-  unsigned nbthreads_sharing;
-  unsigned cacheid;
-
-  unsigned linesize;
-  unsigned linepart;
-  int inclusive;
-  int ways;
-  unsigned sets;
-  unsigned long size;
-};
-
-struct procinfo {
-  unsigned present;
-  unsigned apicid;
-#define PKG 0
-#define CORE 1
-#define NODE 2 /* not used for building NUMA nodes, but still used to identify objects (e.g. same core ids in different NUMA nodes on Hygon Dhyana) */
-#define UNIT 3
-#define TILE 4
-#define MODULE 5
-#define DIE 6
-#define COMPLEX 7
-#define HWLOC_X86_PROCINFO_ID_NR 8
-  unsigned ids[HWLOC_X86_PROCINFO_ID_NR];
-  unsigned *otherids;
-  unsigned levels; /* total number of levels.
-                    * IDs are either stored in otherids[level]
-                    * or in ids[type] with otherids[level] = UINT_MAX
-                    */
-  unsigned numcaches;
-  struct cacheinfo *cache;
-  char cpuvendor[13];
-  char cpumodel[3*4*4+1];
-  unsigned cpustepping;
-  unsigned cpumodelnumber;
-  unsigned cpufamilynumber;
-
-  unsigned hybridcoretype;
-  unsigned hybridnativemodel;
-  unsigned power_efficiency_ranking;
-};
 
 /* AMD legacy cache information from specific CPUID 0x80000005-6 leaves */
 static void setup__amd_cache_legacy(struct procinfo *infos, unsigned level, hwloc_obj_cache_type_t type, unsigned nbthreads_sharing, unsigned cpuid)
@@ -1020,9 +1020,10 @@ hwloc_x86_add_groups(hwloc_topology_t topology,
 }
 
 /* Analyse information stored in infos, and build/annotate topology levels accordingly */
-static void summarize(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data, struct procinfo *infos, unsigned long flags)
+static void summarize(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data, unsigned long flags)
 {
   unsigned nbprocs = data->nbprocs;
+  struct procinfo *infos = data->procinfos;
   hwloc_bitmap_t complete_cpuset = hwloc_bitmap_alloc();
   unsigned i, j, l, level;
   int one = -1;
@@ -1506,12 +1507,13 @@ look_cpukinds_amd(struct hwloc_topology *topology,
 
 static int
 look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data,
-           struct procinfo *infos, unsigned long flags,
+           unsigned long flags,
 	   int (*get_cpubind)(hwloc_topology_t topology, hwloc_cpuset_t set, int flags),
 	   int (*set_cpubind)(hwloc_topology_t topology, hwloc_const_cpuset_t set, int flags),
            hwloc_bitmap_t restrict_set)
 {
   unsigned nbprocs = data->nbprocs;
+  struct procinfo *infos = data->procinfos;
   hwloc_bitmap_t orig_cpuset = NULL;
   hwloc_bitmap_t set = NULL;
   unsigned i;
@@ -1560,7 +1562,7 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
   }
 
   if (data->apicid_unique) {
-    summarize(topology, data, infos, flags);
+    summarize(topology, data, flags);
 
     if (data->is_hybrid
         && !(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
@@ -1776,7 +1778,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   if (!src_cpuiddump && !hwloc_have_x86_cpuid())
     goto out;
 
-  infos = calloc(nbprocs, sizeof(struct procinfo));
+  data->procinfos = infos = calloc(nbprocs, sizeof(struct procinfo));
   if (NULL == infos)
     goto out;
   for (i = 0; i < nbprocs; i++) {
@@ -1790,11 +1792,11 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   }
 
   if (hwloc_x86_get_features(data, src_cpuiddump)  < 0)
-    goto out_with_infos;
+    goto out;
 
   hwloc_x86_os_state_save(&os_state, src_cpuiddump);
 
-  ret = look_procs(topology, data, infos, flags,
+  ret = look_procs(topology, data, flags,
 		   get_cpubind, set_cpubind, restrict_set);
   if (!ret)
     /* success, we're done */
@@ -1803,21 +1805,12 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   if (nbprocs == 1) {
     /* only one processor, no need to bind */
     look_proc(topology, data, &infos[0], src_cpuiddump);
-    summarize(topology, data, infos, flags);
+    summarize(topology, data, flags);
     ret = 0;
   }
 
 out_with_os_state:
   hwloc_x86_os_state_restore(&os_state, src_cpuiddump);
-
-out_with_infos:
-  if (NULL != infos) {
-    for (i = 0; i < nbprocs; i++) {
-      free(infos[i].cache);
-      free(infos[i].otherids);
-    }
-    free(infos);
-  }
 
 out:
   hwloc_bitmap_free(restrict_set);
@@ -2003,6 +1996,7 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
       fprintf(stderr, "hwloc x86 backend cannot work under Valgrind, disabling.\n"
               "May be reenabled by dumping CPUIDs with hwloc-gather-cpuid\n"
               "and reloading them under Valgrind with HWLOC_CPUID_PATH.\n");
+      hwloc_bitmap_free(data->apicid_set);
       return -1;
     }
 #endif
@@ -2075,6 +2069,14 @@ hwloc_x86_exit(hwloc_topology_t topology)
 {
   struct hwloc_x86_backend_data_s *data = topology->x86_data;
   if (data) {
+    if (NULL != data->procinfos) {
+      unsigned i;
+      for (i = 0; i < data->nbprocs; i++) {
+        free(data->procinfos[i].cache);
+        free(data->procinfos[i].otherids);
+      }
+      free(data->procinfos);
+    }
     hwloc_bitmap_free(data->apicid_set);
     free(data->src_cpuiddump_path);
     free(data);

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -35,8 +35,6 @@
 #endif
 
 struct hwloc_x86_backend_data_s {
-  char *src_cpuiddump_path;
-
   char pu_support;
   unsigned nbprocs;
 
@@ -116,39 +114,30 @@ struct hwloc_x86_backend_data_s {
       unsigned long size;
     } *cache;
   } *procinfos;
+
+  struct cpuiddump {
+    unsigned nr;
+    struct cpuiddump_entry {
+      unsigned inmask; /* which of ine[abcd]x are set on input */
+      unsigned ineax;
+      unsigned inebx;
+      unsigned inecx;
+      unsigned inedx;
+      unsigned outeax;
+      unsigned outebx;
+      unsigned outecx;
+      unsigned outedx;
+    } *entries;
+  } *cpuiddumps;
 };
 
 /************************************
  * Management of cpuid dump as input
  */
 
-struct cpuiddump {
-  unsigned nr;
-  struct cpuiddump_entry {
-    unsigned inmask; /* which of ine[abcd]x are set on input */
-    unsigned ineax;
-    unsigned inebx;
-    unsigned inecx;
-    unsigned inedx;
-    unsigned outeax;
-    unsigned outebx;
-    unsigned outecx;
-    unsigned outedx;
-  } *entries;
-};
-
-static void
-cpuiddump_free(struct cpuiddump *cpuiddump)
+static int
+cpuiddump_read(struct cpuiddump *cpuiddump, const char *dirpath, unsigned idx)
 {
-  if (cpuiddump->nr)
-    free(cpuiddump->entries);
-  free(cpuiddump);
-}
-
-static struct cpuiddump *
-cpuiddump_read(const char *dirpath, unsigned idx)
-{
-  struct cpuiddump *cpuiddump;
   struct cpuiddump_entry *cur;
   size_t filenamelen;
   char *filename;
@@ -156,16 +145,10 @@ cpuiddump_read(const char *dirpath, unsigned idx)
   char line[128];
   unsigned nr;
 
-  cpuiddump = malloc(sizeof(*cpuiddump));
-  if (!cpuiddump) {
-    fprintf(stderr, "hwloc/x86: Failed to allocate cpuiddump for PU #%u, ignoring cpuiddump.\n", idx);
-    goto out;
-  }
-
   filenamelen = strlen(dirpath) + 15;
   filename = malloc(filenamelen);
   if (!filename)
-    goto out_with_dump;
+    goto out;
   snprintf(filename, filenamelen, "%s/pu%u", dirpath, idx);
   file = fopen(filename, "r");
   if (!file) {
@@ -202,16 +185,14 @@ cpuiddump_read(const char *dirpath, unsigned idx)
   cpuiddump->nr = nr;
   fclose(file);
   free(filename);
-  return cpuiddump;
+  return 0;
 
  out_with_file:
   fclose(file);
  out_with_filename:
   free(filename);
- out_with_dump:
-  free(cpuiddump);
  out:
-  return NULL;
+  return -1;
 }
 
 static void
@@ -1520,7 +1501,7 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
   hwloc_bitmap_t set = NULL;
   unsigned i;
 
-  if (!data->src_cpuiddump_path) {
+  if (!data->cpuiddumps) {
     orig_cpuset = hwloc_bitmap_alloc();
     if (get_cpubind(topology, orig_cpuset, HWLOC_CPUBIND_STRICT)) {
       hwloc_bitmap_free(orig_cpuset);
@@ -1530,18 +1511,12 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
   }
 
   for (i = 0; i < nbprocs; i++) {
-    struct cpuiddump *src_cpuiddump = NULL;
-
     if (restrict_set && !hwloc_bitmap_isset(restrict_set, i)) {
       /* skip this CPU outside of the binding mask */
       continue;
     }
 
-    if (data->src_cpuiddump_path) {
-      src_cpuiddump = cpuiddump_read(data->src_cpuiddump_path, i);
-      if (!src_cpuiddump)
-	continue;
-    } else {
+    if (!data->cpuiddumps) {
       hwloc_bitmap_only(set, i);
       hwloc_debug("binding to CPU%u\n", i);
       if (set_cpubind(topology, set, HWLOC_CPUBIND_STRICT)) {
@@ -1550,14 +1525,10 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
       }
     }
 
-    look_proc(topology, data, &infos[i], src_cpuiddump);
-
-    if (data->src_cpuiddump_path) {
-      cpuiddump_free(src_cpuiddump);
-    }
+    look_proc(topology, data, &infos[i], data->cpuiddumps ? &data->cpuiddumps[i] : NULL);
   }
 
-  if (!data->src_cpuiddump_path) {
+  if (!data->cpuiddumps) {
     set_cpubind(topology, orig_cpuset, 0);
     hwloc_bitmap_free(set);
     hwloc_bitmap_free(orig_cpuset);
@@ -1728,15 +1699,13 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
    * but the current overhead is negligible, so just always reget them.
    */
   hwloc_set_native_binding_hooks(&hooks, &support);
-  /* in theory, those are only needed if !data->src_cpuiddump_path || HWLOC_TOPOLOGY_FLAG_RESTRICT_TO_BINDING
+  /* in theory, those are only needed if !data->cpuiddumps || HWLOC_TOPOLOGY_FLAG_RESTRICT_TO_BINDING
    * but that's the vast majority of cases anyway, and the overhead is very small.
    */
 
-  if (data->src_cpuiddump_path) {
-    /* Just read cpuid from the dump (implies !topology->is_thissystem by default) */
-    src_cpuiddump = cpuiddump_read(data->src_cpuiddump_path, 0);
-    if (!src_cpuiddump)
-      goto out;
+  if (data->cpuiddumps) {
+    /* Just use cpuid from the dump (implies !topology->is_thissystem by default) */
+    src_cpuiddump = &data->cpuiddumps[0];
 
   } else {
     /* Using real hardware.
@@ -1816,8 +1785,6 @@ out_with_os_state:
 
 out:
   hwloc_bitmap_free(restrict_set);
-  if (src_cpuiddump)
-    cpuiddump_free(src_cpuiddump);
   return ret;
 }
 
@@ -1828,7 +1795,7 @@ hwloc_x86_discover(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   int alreadypus = 0;
   int ret;
 
-  if (data->nbprocs > 1 && !data->src_cpuiddump_path && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING)) {
+  if (data->nbprocs > 1 && !data->cpuiddumps && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING)) {
     return 0;
   }
 
@@ -1860,7 +1827,7 @@ fulldiscovery:
 
   hwloc__add_info(&topology->infos, "Backend", "x86");
 
-  if (!data->src_cpuiddump_path) { /* CPUID dump works for both x86 and x86_64 */
+  if (!data->cpuiddumps) { /* CPUID dump works for both x86 and x86_64 */
 #ifdef HAVE_UNAME
     hwloc_add_uname_info(topology, NULL); /* we already know is_thissystem() is true */
 #else
@@ -1987,17 +1954,25 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
   if (src_cpuiddump_path) {
     hwloc_bitmap_t set = hwloc_bitmap_alloc();
     if (set && !hwloc_x86_check_cpuiddump_input(src_cpuiddump_path, set)) {
-      data->src_cpuiddump_path = strdup(src_cpuiddump_path);
+      unsigned nbprocs = hwloc_bitmap_weight(set);
       assert(!hwloc_bitmap_iszero(set)); /* enforced by hwloc_x86_check_cpuiddump_input() */
-      data->nbprocs = hwloc_bitmap_weight(set);
-      data->pu_support = 1;
-    } else {
-      fprintf(stderr, "hwloc/x86: Ignoring dumped cpuid directory (%s).\n", strerror(errno));
+      data->cpuiddumps = malloc(nbprocs * sizeof(struct cpuiddump));
+      if (NULL != data->cpuiddumps) {
+        unsigned i;
+        for(i=0; i<nbprocs; i++) {
+          data->cpuiddumps[i].nr = 0;
+          cpuiddump_read(&data->cpuiddumps[i], src_cpuiddump_path, i);
+        }
+        data->nbprocs = nbprocs;
+        data->pu_support = 1;
+      }
     }
+    if (!data->cpuiddumps && HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc/x86: Ignoring dumped cpuid directory (%s).\n", strerror(errno));
     hwloc_bitmap_free(set);
   }
 
-  if (!data->src_cpuiddump_path) {
+  if (!data->cpuiddumps) {
     int nbprocs;
 
 #if HAVE_DECL_RUNNING_ON_VALGRIND
@@ -2051,7 +2026,7 @@ hwloc_x86_prepare(struct hwloc_topology *topology)
     goto out_with_data;
   topology->x86_data = data;
 
-  if (data->src_cpuiddump_path)
+  if (data->cpuiddumps)
     HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, 1 /* forced cpuid is always by envvar */);
 
   return;
@@ -2078,6 +2053,13 @@ hwloc_x86_exit(hwloc_topology_t topology)
 {
   struct hwloc_x86_backend_data_s *data = topology->x86_data;
   if (data) {
+    if (NULL != data->cpuiddumps) {
+      unsigned i;
+      for (i = 0; i < data->nbprocs; i++)
+        if (data->cpuiddumps[i].nr)
+          free(data->cpuiddumps[i].entries);
+      free(data->cpuiddumps);
+    }
     if (NULL != data->procinfos) {
       unsigned i;
       for (i = 0; i < data->nbprocs; i++) {
@@ -2087,7 +2069,6 @@ hwloc_x86_exit(hwloc_topology_t topology)
       free(data->procinfos);
     }
     hwloc_bitmap_free(data->apicid_set);
-    free(data->src_cpuiddump_path);
     free(data);
   }
   hwloc_x86_init(topology);

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1991,23 +1991,13 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
 {
   const char *src_cpuiddump_path;
 
-  /* default values */
+  /* non-zero default values (data was calloc'ed) */
   data->vendor = HWLOC_X86_VENDOR_UNKNOWN;
-  data->highest_cpuid = 0;
-  data->highest_ext_cpuid = 0;
-  memset(&data->features, 0, sizeof(data->features));
-  data->is_knl = 0;
-  data->is_hybrid = 0;
+  data->apicid_unique = 1;
+
   data->apicid_set = hwloc_bitmap_alloc();
   if (!data->apicid_set)
     return -1;
-  data->apicid_unique = 1;
-  data->src_cpuiddump_path = NULL;
-  data->found_die_ids = 0;
-  data->found_complex_ids = 0;
-  data->found_unit_ids = 0;
-  data->found_module_ids = 0;
-  data->found_tile_ids = 0;
 
   src_cpuiddump_path = getenv("HWLOC_CPUID_PATH");
   if (src_cpuiddump_path) {
@@ -2048,7 +2038,7 @@ hwloc_x86_prepare(struct hwloc_topology *topology)
       topology->x86_mode = HWLOC_X86_MODE_CUSTOM;
   }
 
-  data = malloc(sizeof(*data));
+  data = calloc(1, sizeof(*data));
   if (!data)
     goto out;
   if (hwloc_x86_setup(data) < 0)

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -35,6 +35,15 @@
 #endif
 
 struct hwloc_x86_backend_data_s {
+#define HWLOC_X86_STATE_INIT (1UL<<0) /* only init done */
+#define HWLOC_X86_STATE_FEATURES (1UL<<1) /* queried features from the current CPU */
+#define HWLOC_X86_STATE_FEATURES_FAILED (1UL<<2) /* failed to get features */
+#define HWLOC_X86_STATE_QUERIED (1UL<<3) /* queried everything from all CPUs */
+#define HWLOC_X86_STATE_QUERY_FAILED (1UL<<4) /* query failed */
+#define HWLOC_X86_STATE_OBJECTS (1UL<<5) /* built/inserted objects */
+#define HWLOC_X86_STATE_CPUKINDS (1UL<<6) /* built cpukinds */
+  unsigned long state;
+
   char pu_support;
   unsigned nbprocs;
 
@@ -1350,6 +1359,59 @@ static void summarize(struct hwloc_topology *topology, struct hwloc_x86_backend_
   hwloc_bitmap_free(complete_cpuset);
 }
 
+static int
+hwloc_x86_build_objects(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
+{
+  if (data->pu_support)
+    topology->support.discovery->pu = 1;
+
+  if (data->state & HWLOC_X86_STATE_QUERY_FAILED) {
+    /* we failed to query, just add PUs if none */
+    if (!topology->levels[0][0]->cpuset) {
+      hwloc_alloc_root_sets(topology->levels[0][0]);
+      hwloc_setup_pu_level(topology, data->nbprocs);
+    }
+    data->state |= HWLOC_X86_STATE_OBJECTS;
+    return 0;
+  }
+  assert(data->state & HWLOC_X86_STATE_QUERIED);
+
+  if (topology->levels[0][0]->cpuset) {
+    /* somebody else discovered things, reconnect levels so that we can look at them */
+    hwloc__reconnect(topology, 0);
+    if (topology->nb_levels != 2 || topology->level_nbobjects[1] != data->nbprocs) {
+      /* either more than a PU level was discovered, or the number of PUs doesn't match,
+       * just annotate the existing objects */
+      summarize(topology, data, 0);
+      hwloc__add_info(&topology->infos, "Backend", "x86");
+      data->state |= HWLOC_X86_STATE_OBJECTS;
+      return 0;
+    }
+  } else {
+    /* topology is empty, initialize it */
+    hwloc_alloc_root_sets(topology->levels[0][0]);
+  }
+
+  summarize(topology, data, HWLOC_X86_DISC_FLAG_FULL);
+  hwloc__add_info(&topology->infos, "Backend", "x86");
+
+  if (!data->cpuiddumps) { /* CPUID dump works for both x86 and x86_64 */
+#ifdef HAVE_UNAME
+    hwloc_add_uname_info(topology, NULL); /* we already know is_thissystem() is true */
+#else
+    /* uname isn't available, manually setup the "Architecture" info */
+#ifdef HWLOC_X86_64_ARCH
+    hwloc_obj_add_info(topology->levels[0][0], "Architecture", "x86_64");
+#else
+    hwloc_obj_add_info(topology->levels[0][0], "Architecture", "x86");
+#endif
+#endif
+  }
+
+  data->state |= HWLOC_X86_STATE_OBJECTS;
+  return 0;
+}
+
 static void
 look_cpukinds_intel(struct hwloc_topology *topology,
                     unsigned nbprocs, struct procinfo *infos)
@@ -1488,6 +1550,31 @@ look_cpukinds_amd(struct hwloc_topology *topology,
   }
 }
 
+static int
+hwloc_x86_build_cpukinds(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
+{
+  if (data->state & HWLOC_X86_STATE_QUERY_FAILED) {
+    data->state |= HWLOC_X86_STATE_CPUKINDS;
+    return 0;
+  }
+
+  if (!data->is_hybrid || data->nbprocs == 1
+      || (topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
+    data->state |= HWLOC_X86_STATE_CPUKINDS;
+    return 0;
+  }
+
+  /* use hybrid info for cpukinds */
+  enum hwloc_x86_vendor vendor = data->vendor;
+  if (on_intel())
+    look_cpukinds_intel(topology, data->nbprocs, data->procinfos);
+  else if (on_amd())
+    look_cpukinds_amd(topology, data->nbprocs, data->procinfos);
+
+  data->state |= HWLOC_X86_STATE_CPUKINDS;
+  return 0;
+}
+
 #if defined HWLOC_FREEBSD_SYS && defined HAVE_CPUSET_SETID
 #include <sys/param.h>
 #include <sys/cpuset.h>
@@ -1601,6 +1688,8 @@ hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
   unsigned highest_ext_cpuid;
   enum hwloc_x86_vendor vendor;
 
+  assert(data->state == HWLOC_X86_STATE_INIT);
+
   eax = 0x00;
   cpuid_or_from_dump(&eax, &ebx, &ecx, &edx, src_cpuiddump);
   highest_cpuid = eax;
@@ -1618,7 +1707,7 @@ hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
 
   hwloc_debug("highest cpuid %x, vendor %u\n", highest_cpuid, vendor);
   if (highest_cpuid < 0x01)
-    return -1;
+    goto error;
 
   data->highest_cpuid = highest_cpuid;
   data->vendor = vendor;
@@ -1650,7 +1739,12 @@ hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
     data->features[6] = ecx;
   }
 
+  data->state |= HWLOC_X86_STATE_FEATURES;
   return 0;
+
+ error:
+  data->state |= HWLOC_X86_STATE_FEATURES_FAILED;
+  return -1;
 }
 
 /* fake cpubind for when nbprocs=1 and no binding support */
@@ -1668,7 +1762,7 @@ static int fake_set_cpubind(hwloc_topology_t topology __hwloc_attribute_unused,
 }
 
 static
-int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data, unsigned long flags)
+int hwloc_x86_query_all(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
 {
   unsigned nbprocs = data->nbprocs;
   unsigned i;
@@ -1680,6 +1774,13 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   int (*set_cpubind)(hwloc_topology_t topology, hwloc_const_cpuset_t set, int flags) = NULL;
   hwloc_bitmap_t restrict_set = NULL;
   int ret = -1;
+
+  if (data->state & HWLOC_X86_STATE_FEATURES_FAILED)
+    goto error;
+  assert(data->state & HWLOC_X86_STATE_FEATURES);
+
+  if (data->nbprocs > 1 && !data->cpuiddumps && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING))
+    goto error;
 
   /* check if binding works */
   memset(&hooks, 0, sizeof(hooks));
@@ -1711,7 +1812,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     } else {
       /* we need binding support if there are multiple PUs */
       if (nbprocs > 1)
-	goto out;
+	goto error;
       get_cpubind = fake_get_cpubind;
       set_cpubind = fake_set_cpubind;
     }
@@ -1720,7 +1821,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   if (topology->flags & HWLOC_TOPOLOGY_FLAG_RESTRICT_TO_CPUBINDING) {
     restrict_set = hwloc_bitmap_alloc();
     if (!restrict_set)
-      goto out;
+      goto error;
     if (hooks.get_thisproc_cpubind)
       hooks.get_thisproc_cpubind(topology, restrict_set, 0);
     else if (hooks.get_thisthread_cpubind)
@@ -1733,7 +1834,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
 
   data->procinfos = infos = calloc(nbprocs, sizeof(struct procinfo));
   if (NULL == infos)
-    goto out;
+    goto error;
   for (i = 0; i < nbprocs; i++) {
     infos[i].ids[PKG] = (unsigned) -1;
     infos[i].ids[CORE] = (unsigned) -1;
@@ -1748,91 +1849,29 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
 		   get_cpubind, set_cpubind, restrict_set);
   if (!ret) {
     /* success */
-    if (data->apicid_unique) {
-      summarize(topology, data, flags);
-
-      if (data->is_hybrid
-          && !(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
-        /* use hybrid info for cpukinds */
-        enum hwloc_x86_vendor vendor = data->vendor;
-        if (on_intel())
-          look_cpukinds_intel(topology, nbprocs, infos);
-        else if (on_amd())
-          look_cpukinds_amd(topology, nbprocs, infos);
-      }
-    } else {
+    if (!data->apicid_unique) {
       hwloc_debug("x86 APIC IDs aren't unique, x86 discovery ignored.\n");
-      /* do nothing and return success, so that the caller does nothing either */
+      goto error;
     }
 
   }
   else if (nbprocs == 1) {
     /* look_procs() fails but there's only one processor, try without binding */
     look_proc(topology, data, &infos[0], data->cpuiddumps ? &data->cpuiddumps[0] : NULL);
-    summarize(topology, data, flags);
     ret = 0;
-  }
-
- out:
-  hwloc_bitmap_free(restrict_set);
-  return ret;
-}
-
-static int
-hwloc_x86_discover(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
-{
-  unsigned long flags = 0;
-  int alreadypus = 0;
-  int ret;
-
-  if (data->nbprocs > 1 && !data->cpuiddumps && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING)) {
-    return 0;
-  }
-
-  if (topology->levels[0][0]->cpuset) {
-    /* somebody else discovered things, reconnect levels so that we can look at them */
-    hwloc__reconnect(topology, 0);
-    if (topology->nb_levels == 2 && topology->level_nbobjects[1] == data->nbprocs) {
-      /* only PUs were discovered, as much as we would, complete the topology with everything else */
-      alreadypus = 1;
-      goto fulldiscovery;
-    }
-
-    /* several object types were added, we can't easily complete, just do partial discovery */
-    ret = hwloc_look_x86(topology, data, flags);
-    if (!ret)
-      hwloc__add_info(&topology->infos, "Backend", "x86");
-    return 0;
   } else {
-    /* topology is empty, initialize it */
-    hwloc_alloc_root_sets(topology->levels[0][0]);
+    /* couldn't query all CPUs */
+    goto error;
   }
 
-fulldiscovery:
-  if (hwloc_look_x86(topology, data, flags | HWLOC_X86_DISC_FLAG_FULL) < 0) {
-    /* if failed, create PUs */
-    if (!alreadypus)
-      hwloc_setup_pu_level(topology, data->nbprocs);
-  }
+  hwloc_bitmap_free(restrict_set);
+  data->state |= HWLOC_X86_STATE_QUERIED;
+  return ret;
 
-  hwloc__add_info(&topology->infos, "Backend", "x86");
-
-  if (!data->cpuiddumps) { /* CPUID dump works for both x86 and x86_64 */
-#ifdef HAVE_UNAME
-    hwloc_add_uname_info(topology, NULL); /* we already know is_thissystem() is true */
-#else
-    /* uname isn't available, manually setup the "Architecture" info */
-#ifdef HWLOC_X86_64_ARCH
-    hwloc_obj_add_info(topology->levels[0][0], "Architecture", "x86_64");
-#else
-    hwloc_obj_add_info(topology->levels[0][0], "Architecture", "x86");
-#endif
-#endif
-  }
-  if (data->pu_support)
-    topology->support.discovery->pu = 1;
-
-  return 1;
+ error:
+  hwloc_bitmap_free(restrict_set);
+  data->state |= HWLOC_X86_STATE_QUERY_FAILED;
+  return -1;
 }
 
 static int
@@ -1985,11 +2024,13 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
     data->nbprocs = (unsigned) nbprocs;
   }
 
+  data->state = HWLOC_X86_STATE_INIT;
   return 0;
 
  out_with_apicid_set:
   hwloc_bitmap_free(data->apicid_set);
  out:
+  data->state = 0;
   return -1;
 }
 
@@ -2081,10 +2122,12 @@ hwloc_x86_discover_all(hwloc_topology_t topology)
   assert(topology->x86_mode != HWLOC_X86_MODE_DONE);
 
   /* query features from current CPU (or CPU#0 dump) */
-  if (hwloc_x86_get_features(data) < 0)
-    return -1;
+  hwloc_x86_get_features(data);
 
-  hwloc_x86_discover(topology, data);
+  hwloc_x86_query_all(topology, data);
+
+  hwloc_x86_build_objects(topology, data);
+  hwloc_x86_build_cpukinds(topology, data);
 
   topology->x86_mode = HWLOC_X86_MODE_DONE;
   return 0;

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -169,7 +169,8 @@ cpuiddump_read(const char *dirpath, unsigned idx)
   snprintf(filename, filenamelen, "%s/pu%u", dirpath, idx);
   file = fopen(filename, "r");
   if (!file) {
-    fprintf(stderr, "hwloc/x86: Could not read dumped cpuid file %s, ignoring cpuiddump.\n", filename);
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc/x86: Could not read dumped cpuid file %s (%s), ignoring cpuiddump.\n", filename, strerror(errno));
     goto out_with_filename;
   }
 
@@ -178,7 +179,8 @@ cpuiddump_read(const char *dirpath, unsigned idx)
     nr++;
   cpuiddump->entries = malloc(nr * sizeof(struct cpuiddump_entry));
   if (!cpuiddump->entries) {
-    fprintf(stderr, "hwloc/x86: Failed to allocate %u cpuiddump entries for PU #%u, ignoring cpuiddump.\n", nr, idx);
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc/x86: Failed to allocate %u cpuiddump entries for PU #%u (%s), ignoring cpuiddump.\n", nr, idx, strerror(errno));
     goto out_with_file;
   }
 
@@ -1888,8 +1890,11 @@ hwloc_x86_check_cpuiddump_input(const char *src_cpuiddump_path, hwloc_bitmap_t s
   char line [32];
 
   dir = opendir(src_cpuiddump_path);
-  if (!dir) 
+  if (!dir) {
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc/x86: Couldn't open dumped cpuid directory `%s' (%s)\n", src_cpuiddump_path, strerror(errno));
     return -1;
+  }
 
   path = malloc(strlen(src_cpuiddump_path) + strlen("/hwloc-cpuid-info") + 1);
   if (!path)
@@ -1897,18 +1902,21 @@ hwloc_x86_check_cpuiddump_input(const char *src_cpuiddump_path, hwloc_bitmap_t s
   sprintf(path, "%s/hwloc-cpuid-info", src_cpuiddump_path);
   file = fopen(path, "r");
   if (!file) {
-    fprintf(stderr, "hwloc/x86: Couldn't open dumped cpuid summary %s\n", path);
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc/x86: Couldn't open dumped cpuid summary `%s' (%s)\n", path, strerror(errno));
     goto out_with_path;
   }
   if (!fgets(line, sizeof(line), file)) {
-    fprintf(stderr, "hwloc/x86: Failed to read dumped cpuid summary in %s\n", path);
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc/x86: Failed to read dumped cpuid summary in `%s' (%s)\n", path, strerror(errno));
     fclose(file);
     errno = EINVAL;
     goto out_with_path;
   }
   fclose(file);
   if (strncmp(line, "Architecture: x86", 17)) {
-    fprintf(stderr, "hwloc/x86: Found non-x86 dumped cpuid summary in %s: %s\n", path, line);
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc/x86: Found non-x86 dumped cpuid summary in `%s': %s\n", path, line);
     errno = EINVAL;
     goto out_with_path;
   }
@@ -1920,16 +1928,17 @@ hwloc_x86_check_cpuiddump_input(const char *src_cpuiddump_path, hwloc_bitmap_t s
       unsigned long idx = strtoul(dirent->d_name+2, &end, 10);
       if (!*end)
 	hwloc_bitmap_set(set, idx);
-      else
-	fprintf(stderr, "hwloc/x86: Ignoring invalid dirent `%s' in dumped cpuid directory `%s'\n",
-		dirent->d_name, src_cpuiddump_path);
+      else if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+        fprintf(stderr, "hwloc/x86: Ignoring invalid dirent `%s' in dumped cpuid directory `%s'\n",
+                dirent->d_name, src_cpuiddump_path);
     }
   }
   closedir(dir);
 
   if (hwloc_bitmap_iszero(set)) {
-    fprintf(stderr, "hwloc/x86: Did not find any valid pu%%u entry in dumped cpuid directory `%s'\n",
-	    src_cpuiddump_path);
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc/x86: Did not find any valid pu%%u entry in dumped cpuid directory `%s'\n",
+              src_cpuiddump_path);
     errno = EINVAL;
     return -1;
   } else if (hwloc_bitmap_last(set) != hwloc_bitmap_weight(set) - 1) {

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1488,6 +1488,27 @@ look_cpukinds_amd(struct hwloc_topology *topology,
   }
 }
 
+#if defined HWLOC_FREEBSD_SYS && defined HAVE_CPUSET_SETID
+#include <sys/param.h>
+#include <sys/cpuset.h>
+typedef cpusetid_t hwloc_x86_os_state_t;
+static void hwloc_x86_os_state_save(hwloc_x86_os_state_t *state)
+{
+  /* temporary make all cpus available during discovery */
+  cpuset_getid(CPU_LEVEL_CPUSET, CPU_WHICH_PID, -1, state);
+  cpuset_setid(CPU_WHICH_PID, -1, 0);
+}
+static void hwloc_x86_os_state_restore(hwloc_x86_os_state_t *state)
+{
+  /* restore initial cpuset */
+  cpuset_setid(CPU_WHICH_PID, -1, *state);
+}
+#else /* !defined HWLOC_FREEBSD_SYS || !defined HAVE_CPUSET_SETID */
+typedef void * hwloc_x86_os_state_t;
+static void hwloc_x86_os_state_save(hwloc_x86_os_state_t *state __hwloc_attribute_unused) { }
+static void hwloc_x86_os_state_restore(hwloc_x86_os_state_t *state __hwloc_attribute_unused) { }
+#endif /* !defined HWLOC_FREEBSD_SYS || !defined HAVE_CPUSET_SETID */
+
 static int
 look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data,
            unsigned long flags,
@@ -1497,15 +1518,19 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
 {
   unsigned nbprocs = data->nbprocs;
   struct procinfo *infos = data->procinfos;
+  hwloc_x86_os_state_t os_state;
   hwloc_bitmap_t orig_cpuset = NULL;
   hwloc_bitmap_t set = NULL;
   unsigned i;
+
+  if (data->cpuiddumps)
+    hwloc_x86_os_state_save(&os_state);
 
   if (!data->cpuiddumps) {
     orig_cpuset = hwloc_bitmap_alloc();
     if (get_cpubind(topology, orig_cpuset, HWLOC_CPUBIND_STRICT)) {
       hwloc_bitmap_free(orig_cpuset);
-      return -1;
+      goto error;
     }
     set = hwloc_bitmap_alloc();
   }
@@ -1550,7 +1575,15 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
     hwloc_debug("x86 APIC IDs aren't unique, x86 discovery ignored.\n");
     /* do nothing and return success, so that the caller does nothing either */
   }
+
+  if (data->cpuiddumps)
+    hwloc_x86_os_state_restore(&os_state);
   return 0;
+
+ error:
+  if (data->cpuiddumps)
+    hwloc_x86_os_state_restore(&os_state);
+  return -1;
 }
 
 /* GenuineIntel */
@@ -1638,31 +1671,6 @@ hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
   return 0;
 }
 
-#if defined HWLOC_FREEBSD_SYS && defined HAVE_CPUSET_SETID
-#include <sys/param.h>
-#include <sys/cpuset.h>
-typedef cpusetid_t hwloc_x86_os_state_t;
-static void hwloc_x86_os_state_save(hwloc_x86_os_state_t *state, struct cpuiddump *src_cpuiddump)
-{
-  if (!src_cpuiddump) {
-    /* temporary make all cpus available during discovery */
-    cpuset_getid(CPU_LEVEL_CPUSET, CPU_WHICH_PID, -1, state);
-    cpuset_setid(CPU_WHICH_PID, -1, 0);
-  }
-}
-static void hwloc_x86_os_state_restore(hwloc_x86_os_state_t *state, struct cpuiddump *src_cpuiddump)
-{
-  if (!src_cpuiddump) {
-    /* restore initial cpuset */
-    cpuset_setid(CPU_WHICH_PID, -1, *state);
-  }
-}
-#else /* !defined HWLOC_FREEBSD_SYS || !defined HAVE_CPUSET_SETID */
-typedef void * hwloc_x86_os_state_t;
-static void hwloc_x86_os_state_save(hwloc_x86_os_state_t *state __hwloc_attribute_unused, struct cpuiddump *src_cpuiddump __hwloc_attribute_unused) { }
-static void hwloc_x86_os_state_restore(hwloc_x86_os_state_t *state __hwloc_attribute_unused, struct cpuiddump *src_cpuiddump __hwloc_attribute_unused) { }
-#endif /* !defined HWLOC_FREEBSD_SYS || !defined HAVE_CPUSET_SETID */
-
 /* fake cpubind for when nbprocs=1 and no binding support */
 static int fake_get_cpubind(hwloc_topology_t topology __hwloc_attribute_unused,
 			    hwloc_cpuset_t set __hwloc_attribute_unused,
@@ -1683,7 +1691,6 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   unsigned nbprocs = data->nbprocs;
   unsigned i;
   struct procinfo *infos = NULL;
-  hwloc_x86_os_state_t os_state;
   struct hwloc_binding_hooks hooks;
   struct hwloc_topology_support support;
   struct hwloc_topology_membind_support memsupport __hwloc_attribute_unused;
@@ -1760,13 +1767,11 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     infos[i].ids[DIE] = (unsigned) -1;
   }
 
-  hwloc_x86_os_state_save(&os_state, src_cpuiddump);
-
   ret = look_procs(topology, data, flags,
 		   get_cpubind, set_cpubind, restrict_set);
   if (!ret)
     /* success, we're done */
-    goto out_with_os_state;
+    goto out;
 
   if (nbprocs == 1) {
     /* only one processor, no need to bind */
@@ -1774,9 +1779,6 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     summarize(topology, data, flags);
     ret = 0;
   }
-
-out_with_os_state:
-  hwloc_x86_os_state_restore(&os_state, src_cpuiddump);
 
 out:
   hwloc_bitmap_free(restrict_set);

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1511,7 +1511,6 @@ static void hwloc_x86_os_state_restore(hwloc_x86_os_state_t *state __hwloc_attri
 
 static int
 look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data,
-           unsigned long flags,
 	   int (*get_cpubind)(hwloc_topology_t topology, hwloc_cpuset_t set, int flags),
 	   int (*set_cpubind)(hwloc_topology_t topology, hwloc_const_cpuset_t set, int flags),
            hwloc_bitmap_t restrict_set)
@@ -1557,23 +1556,6 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
     set_cpubind(topology, orig_cpuset, 0);
     hwloc_bitmap_free(set);
     hwloc_bitmap_free(orig_cpuset);
-  }
-
-  if (data->apicid_unique) {
-    summarize(topology, data, flags);
-
-    if (data->is_hybrid
-        && !(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
-      /* use hybrid info for cpukinds */
-      enum hwloc_x86_vendor vendor = data->vendor;
-      if (on_intel())
-        look_cpukinds_intel(topology, nbprocs, infos);
-      else if (on_amd())
-        look_cpukinds_amd(topology, nbprocs, infos);
-    }
-  } else {
-    hwloc_debug("x86 APIC IDs aren't unique, x86 discovery ignored.\n");
-    /* do nothing and return success, so that the caller does nothing either */
   }
 
   if (data->cpuiddumps)
@@ -1762,20 +1744,36 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     infos[i].ids[DIE] = (unsigned) -1;
   }
 
-  ret = look_procs(topology, data, flags,
+  ret = look_procs(topology, data,
 		   get_cpubind, set_cpubind, restrict_set);
-  if (!ret)
-    /* success, we're done */
-    goto out;
+  if (!ret) {
+    /* success */
+    if (data->apicid_unique) {
+      summarize(topology, data, flags);
 
-  if (nbprocs == 1) {
-    /* only one processor, no need to bind */
+      if (data->is_hybrid
+          && !(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
+        /* use hybrid info for cpukinds */
+        enum hwloc_x86_vendor vendor = data->vendor;
+        if (on_intel())
+          look_cpukinds_intel(topology, nbprocs, infos);
+        else if (on_amd())
+          look_cpukinds_amd(topology, nbprocs, infos);
+      }
+    } else {
+      hwloc_debug("x86 APIC IDs aren't unique, x86 discovery ignored.\n");
+      /* do nothing and return success, so that the caller does nothing either */
+    }
+
+  }
+  else if (nbprocs == 1) {
+    /* look_procs() fails but there's only one processor, try without binding */
     look_proc(topology, data, &infos[0], data->cpuiddumps ? &data->cpuiddumps[0] : NULL);
     summarize(topology, data, flags);
     ret = 0;
   }
 
-out:
+ out:
   hwloc_bitmap_free(restrict_set);
   return ret;
 }

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -35,6 +35,15 @@
 #endif
 
 struct hwloc_x86_backend_data_s {
+#define HWLOC_X86_STATE_INIT (1UL<<0) /* only init done */
+#define HWLOC_X86_STATE_FEATURES (1UL<<1) /* queried features from the current CPU */
+#define HWLOC_X86_STATE_FEATURES_FAILED (1UL<<2) /* failed to get features */
+#define HWLOC_X86_STATE_QUERIED (1UL<<3) /* queried everything from all CPUs */
+#define HWLOC_X86_STATE_QUERY_FAILED (1UL<<4) /* query failed */
+#define HWLOC_X86_STATE_OBJECTS (1UL<<5) /* built/inserted objects */
+#define HWLOC_X86_STATE_CPUKINDS (1UL<<6) /* built cpukinds */
+  unsigned long state;
+
   char pu_support;
   unsigned nbprocs;
 
@@ -1350,6 +1359,59 @@ static void summarize(struct hwloc_topology *topology, struct hwloc_x86_backend_
   hwloc_bitmap_free(complete_cpuset);
 }
 
+static int
+hwloc_x86_build_objects(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
+{
+  /* the caller must have allocated root sets */
+  assert(topology->levels[0][0]->cpuset);
+
+  if (data->pu_support)
+    topology->support.discovery->pu = 1;
+
+  if (data->state & HWLOC_X86_STATE_QUERY_FAILED) {
+    /* we failed to query, just add PUs if none */
+    if (!topology->levels[0][0]->cpuset) {
+      hwloc_alloc_root_sets(topology->levels[0][0]);
+      hwloc_setup_pu_level(topology, data->nbprocs);
+    }
+    data->state |= HWLOC_X86_STATE_OBJECTS;
+    return 0;
+  }
+  assert(data->state & HWLOC_X86_STATE_QUERIED);
+
+  if (!hwloc_bitmap_iszero(topology->levels[0][0]->cpuset)) {
+    /* somebody else discovered things, reconnect levels so that we can look at them */
+    hwloc__reconnect(topology, 0);
+    if (topology->nb_levels != 2 || topology->level_nbobjects[1] != data->nbprocs) {
+      /* either more than a PU level was discovered, or the number of PUs doesn't match,
+       * just annotate the existing objects */
+      summarize(topology, data, 0);
+      hwloc__add_info(&topology->infos, "Backend", "x86");
+      data->state |= HWLOC_X86_STATE_OBJECTS;
+      return 0;
+    }
+  }
+
+  summarize(topology, data, HWLOC_X86_DISC_FLAG_FULL);
+  hwloc__add_info(&topology->infos, "Backend", "x86");
+
+  if (!data->cpuiddumps) { /* CPUID dump works for both x86 and x86_64 */
+#ifdef HAVE_UNAME
+    hwloc_add_uname_info(topology, NULL); /* we already know is_thissystem() is true */
+#else
+    /* uname isn't available, manually setup the "Architecture" info */
+#ifdef HWLOC_X86_64_ARCH
+    hwloc_obj_add_info(topology->levels[0][0], "Architecture", "x86_64");
+#else
+    hwloc_obj_add_info(topology->levels[0][0], "Architecture", "x86");
+#endif
+#endif
+  }
+
+  data->state |= HWLOC_X86_STATE_OBJECTS;
+  return 0;
+}
+
 static void
 look_cpukinds_intel(struct hwloc_topology *topology,
                     unsigned nbprocs, struct procinfo *infos)
@@ -1522,6 +1584,31 @@ look_cpukinds_amd(struct hwloc_topology *topology,
   }
 }
 
+static int
+hwloc_x86_build_cpukinds(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
+{
+  if (data->state & HWLOC_X86_STATE_QUERY_FAILED) {
+    data->state |= HWLOC_X86_STATE_CPUKINDS;
+    return 0;
+  }
+
+  if (!data->is_hybrid || data->nbprocs == 1
+      || (topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
+    data->state |= HWLOC_X86_STATE_CPUKINDS;
+    return 0;
+  }
+
+  /* use hybrid info for cpukinds */
+  enum hwloc_x86_vendor vendor = data->vendor;
+  if (on_intel())
+    look_cpukinds_intel(topology, data->nbprocs, data->procinfos);
+  else if (on_amd())
+    look_cpukinds_amd(topology, data->nbprocs, data->procinfos);
+
+  data->state |= HWLOC_X86_STATE_CPUKINDS;
+  return 0;
+}
+
 #if defined HWLOC_FREEBSD_SYS && defined HAVE_CPUSET_SETID
 #include <sys/param.h>
 #include <sys/cpuset.h>
@@ -1628,6 +1715,8 @@ hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
   unsigned highest_ext_cpuid;
   enum hwloc_x86_vendor vendor;
 
+  assert(data->state == HWLOC_X86_STATE_INIT);
+
   eax = 0x00;
   cpuid_or_from_dump(&eax, &ebx, &ecx, &edx, src_cpuiddump);
   highest_cpuid = eax;
@@ -1645,7 +1734,7 @@ hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
 
   hwloc_debug("highest cpuid %x, vendor %u\n", highest_cpuid, vendor);
   if (highest_cpuid < 0x01)
-    return -1;
+    goto error;
 
   data->highest_cpuid = highest_cpuid;
   data->vendor = vendor;
@@ -1677,7 +1766,12 @@ hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
     data->features[6] = ecx;
   }
 
+  data->state |= HWLOC_X86_STATE_FEATURES;
   return 0;
+
+ error:
+  data->state |= HWLOC_X86_STATE_FEATURES_FAILED;
+  return -1;
 }
 
 /* fake cpubind for when nbprocs=1 and no binding support */
@@ -1695,7 +1789,7 @@ static int fake_set_cpubind(hwloc_topology_t topology __hwloc_attribute_unused,
 }
 
 static
-int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data, unsigned long flags)
+int hwloc_x86_query_all(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
 {
   unsigned nbprocs = data->nbprocs;
   unsigned i;
@@ -1707,6 +1801,13 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   int (*set_cpubind)(hwloc_topology_t topology, hwloc_const_cpuset_t set, int flags) = NULL;
   hwloc_bitmap_t restrict_set = NULL;
   int ret = -1;
+
+  if (data->state & HWLOC_X86_STATE_FEATURES_FAILED)
+    goto error;
+  assert(data->state & HWLOC_X86_STATE_FEATURES);
+
+  if (data->nbprocs > 1 && !data->cpuiddumps && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING))
+    goto error;
 
   /* check if binding works */
   memset(&hooks, 0, sizeof(hooks));
@@ -1741,7 +1842,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     } else {
       /* we need binding support if there are multiple PUs */
       if (nbprocs > 1)
-	goto out;
+	goto error;
       get_cpubind = fake_get_cpubind;
       set_cpubind = fake_set_cpubind;
     }
@@ -1750,7 +1851,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   if (topology->flags & HWLOC_TOPOLOGY_FLAG_RESTRICT_TO_CPUBINDING) {
     restrict_set = hwloc_bitmap_alloc();
     if (!restrict_set)
-      goto out;
+      goto error;
     if (hooks.get_thisproc_cpubind)
       hooks.get_thisproc_cpubind(topology, restrict_set, 0);
     else if (hooks.get_thisthread_cpubind)
@@ -1763,7 +1864,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
 
   data->procinfos = infos = calloc(nbprocs, sizeof(struct procinfo));
   if (NULL == infos)
-    goto out;
+    goto error;
   for (i = 0; i < nbprocs; i++) {
     infos[i].ids[PKG] = (unsigned) -1;
     infos[i].ids[CORE] = (unsigned) -1;
@@ -1778,91 +1879,29 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
 		   get_cpubind, set_cpubind, restrict_set);
   if (!ret) {
     /* success */
-    if (data->apicid_unique) {
-      summarize(topology, data, flags);
-
-      if (data->is_hybrid
-          && !(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
-        /* use hybrid info for cpukinds */
-        enum hwloc_x86_vendor vendor = data->vendor;
-        if (on_intel())
-          look_cpukinds_intel(topology, nbprocs, infos);
-        else if (on_amd())
-          look_cpukinds_amd(topology, nbprocs, infos);
-      }
-    } else {
+    if (!data->apicid_unique) {
       hwloc_debug("x86 APIC IDs aren't unique, x86 discovery ignored.\n");
-      /* do nothing and return success, so that the caller does nothing either */
+      goto error;
     }
 
   }
   else if (nbprocs == 1) {
     /* look_procs() fails but there's only one processor, try without binding */
     look_proc(topology, data, &infos[0], data->cpuiddumps ? &data->cpuiddumps[0] : NULL);
-    summarize(topology, data, flags);
     ret = 0;
+  } else {
+    /* couldn't query all CPUs */
+    goto error;
   }
 
- out:
   hwloc_bitmap_free(restrict_set);
+  data->state |= HWLOC_X86_STATE_QUERIED;
   return ret;
-}
 
-static int
-hwloc_x86_discover(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
-{
-  unsigned long flags = 0;
-  int alreadypus = 0;
-  int ret;
-
-  /* the caller must have allocated root sets */
-  assert(topology->levels[0][0]->cpuset);
-
-  if (data->nbprocs > 1 && !data->cpuiddumps && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING)) {
-    return 0;
-  }
-
-  if (!hwloc_bitmap_iszero(topology->levels[0][0]->cpuset)) {
-    /* somebody else discovered things, reconnect levels so that we can look at them */
-    hwloc__reconnect(topology, 0);
-    if (topology->nb_levels == 2 && topology->level_nbobjects[1] == data->nbprocs) {
-      /* only PUs were discovered, as much as we would, complete the topology with everything else */
-      alreadypus = 1;
-      goto fulldiscovery;
-    }
-
-    /* several object types were added, we can't easily complete, just do partial discovery */
-    ret = hwloc_look_x86(topology, data, flags);
-    if (!ret)
-      hwloc__add_info(&topology->infos, "Backend", "x86");
-    return 0;
-  }
-
-fulldiscovery:
-  if (hwloc_look_x86(topology, data, flags | HWLOC_X86_DISC_FLAG_FULL) < 0) {
-    /* if failed, create PUs */
-    if (!alreadypus)
-      hwloc_setup_pu_level(topology, data->nbprocs);
-  }
-
-  hwloc__add_info(&topology->infos, "Backend", "x86");
-
-  if (!data->cpuiddumps) { /* CPUID dump works for both x86 and x86_64 */
-#ifdef HAVE_UNAME
-    hwloc_add_uname_info(topology, NULL); /* we already know is_thissystem() is true */
-#else
-    /* uname isn't available, manually setup the "Architecture" info */
-#ifdef HWLOC_X86_64_ARCH
-    hwloc_obj_add_info(topology->levels[0][0], "Architecture", "x86_64");
-#else
-    hwloc_obj_add_info(topology->levels[0][0], "Architecture", "x86");
-#endif
-#endif
-  }
-  if (data->pu_support)
-    topology->support.discovery->pu = 1;
-
-  return 1;
+ error:
+  hwloc_bitmap_free(restrict_set);
+  data->state |= HWLOC_X86_STATE_QUERY_FAILED;
+  return -1;
 }
 
 static int
@@ -2005,11 +2044,13 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
     data->nbprocs = (unsigned) nbprocs;
   }
 
+  data->state = HWLOC_X86_STATE_INIT;
   return 0;
 
  out_with_apicid_set:
   hwloc_bitmap_free(data->apicid_set);
  out:
+  data->state = 0;
   return -1;
 }
 
@@ -2108,10 +2149,12 @@ hwloc_x86_discover_all(hwloc_topology_t topology)
   assert(topology->x86_mode != HWLOC_X86_MODE_DONE);
 
   /* query features from current CPU (or CPU#0 dump) */
-  if (hwloc_x86_get_features(data) < 0)
-    return -1;
+  hwloc_x86_get_features(data);
 
-  hwloc_x86_discover(topology, data);
+  hwloc_x86_query_all(topology, data);
+
+  hwloc_x86_build_objects(topology, data);
+  hwloc_x86_build_cpukinds(topology, data);
 
   topology->x86_mode = HWLOC_X86_MODE_DONE;
   return 0;

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -71,7 +71,7 @@ struct hwloc_x86_backend_data_s {
   int apicid_unique;
 
   int is_knl;
-  int is_hybrid;
+  int is_hybrid; /* -1 if unknown */
 
   int found_die_ids;
   int found_complex_ids;
@@ -1592,7 +1592,8 @@ hwloc_x86_build_cpukinds(struct hwloc_topology *topology, struct hwloc_x86_backe
     return 0;
   }
 
-  if (!data->is_hybrid || data->nbprocs == 1
+  if (data->is_hybrid < 1 /* either not hybrid, or we don't know and have no way to build cpukinds */
+      || data->nbprocs == 1
       || (topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
     data->state |= HWLOC_X86_STATE_CPUKINDS;
     return 0;
@@ -1765,6 +1766,11 @@ hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
     data->features[1] = edx;
     data->features[6] = ecx;
   }
+
+  if (on_intel() || on_amd())
+    /* AMD and Intel aren't "unknown", we'll get "hybrid" during query */
+    data->is_hybrid = 0;
+  /* other vendors don't have hybrid CPU yet, and we don't know where to check, keep "unknown" */
 
   data->state |= HWLOC_X86_STATE_FEATURES;
   return 0;
@@ -1994,10 +2000,12 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
 
   /* non-zero default values (data was memset'ed) */
   data->vendor = HWLOC_X86_VENDOR_UNKNOWN;
+  data->apicid_unique = 1;
+  data->is_hybrid = -1; /* unknown */
+
   data->apicid_set = hwloc_bitmap_alloc();
   if (!data->apicid_set)
     goto out;
-  data->apicid_unique = 1;
 
   src_cpuiddump_path = getenv("HWLOC_CPUID_PATH");
   if (src_cpuiddump_path) {
@@ -2186,4 +2194,20 @@ hwloc_x86_discover_all(hwloc_topology_t topology)
 
   topology->x86_mode = HWLOC_X86_MODE_DONE;
   return 0;
+}
+
+int
+hwloc_x86_maybe_hybrid(hwloc_topology_t topology)
+{
+  struct hwloc_x86_backend_data_s *data = topology->x86_data;
+
+  if (!data)
+    /* we won't know */
+    return -1;
+  assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
+
+  if (topology->x86_mode != HWLOC_X86_MODE_DONE)
+    hwloc__x86_do_until(topology, data, HWLOC_X86_STATE_FEATURES|HWLOC_X86_STATE_QUERIED);
+
+  return data->is_hybrid;
 }

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -2139,6 +2139,40 @@ hwloc_x86_exit(hwloc_topology_t topology)
   hwloc_x86_init(topology);
 }
 
+static void
+hwloc__x86_do_until(hwloc_topology_t topology,
+                    struct hwloc_x86_backend_data_s *data,
+                    unsigned long until_state)
+{
+  assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
+  assert(data);
+  assert(data->state & HWLOC_X86_STATE_INIT);
+
+  if ((until_state & HWLOC_X86_STATE_FEATURES)
+      && !(data->state & (HWLOC_X86_STATE_FEATURES|HWLOC_X86_STATE_FEATURES_FAILED))) {
+    /* query features from current CPU (or CPU#0 dump) */
+    hwloc_x86_get_features(data);
+  }
+
+  if ((until_state & HWLOC_X86_STATE_QUERIED)
+      && !(data->state & (HWLOC_X86_STATE_QUERIED|HWLOC_X86_STATE_QUERY_FAILED))) {
+    /* query all CPUs, requires features */
+    hwloc_x86_query_all(topology, data);
+  }
+
+  if ((until_state & HWLOC_X86_STATE_OBJECTS)
+      && !(data->state & HWLOC_X86_STATE_OBJECTS)) {
+    /* build/insert objects, requires query */
+    hwloc_x86_build_objects(topology, data);
+  }
+
+  if ((until_state & HWLOC_X86_STATE_CPUKINDS)
+      && !(data->state & HWLOC_X86_STATE_CPUKINDS)) {
+    /* build cpukinds, require query*/
+    hwloc_x86_build_cpukinds(topology, data);
+  }
+}
+
 int
 hwloc_x86_discover_all(hwloc_topology_t topology)
 {
@@ -2148,13 +2182,7 @@ hwloc_x86_discover_all(hwloc_topology_t topology)
   assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
   assert(topology->x86_mode != HWLOC_X86_MODE_DONE);
 
-  /* query features from current CPU (or CPU#0 dump) */
-  hwloc_x86_get_features(data);
-
-  hwloc_x86_query_all(topology, data);
-
-  hwloc_x86_build_objects(topology, data);
-  hwloc_x86_build_cpukinds(topology, data);
+  hwloc__x86_do_until(topology, data, HWLOC_X86_STATE_FEATURES|HWLOC_X86_STATE_QUERIED|HWLOC_X86_STATE_OBJECTS|HWLOC_X86_STATE_CPUKINDS);
 
   topology->x86_mode = HWLOC_X86_MODE_DONE;
   return 0;

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -2042,7 +2042,9 @@ hwloc_x86_component_instantiate(struct hwloc_topology *topology,
   if (src_cpuiddump_path) {
     hwloc_bitmap_t set = hwloc_bitmap_alloc();
     if (set && !hwloc_x86_check_cpuiddump_input(src_cpuiddump_path, set)) {
-      backend->is_thissystem = 0;
+
+      HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
+
       data->src_cpuiddump_path = strdup(src_cpuiddump_path);
       assert(!hwloc_bitmap_iszero(set)); /* enforced by hwloc_x86_check_cpuiddump_input() */
       data->nbprocs = hwloc_bitmap_weight(set);

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1545,7 +1545,6 @@ static void hwloc_x86_os_state_restore(hwloc_x86_os_state_t *state __hwloc_attri
 
 static int
 look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data,
-           unsigned long flags,
 	   int (*get_cpubind)(hwloc_topology_t topology, hwloc_cpuset_t set, int flags),
 	   int (*set_cpubind)(hwloc_topology_t topology, hwloc_const_cpuset_t set, int flags),
            hwloc_bitmap_t restrict_set)
@@ -1592,23 +1591,6 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
     hwloc_bitmap_free(set);
     hwloc_bitmap_free(orig_cpuset);
     hwloc_x86_os_state_restore(&os_state);
-  }
-
-  if (data->apicid_unique) {
-    summarize(topology, data, flags);
-
-    if (data->is_hybrid
-        && !(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
-      /* use hybrid info for cpukinds */
-      enum hwloc_x86_vendor vendor = data->vendor;
-      if (on_intel())
-        look_cpukinds_intel(topology, nbprocs, infos);
-      else if (on_amd())
-        look_cpukinds_amd(topology, nbprocs, infos);
-    }
-  } else {
-    hwloc_debug("x86 APIC IDs aren't unique, x86 discovery ignored.\n");
-    /* do nothing and return success, so that the caller does nothing either */
   }
   return 0;
 }
@@ -1792,20 +1774,36 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     infos[i].ids[DIE] = (unsigned) -1;
   }
 
-  ret = look_procs(topology, data, flags,
+  ret = look_procs(topology, data,
 		   get_cpubind, set_cpubind, restrict_set);
-  if (!ret)
-    /* success, we're done */
-    goto out;
+  if (!ret) {
+    /* success */
+    if (data->apicid_unique) {
+      summarize(topology, data, flags);
 
-  if (nbprocs == 1) {
-    /* only one processor, no need to bind */
+      if (data->is_hybrid
+          && !(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
+        /* use hybrid info for cpukinds */
+        enum hwloc_x86_vendor vendor = data->vendor;
+        if (on_intel())
+          look_cpukinds_intel(topology, nbprocs, infos);
+        else if (on_amd())
+          look_cpukinds_amd(topology, nbprocs, infos);
+      }
+    } else {
+      hwloc_debug("x86 APIC IDs aren't unique, x86 discovery ignored.\n");
+      /* do nothing and return success, so that the caller does nothing either */
+    }
+
+  }
+  else if (nbprocs == 1) {
+    /* look_procs() fails but there's only one processor, try without binding */
     look_proc(topology, data, &infos[0], data->cpuiddumps ? &data->cpuiddumps[0] : NULL);
     summarize(topology, data, flags);
     ret = 0;
   }
 
-out:
+ out:
   hwloc_bitmap_free(restrict_set);
   return ret;
 }

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1858,21 +1858,20 @@ out:
 }
 
 static int
-hwloc_x86_discover(struct hwloc_backend *backend, struct hwloc_disc_status *dstatus)
+hwloc_x86_discover(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data)
 {
-  struct hwloc_x86_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
-  struct hwloc_topology *topology = backend->topology;
   unsigned long flags = 0;
   int alreadypus = 0;
   int ret;
 
-  assert(dstatus->phase == HWLOC_DISC_PHASE_CPU);
+  /* the caller must have allocated root sets */
+  assert(topology->levels[0][0]->cpuset);
 
   if (data->nbprocs > 1 && !data->src_cpuiddump_path && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING)) {
     return 0;
   }
 
-  if (topology->levels[0][0]->cpuset) {
+  if (!hwloc_bitmap_iszero(topology->levels[0][0]->cpuset)) {
     /* somebody else discovered things, reconnect levels so that we can look at them */
     hwloc__reconnect(topology, 0);
     if (topology->nb_levels == 2 && topology->level_nbobjects[1] == data->nbprocs) {
@@ -1886,9 +1885,6 @@ hwloc_x86_discover(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
     if (!ret)
       hwloc__add_info(&topology->infos, "Backend", "x86");
     return 0;
-  } else {
-    /* topology is empty, initialize it */
-    hwloc_alloc_root_sets(topology->levels[0][0]);
   }
 
 fulldiscovery:
@@ -2006,8 +2002,6 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
 {
   const char *src_cpuiddump_path;
 
-  /* default values */
-  memset(data, 0, sizeof(*data));
   /* non-zero default values (data was memset'ed) */
   data->vendor = HWLOC_X86_VENDOR_UNKNOWN;
   data->apicid_set = hwloc_bitmap_alloc();
@@ -2060,67 +2054,88 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
   return -1;
 }
 
-static void
-hwloc_x86_exit(struct hwloc_x86_backend_data_s *data)
+void
+hwloc_x86_prepare(struct hwloc_topology *topology)
 {
-  hwloc_bitmap_free(data->apicid_set);
-  free(data->src_cpuiddump_path);
-}
-
-static void
-hwloc_x86_backend_disable(struct hwloc_backend *backend)
-{
-  struct hwloc_x86_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
-  hwloc_x86_exit(data);
-}
-
-static struct hwloc_backend *
-hwloc_x86_component_instantiate(struct hwloc_topology *topology,
-				struct hwloc_disc_component *component,
-				unsigned excluded_phases __hwloc_attribute_unused,
-				const void *_data1 __hwloc_attribute_unused,
-				const void *_data2 __hwloc_attribute_unused,
-				const void *_data3 __hwloc_attribute_unused)
-{
-  struct hwloc_backend *backend;
   struct hwloc_x86_backend_data_s *data;
+  const char *env;
 
-  backend = hwloc_backend_alloc(topology, component, sizeof(*data));
-  if (!backend)
+  env = getenv("HWLOC_X86");
+  if (env) {
+    topology->x86_env = env;
+    if (!strcmp(env, "none")) {
+      topology->x86_mode = HWLOC_X86_MODE_NONE;
+      return;
+    }
+    else if (!strcmp(env, "last"))
+      topology->x86_mode = HWLOC_X86_MODE_LAST;
+    else if (!strcmp(env, "first"))
+      topology->x86_mode = HWLOC_X86_MODE_FIRST;
+    else if (!strcmp(env, "only"))
+      topology->x86_mode = HWLOC_X86_MODE_ONLY;
+    else
+      topology->x86_mode = HWLOC_X86_MODE_CUSTOM;
+  }
+
+  data = calloc(1, sizeof(*data));
+  if (!data)
     goto out;
-
-  backend->discover = hwloc_x86_discover;
-  backend->disable = hwloc_x86_backend_disable;
-
-  /* default values */
-  data = HWLOC_BACKEND_PRIVATE_DATA(backend);
   if (hwloc_x86_setup(data) < 0)
-    goto out_with_backend;
+    goto out_with_data;
+  topology->x86_data = data;
+
   if (data->src_cpuiddump_path)
-    HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
+    HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, 1 /* forced cpuid is always by envvar */);
 
-  return backend;
+  return;
 
- out_with_backend:
-  free(backend);
+ out_with_data:
+  free(data);
  out:
-  return NULL;
+  topology->x86_mode = HWLOC_X86_MODE_NONE;
+  if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL))
+    fprintf(stderr, "hwloc/x86: failed to prepare backend data, disabling.\n");
+  return;
 }
 
-static struct hwloc_disc_component hwloc_x86_disc_component = {
-  "x86",
-  HWLOC_DISC_PHASE_CPU,
-  HWLOC_DISC_PHASE_GLOBAL,
-  hwloc_x86_component_instantiate,
-  45, /* between native and no_os */
-  1,
-  NULL
-};
+enum hwloc_x86_mode_e
+hwloc_x86_fixup_mode(struct hwloc_topology *topology,
+                     enum hwloc_x86_mode_e dflt, int maybecustom,
+                     const char *osname)
+{
+  if (topology->x86_mode == HWLOC_X86_MODE_CUSTOM && !maybecustom) {
+    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER|HWLOC_SHOWMSG_X86))
+      fprintf(stderr, "hwloc/%s: no custom x86 mode, using default.\n", osname);
+    topology->x86_mode = dflt;
+  } else if (topology->x86_mode == HWLOC_X86_MODE_DEFAULT) {
+    topology->x86_mode = dflt;
+  }
+  return topology->x86_mode;
+}
 
-const struct hwloc_component hwloc_x86_component = {
-  HWLOC_COMPONENT_ABI,
-  NULL, NULL,
-  HWLOC_COMPONENT_TYPE_DISC,
-  0,
-  &hwloc_x86_disc_component
-};
+void
+hwloc_x86_exit(hwloc_topology_t topology)
+{
+  struct hwloc_x86_backend_data_s *data = topology->x86_data;
+  if (data) {
+    hwloc_bitmap_free(data->apicid_set);
+    free(data->src_cpuiddump_path);
+    free(data);
+  }
+  hwloc_x86_init(topology);
+}
+
+int
+hwloc_x86_discover_all(hwloc_topology_t topology)
+{
+  struct hwloc_x86_backend_data_s *data = topology->x86_data;
+
+  assert(data);
+  assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
+  assert(topology->x86_mode != HWLOC_X86_MODE_DONE);
+
+  hwloc_x86_discover(topology, data);
+
+  topology->x86_mode = HWLOC_X86_MODE_DONE;
+  return 0;
+}

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -70,6 +70,51 @@ struct hwloc_x86_backend_data_s {
   int found_module_ids;
   int found_tile_ids;
 
+  struct procinfo {
+    unsigned present;
+    unsigned apicid;
+#define PKG 0
+#define CORE 1
+#define NODE 2 /* not used for building NUMA nodes, but still used to identify objects (e.g. same core ids in different NUMA nodes on Hygon Dhyana) */
+#define UNIT 3
+#define TILE 4
+#define MODULE 5
+#define DIE 6
+#define COMPLEX 7
+#define HWLOC_X86_PROCINFO_ID_NR 8
+    unsigned ids[HWLOC_X86_PROCINFO_ID_NR];
+    unsigned *otherids;
+    unsigned levels; /* total number of levels.
+                      * IDs are either stored in otherids[level]
+                      * or in ids[type] with otherids[level] = UINT_MAX
+                      */
+
+    char cpuvendor[13];
+    char cpumodel[3*4*4+1];
+    unsigned cpustepping;
+    unsigned cpumodelnumber;
+    unsigned cpufamilynumber;
+
+    unsigned hybridcoretype;
+    unsigned hybridnativemodel;
+    unsigned power_efficiency_ranking;
+
+    unsigned numcaches;
+    struct cacheinfo {
+      hwloc_obj_cache_type_t type;
+      unsigned level;
+      unsigned nbthreads_sharing;
+      unsigned cacheid;
+
+      unsigned linesize;
+      unsigned linepart;
+      int inclusive;
+      int ways;
+      unsigned sets;
+      unsigned long size;
+    } *cache;
+  } *procinfos;
+
   struct cpuiddump {
     unsigned nr;
     struct cpuiddump_entry {
@@ -205,51 +250,6 @@ enum hwloc_x86_disc_flags {
 #define has_topoext() (features[6] & (1 << 22))
 #define has_x2apic() (features[4] & (1 << 21))
 #define has_hybrid() (features[18] & (1 << 15))
-
-struct cacheinfo {
-  hwloc_obj_cache_type_t type;
-  unsigned level;
-  unsigned nbthreads_sharing;
-  unsigned cacheid;
-
-  unsigned linesize;
-  unsigned linepart;
-  int inclusive;
-  int ways;
-  unsigned sets;
-  unsigned long size;
-};
-
-struct procinfo {
-  unsigned present;
-  unsigned apicid;
-#define PKG 0
-#define CORE 1
-#define NODE 2 /* not used for building NUMA nodes, but still used to identify objects (e.g. same core ids in different NUMA nodes on Hygon Dhyana) */
-#define UNIT 3
-#define TILE 4
-#define MODULE 5
-#define DIE 6
-#define COMPLEX 7
-#define HWLOC_X86_PROCINFO_ID_NR 8
-  unsigned ids[HWLOC_X86_PROCINFO_ID_NR];
-  unsigned *otherids;
-  unsigned levels; /* total number of levels.
-                    * IDs are either stored in otherids[level]
-                    * or in ids[type] with otherids[level] = UINT_MAX
-                    */
-  unsigned numcaches;
-  struct cacheinfo *cache;
-  char cpuvendor[13];
-  char cpumodel[3*4*4+1];
-  unsigned cpustepping;
-  unsigned cpumodelnumber;
-  unsigned cpufamilynumber;
-
-  unsigned hybridcoretype;
-  unsigned hybridnativemodel;
-  unsigned power_efficiency_ranking;
-};
 
 /* AMD legacy cache information from specific CPUID 0x80000005-6 leaves */
 static void setup__amd_cache_legacy(struct procinfo *infos, unsigned level, hwloc_obj_cache_type_t type, unsigned nbthreads_sharing, unsigned cpuid)
@@ -1003,9 +1003,10 @@ hwloc_x86_add_groups(hwloc_topology_t topology,
 }
 
 /* Analyse information stored in infos, and build/annotate topology levels accordingly */
-static void summarize(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data, struct procinfo *infos, unsigned long flags)
+static void summarize(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data, unsigned long flags)
 {
   unsigned nbprocs = data->nbprocs;
+  struct procinfo *infos = data->procinfos;
   hwloc_bitmap_t complete_cpuset = hwloc_bitmap_alloc();
   unsigned i, j, l, level;
   int one = -1;
@@ -1544,13 +1545,14 @@ static void hwloc_x86_os_state_restore(hwloc_x86_os_state_t *state __hwloc_attri
 
 static int
 look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *data,
-           struct procinfo *infos, unsigned long flags,
+           unsigned long flags,
 	   int (*get_cpubind)(hwloc_topology_t topology, hwloc_cpuset_t set, int flags),
 	   int (*set_cpubind)(hwloc_topology_t topology, hwloc_const_cpuset_t set, int flags),
            hwloc_bitmap_t restrict_set)
 {
   unsigned nbprocs = data->nbprocs;
   hwloc_x86_os_state_t os_state;
+  struct procinfo *infos = data->procinfos;
   hwloc_bitmap_t orig_cpuset = NULL;
   hwloc_bitmap_t set = NULL;
   unsigned i;
@@ -1593,7 +1595,7 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
   }
 
   if (data->apicid_unique) {
-    summarize(topology, data, infos, flags);
+    summarize(topology, data, flags);
 
     if (data->is_hybrid
         && !(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS)) {
@@ -1777,7 +1779,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     }
   }
 
-  infos = calloc(nbprocs, sizeof(struct procinfo));
+  data->procinfos = infos = calloc(nbprocs, sizeof(struct procinfo));
   if (NULL == infos)
     goto out;
   for (i = 0; i < nbprocs; i++) {
@@ -1790,26 +1792,17 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     infos[i].ids[DIE] = (unsigned) -1;
   }
 
-  ret = look_procs(topology, data, infos, flags,
+  ret = look_procs(topology, data, flags,
 		   get_cpubind, set_cpubind, restrict_set);
   if (!ret)
     /* success, we're done */
-    goto out_with_infos;
+    goto out;
 
   if (nbprocs == 1) {
     /* only one processor, no need to bind */
     look_proc(topology, data, &infos[0], data->cpuiddumps ? &data->cpuiddumps[0] : NULL);
-    summarize(topology, data, infos, flags);
+    summarize(topology, data, flags);
     ret = 0;
-  }
-
-out_with_infos:
-  if (NULL != infos) {
-    for (i = 0; i < nbprocs; i++) {
-      free(infos[i].cache);
-      free(infos[i].otherids);
-    }
-    free(infos);
   }
 
 out:
@@ -2086,6 +2079,14 @@ hwloc_x86_exit(hwloc_topology_t topology)
 {
   struct hwloc_x86_backend_data_s *data = topology->x86_data;
   if (data) {
+    if (NULL != data->procinfos) {
+      unsigned i;
+      for (i = 0; i < data->nbprocs; i++) {
+        free(data->procinfos[i].cache);
+        free(data->procinfos[i].otherids);
+      }
+      free(data->procinfos);
+    }
     if (NULL != data->cpuiddumps) {
       unsigned i;
       for (i = 0; i < data->nbprocs; i++)

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -35,8 +35,6 @@
 #endif
 
 struct hwloc_x86_backend_data_s {
-  char *src_cpuiddump_path;
-
   char pu_support;
   unsigned nbprocs;
 
@@ -71,39 +69,30 @@ struct hwloc_x86_backend_data_s {
   int found_unit_ids;
   int found_module_ids;
   int found_tile_ids;
+
+  struct cpuiddump {
+    unsigned nr;
+    struct cpuiddump_entry {
+      unsigned inmask; /* which of ine[abcd]x are set on input */
+      unsigned ineax;
+      unsigned inebx;
+      unsigned inecx;
+      unsigned inedx;
+      unsigned outeax;
+      unsigned outebx;
+      unsigned outecx;
+      unsigned outedx;
+    } *entries;
+  } *cpuiddumps;
 };
 
 /************************************
  * Management of cpuid dump as input
  */
 
-struct cpuiddump {
-  unsigned nr;
-  struct cpuiddump_entry {
-    unsigned inmask; /* which of ine[abcd]x are set on input */
-    unsigned ineax;
-    unsigned inebx;
-    unsigned inecx;
-    unsigned inedx;
-    unsigned outeax;
-    unsigned outebx;
-    unsigned outecx;
-    unsigned outedx;
-  } *entries;
-};
-
-static void
-cpuiddump_free(struct cpuiddump *cpuiddump)
+static int
+cpuiddump_read(struct cpuiddump *cpuiddump, const char *dirpath, unsigned idx)
 {
-  if (cpuiddump->nr)
-    free(cpuiddump->entries);
-  free(cpuiddump);
-}
-
-static struct cpuiddump *
-cpuiddump_read(const char *dirpath, unsigned idx)
-{
-  struct cpuiddump *cpuiddump;
   struct cpuiddump_entry *cur;
   size_t filenamelen;
   char *filename;
@@ -111,16 +100,10 @@ cpuiddump_read(const char *dirpath, unsigned idx)
   char line[128];
   unsigned nr;
 
-  cpuiddump = malloc(sizeof(*cpuiddump));
-  if (!cpuiddump) {
-    fprintf(stderr, "hwloc/x86: Failed to allocate cpuiddump for PU #%u, ignoring cpuiddump.\n", idx);
-    goto out;
-  }
-
   filenamelen = strlen(dirpath) + 15;
   filename = malloc(filenamelen);
   if (!filename)
-    goto out_with_dump;
+    goto out;
   snprintf(filename, filenamelen, "%s/pu%u", dirpath, idx);
   file = fopen(filename, "r");
   if (!file) {
@@ -157,16 +140,14 @@ cpuiddump_read(const char *dirpath, unsigned idx)
   cpuiddump->nr = nr;
   fclose(file);
   free(filename);
-  return cpuiddump;
+  return 0;
 
  out_with_file:
   fclose(file);
  out_with_filename:
   free(filename);
- out_with_dump:
-  free(cpuiddump);
  out:
-  return NULL;
+  return -1;
 }
 
 static void
@@ -1574,7 +1555,7 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
   hwloc_bitmap_t set = NULL;
   unsigned i;
 
-  if (!data->src_cpuiddump_path) {
+  if (!data->cpuiddumps) {
     hwloc_x86_os_state_save(&os_state);
 
     orig_cpuset = hwloc_bitmap_alloc();
@@ -1587,18 +1568,12 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
   }
 
   for (i = 0; i < nbprocs; i++) {
-    struct cpuiddump *src_cpuiddump = NULL;
-
     if (restrict_set && !hwloc_bitmap_isset(restrict_set, i)) {
       /* skip this CPU outside of the binding mask */
       continue;
     }
 
-    if (data->src_cpuiddump_path) {
-      src_cpuiddump = cpuiddump_read(data->src_cpuiddump_path, i);
-      if (!src_cpuiddump)
-	continue;
-    } else {
+    if (!data->cpuiddumps) {
       hwloc_bitmap_only(set, i);
       hwloc_debug("binding to CPU%u\n", i);
       if (set_cpubind(topology, set, HWLOC_CPUBIND_STRICT)) {
@@ -1607,14 +1582,10 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
       }
     }
 
-    look_proc(topology, data, &infos[i], src_cpuiddump);
-
-    if (data->src_cpuiddump_path) {
-      cpuiddump_free(src_cpuiddump);
-    }
+    look_proc(topology, data, &infos[i], data->cpuiddumps ? &data->cpuiddumps[i] : NULL);
   }
 
-  if (!data->src_cpuiddump_path) {
+  if (!data->cpuiddumps) {
     set_cpubind(topology, orig_cpuset, 0);
     hwloc_bitmap_free(set);
     hwloc_bitmap_free(orig_cpuset);
@@ -1750,7 +1721,6 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   int (*get_cpubind)(hwloc_topology_t topology, hwloc_cpuset_t set, int flags) = NULL;
   int (*set_cpubind)(hwloc_topology_t topology, hwloc_const_cpuset_t set, int flags) = NULL;
   hwloc_bitmap_t restrict_set = NULL;
-  struct cpuiddump *src_cpuiddump = NULL;
   int ret = -1;
 
   /* check if binding works */
@@ -1760,17 +1730,11 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
    * but the current overhead is negligible, so just always reget them.
    */
   hwloc_set_native_binding_hooks(&hooks, &support);
-  /* in theory, those are only needed if !data->src_cpuiddump_path || HWLOC_TOPOLOGY_FLAG_RESTRICT_TO_BINDING
+  /* in theory, those are only needed if !data->cpuiddumps || HWLOC_TOPOLOGY_FLAG_RESTRICT_TO_BINDING
    * but that's the vast majority of cases anyway, and the overhead is very small.
    */
 
-  if (data->src_cpuiddump_path) {
-    /* Just read cpuid from the dump (implies !topology->is_thissystem by default) */
-    src_cpuiddump = cpuiddump_read(data->src_cpuiddump_path, 0);
-    if (!src_cpuiddump)
-      goto out;
-
-  } else {
+  if (!data->cpuiddumps) {
     /* Using real hardware.
      * However we don't enforce topology->is_thissystem so that
      * we may still force use this backend when debugging with !thissystem.
@@ -1825,7 +1789,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     infos[i].ids[DIE] = (unsigned) -1;
   }
 
-  if (hwloc_x86_get_features(data, src_cpuiddump)  < 0)
+  if (hwloc_x86_get_features(data, data->cpuiddumps ? &data->cpuiddumps[0] : NULL)  < 0)
     goto out_with_infos;
 
   ret = look_procs(topology, data, infos, flags,
@@ -1836,7 +1800,7 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
 
   if (nbprocs == 1) {
     /* only one processor, no need to bind */
-    look_proc(topology, data, &infos[0], src_cpuiddump);
+    look_proc(topology, data, &infos[0], data->cpuiddumps ? &data->cpuiddumps[0] : NULL);
     summarize(topology, data, infos, flags);
     ret = 0;
   }
@@ -1852,8 +1816,6 @@ out_with_infos:
 
 out:
   hwloc_bitmap_free(restrict_set);
-  if (src_cpuiddump)
-    cpuiddump_free(src_cpuiddump);
   return ret;
 }
 
@@ -1867,7 +1829,7 @@ hwloc_x86_discover(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
   /* the caller must have allocated root sets */
   assert(topology->levels[0][0]->cpuset);
 
-  if (data->nbprocs > 1 && !data->src_cpuiddump_path && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING)) {
+  if (data->nbprocs > 1 && !data->cpuiddumps && (topology->flags & HWLOC_TOPOLOGY_FLAG_DONT_CHANGE_BINDING)) {
     return 0;
   }
 
@@ -1896,7 +1858,7 @@ fulldiscovery:
 
   hwloc__add_info(&topology->infos, "Backend", "x86");
 
-  if (!data->src_cpuiddump_path) { /* CPUID dump works for both x86 and x86_64 */
+  if (!data->cpuiddumps) { /* CPUID dump works for both x86 and x86_64 */
 #ifdef HAVE_UNAME
     hwloc_add_uname_info(topology, NULL); /* we already know is_thissystem() is true */
 #else
@@ -2013,17 +1975,25 @@ hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
   if (src_cpuiddump_path) {
     hwloc_bitmap_t set = hwloc_bitmap_alloc();
     if (set && !hwloc_x86_check_cpuiddump_input(src_cpuiddump_path, set)) {
-      data->src_cpuiddump_path = strdup(src_cpuiddump_path);
+      unsigned nbprocs = hwloc_bitmap_weight(set);
       assert(!hwloc_bitmap_iszero(set)); /* enforced by hwloc_x86_check_cpuiddump_input() */
-      data->nbprocs = hwloc_bitmap_weight(set);
-      data->pu_support = 1;
-    } else {
-      fprintf(stderr, "hwloc/x86: Ignoring dumped cpuid directory (%s).\n", strerror(errno));
+      data->cpuiddumps = malloc(nbprocs * sizeof(struct cpuiddump));
+      if (NULL != data->cpuiddumps) {
+        unsigned i;
+        for(i=0; i<nbprocs; i++) {
+          data->cpuiddumps[i].nr = 0;
+          cpuiddump_read(&data->cpuiddumps[i], src_cpuiddump_path, i);
+        }
+        data->nbprocs = nbprocs;
+        data->pu_support = 1;
+      }
     }
+    if (!data->cpuiddumps && HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_X86|HWLOC_SHOWMSG_CRITICAL|HWLOC_SHOWMSG_USER))
+      fprintf(stderr, "hwloc/x86: Ignoring dumped cpuid directory (%s).\n", strerror(errno));
     hwloc_bitmap_free(set);
   }
 
-  if (!data->src_cpuiddump_path) {
+  if (!data->cpuiddumps) {
     int nbprocs;
 
     if (!hwloc_have_x86_cpuid())
@@ -2084,7 +2054,7 @@ hwloc_x86_prepare(struct hwloc_topology *topology)
     goto out_with_data;
   topology->x86_data = data;
 
-  if (data->src_cpuiddump_path)
+  if (data->cpuiddumps)
     HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, 1 /* forced cpuid is always by envvar */);
 
   return;
@@ -2118,8 +2088,14 @@ hwloc_x86_exit(hwloc_topology_t topology)
 {
   struct hwloc_x86_backend_data_s *data = topology->x86_data;
   if (data) {
+    if (NULL != data->cpuiddumps) {
+      unsigned i;
+      for (i = 0; i < data->nbprocs; i++)
+        if (data->cpuiddumps[i].nr)
+          free(data->cpuiddumps[i].entries);
+      free(data->cpuiddumps);
+    }
     hwloc_bitmap_free(data->apicid_set);
-    free(data->src_cpuiddump_path);
     free(data);
   }
   hwloc_x86_init(topology);

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1636,8 +1636,9 @@ look_procs(struct hwloc_topology *topology, struct hwloc_x86_backend_data_s *dat
 #define SH_ECX ('a' | ('i'<<8) | (' '<<16) | (' '<<24))
 
 static int
-hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data, struct cpuiddump *src_cpuiddump)
+hwloc_x86_get_features(struct hwloc_x86_backend_data_s *data)
 {
+  struct cpuiddump *src_cpuiddump = data->cpuiddumps ? &data->cpuiddumps[0] : NULL;
   unsigned eax, ebx, ecx = 0, edx;
   unsigned highest_cpuid;
   unsigned highest_ext_cpuid;
@@ -1788,9 +1789,6 @@ int hwloc_look_x86(struct hwloc_topology *topology, struct hwloc_x86_backend_dat
     infos[i].ids[MODULE] = (unsigned) -1;
     infos[i].ids[DIE] = (unsigned) -1;
   }
-
-  if (hwloc_x86_get_features(data, data->cpuiddumps ? &data->cpuiddumps[0] : NULL)  < 0)
-    goto out_with_infos;
 
   ret = look_procs(topology, data, infos, flags,
 		   get_cpubind, set_cpubind, restrict_set);
@@ -2109,6 +2107,10 @@ hwloc_x86_discover_all(hwloc_topology_t topology)
   assert(data);
   assert(topology->x86_mode != HWLOC_X86_MODE_NONE);
   assert(topology->x86_mode != HWLOC_X86_MODE_DONE);
+
+  /* query features from current CPU (or CPU#0 dump) */
+  if (hwloc_x86_get_features(data) < 0)
+    return -1;
 
   hwloc_x86_discover(topology, data);
 

--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -2001,50 +2001,24 @@ hwloc_x86_check_cpuiddump_input(const char *src_cpuiddump_path, hwloc_bitmap_t s
   return -1;
 }
 
-static void
-hwloc_x86_backend_disable(struct hwloc_backend *backend)
+static int
+hwloc_x86_setup(struct hwloc_x86_backend_data_s *data)
 {
-  struct hwloc_x86_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
-  hwloc_bitmap_free(data->apicid_set);
-  free(data->src_cpuiddump_path);
-}
-
-static struct hwloc_backend *
-hwloc_x86_component_instantiate(struct hwloc_topology *topology,
-				struct hwloc_disc_component *component,
-				unsigned excluded_phases __hwloc_attribute_unused,
-				const void *_data1 __hwloc_attribute_unused,
-				const void *_data2 __hwloc_attribute_unused,
-				const void *_data3 __hwloc_attribute_unused)
-{
-  struct hwloc_backend *backend;
-  struct hwloc_x86_backend_data_s *data;
   const char *src_cpuiddump_path;
 
-  backend = hwloc_backend_alloc(topology, component, sizeof(*data));
-  if (!backend)
-    goto out;
-
-  backend->discover = hwloc_x86_discover;
-  backend->disable = hwloc_x86_backend_disable;
-
   /* default values */
-  data = HWLOC_BACKEND_PRIVATE_DATA(backend);
   memset(data, 0, sizeof(*data));
   /* non-zero default values (data was memset'ed) */
   data->vendor = HWLOC_X86_VENDOR_UNKNOWN;
   data->apicid_set = hwloc_bitmap_alloc();
   if (!data->apicid_set)
-    goto out_with_backend;
+    goto out;
   data->apicid_unique = 1;
 
   src_cpuiddump_path = getenv("HWLOC_CPUID_PATH");
   if (src_cpuiddump_path) {
     hwloc_bitmap_t set = hwloc_bitmap_alloc();
     if (set && !hwloc_x86_check_cpuiddump_input(src_cpuiddump_path, set)) {
-
-      HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
-
       data->src_cpuiddump_path = strdup(src_cpuiddump_path);
       assert(!hwloc_bitmap_iszero(set)); /* enforced by hwloc_x86_check_cpuiddump_input() */
       data->nbprocs = hwloc_bitmap_weight(set);
@@ -2078,10 +2052,55 @@ hwloc_x86_component_instantiate(struct hwloc_topology *topology,
     data->nbprocs = (unsigned) nbprocs;
   }
 
-  return backend;
+  return 0;
 
  out_with_apicid_set:
   hwloc_bitmap_free(data->apicid_set);
+ out:
+  return -1;
+}
+
+static void
+hwloc_x86_exit(struct hwloc_x86_backend_data_s *data)
+{
+  hwloc_bitmap_free(data->apicid_set);
+  free(data->src_cpuiddump_path);
+}
+
+static void
+hwloc_x86_backend_disable(struct hwloc_backend *backend)
+{
+  struct hwloc_x86_backend_data_s *data = HWLOC_BACKEND_PRIVATE_DATA(backend);
+  hwloc_x86_exit(data);
+}
+
+static struct hwloc_backend *
+hwloc_x86_component_instantiate(struct hwloc_topology *topology,
+				struct hwloc_disc_component *component,
+				unsigned excluded_phases __hwloc_attribute_unused,
+				const void *_data1 __hwloc_attribute_unused,
+				const void *_data2 __hwloc_attribute_unused,
+				const void *_data3 __hwloc_attribute_unused)
+{
+  struct hwloc_backend *backend;
+  struct hwloc_x86_backend_data_s *data;
+
+  backend = hwloc_backend_alloc(topology, component, sizeof(*data));
+  if (!backend)
+    goto out;
+
+  backend->discover = hwloc_x86_discover;
+  backend->disable = hwloc_x86_backend_disable;
+
+  /* default values */
+  data = HWLOC_BACKEND_PRIVATE_DATA(backend);
+  if (hwloc_x86_setup(data) < 0)
+    goto out_with_backend;
+  if (data->src_cpuiddump_path)
+    HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
+
+  return backend;
+
  out_with_backend:
   free(backend);
  out:

--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -3466,7 +3466,8 @@ hwloc_xml_component_instantiate(struct hwloc_topology *topology,
 
   backend->discover = hwloc_look_xml;
   backend->disable = hwloc_xml_backend_disable;
-  backend->is_thissystem = 0;
+
+  HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(topology, backend->envvar_forced);
 
   if (xmlpath) {
     local_basename = strrchr(xmlpath, '/');

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -3847,6 +3847,8 @@ hwloc__topology_init (struct hwloc_topology **topologyp,
   topology->userdata_import_cb = NULL;
   topology->userdata_not_decoded = 0;
 
+  topology->should_disable_thissystem = 0;
+
   /* Make the topology look like something coherent but empty */
   hwloc_topology_setup_defaults(topology);
 
@@ -4146,6 +4148,33 @@ hwloc_topology_destroy (struct hwloc_topology *topology)
   free(topology);
 }
 
+static void
+hwloc_decide_is_thissystem(struct hwloc_topology *topology)
+{
+  const char *local_env;
+
+  /*
+   * If the application changed the backend with set_foo(),
+   * it may use set_flags() update the is_thissystem flag here.
+   * If it changes the backend with environment variables below,
+   * it may use HWLOC_THISSYSTEM envvar below as well.
+   */
+
+  /* override set_foo() with flags */
+  if (topology->flags & HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM)
+    topology->should_disable_thissystem &= ~HWLOC_SHOULD_DISABLE_THISSYSTEM;
+
+  /* override with envvar-given flag */
+  local_env = getenv("HWLOC_THISSYSTEM");
+  if (local_env && atoi(local_env))
+    topology->should_disable_thissystem &= ~HWLOC_SHOULD_DISABLE_THISSYSTEM_ENVVAR;
+
+  if (topology->should_disable_thissystem)
+    topology->state &= ~HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM;
+  else
+    topology->state |= HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM;
+}
+
 int
 hwloc_topology_load (struct hwloc_topology *topology)
 {
@@ -4232,7 +4261,7 @@ hwloc_topology_load (struct hwloc_topology *topology)
   /* instantiate all possible other backends now */
   hwloc_disc_components_enable_others(topology);
   /* now that backends are enabled, update the thissystem flag and some callbacks */
-  hwloc_backends_is_thissystem(topology);
+  hwloc_decide_is_thissystem(topology);
   hwloc_backends_find_callbacks(topology);
   /*
    * Now set binding hooks according to HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM in topology->state

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -3585,7 +3585,7 @@ hwloc_discover(struct hwloc_topology *topology,
     memset(&topology->machine_memory, 0, sizeof(topology->machine_memory));
     hwloc__insert_object_by_cpuset(topology, NULL, node, "core:defaultnumanode");
   } else {
-    /* if we're sure we found all NUMA nodes without their sizes (x86 backend?),
+    /* if we're sure we found all NUMA nodes without their sizes,
      * we could split topology->total_memory in all of them.
      */
     memset(&topology->machine_memory, 0, sizeof(topology->machine_memory));
@@ -3811,6 +3811,7 @@ hwloc__topology_init (struct hwloc_topology **topologyp,
   hwloc_components_init(); /* uses malloc without tma, but won't need it since dup() caller already took a reference */
   hwloc_topology_components_init(topology);
   hwloc_pci_init(topology); /* make sure both dup() and load() get sane variables */
+  hwloc_x86_init(topology);
 
   /* Setup topology context */
   topology->state = HWLOC_TOPOLOGY_STATE_IS_INIT | HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM;
@@ -4133,6 +4134,7 @@ hwloc_topology_destroy (struct hwloc_topology *topology)
   hwloc_topology_components_fini(topology);
   hwloc_components_fini();
   hwloc_pci_exit(topology);
+  hwloc_x86_exit(topology);
 
   hwloc_topology_clear(topology);
 
@@ -4195,6 +4197,9 @@ hwloc_topology_load (struct hwloc_topology *topology)
     hwloc_internal_distances_prepare(topology);
   if (!(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_MEMATTRS))
     hwloc_internal_memattrs_prepare(topology);
+
+  /* check how to use x86 */
+  hwloc_x86_prepare(topology);
 
   /* check if any cpu cache filter is not NONE */
   topology->want_some_cpu_caches = 0;
@@ -4340,6 +4345,7 @@ hwloc_topology_load (struct hwloc_topology *topology)
 
  out:
   hwloc_pci_exit(topology);
+  hwloc_x86_exit(topology);
   hwloc_topology_clear(topology);
   hwloc_topology_setup_defaults(topology);
   hwloc_backends_disable_all(topology);

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -3586,7 +3586,7 @@ hwloc_discover(struct hwloc_topology *topology,
     memset(&topology->machine_memory, 0, sizeof(topology->machine_memory));
     hwloc__insert_object_by_cpuset(topology, NULL, node, "core:defaultnumanode");
   } else {
-    /* if we're sure we found all NUMA nodes without their sizes (x86 backend?),
+    /* if we're sure we found all NUMA nodes without their sizes,
      * we could split topology->total_memory in all of them.
      */
     memset(&topology->machine_memory, 0, sizeof(topology->machine_memory));
@@ -3812,6 +3812,7 @@ hwloc__topology_init (struct hwloc_topology **topologyp,
   hwloc_components_init(); /* uses malloc without tma, but won't need it since dup() caller already took a reference */
   hwloc_topology_components_init(topology);
   hwloc_pci_init(topology); /* make sure both dup() and load() get sane variables */
+  hwloc_x86_init(topology);
 
   /* Setup topology context */
   topology->state = HWLOC_TOPOLOGY_STATE_IS_INIT | HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM;
@@ -4134,6 +4135,7 @@ hwloc_topology_destroy (struct hwloc_topology *topology)
   hwloc_topology_components_fini(topology);
   hwloc_components_fini();
   hwloc_pci_exit(topology);
+  hwloc_x86_exit(topology);
 
   hwloc_topology_clear(topology);
 
@@ -4196,6 +4198,9 @@ hwloc_topology_load (struct hwloc_topology *topology)
     hwloc_internal_distances_prepare(topology);
   if (!(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_MEMATTRS))
     hwloc_internal_memattrs_prepare(topology);
+
+  /* check how to use x86 */
+  hwloc_x86_prepare(topology);
 
   /* check if any cpu cache filter is not NONE */
   topology->want_some_cpu_caches = 0;
@@ -4341,6 +4346,7 @@ hwloc_topology_load (struct hwloc_topology *topology)
 
  out:
   hwloc_pci_exit(topology);
+  hwloc_x86_exit(topology);
   hwloc_topology_clear(topology);
   hwloc_topology_setup_defaults(topology);
   hwloc_backends_disable_all(topology);

--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -3848,6 +3848,8 @@ hwloc__topology_init (struct hwloc_topology **topologyp,
   topology->userdata_import_cb = NULL;
   topology->userdata_not_decoded = 0;
 
+  topology->should_disable_thissystem = 0;
+
   /* Make the topology look like something coherent but empty */
   hwloc_topology_setup_defaults(topology);
 
@@ -4147,6 +4149,33 @@ hwloc_topology_destroy (struct hwloc_topology *topology)
   free(topology);
 }
 
+static void
+hwloc_decide_is_thissystem(struct hwloc_topology *topology)
+{
+  const char *local_env;
+
+  /*
+   * If the application changed the backend with set_foo(),
+   * it may use set_flags() update the is_thissystem flag here.
+   * If it changes the backend with environment variables below,
+   * it may use HWLOC_THISSYSTEM envvar below as well.
+   */
+
+  /* override set_foo() with flags */
+  if (topology->flags & HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM)
+    topology->should_disable_thissystem &= ~HWLOC_SHOULD_DISABLE_THISSYSTEM;
+
+  /* override with envvar-given flag */
+  local_env = getenv("HWLOC_THISSYSTEM");
+  if (local_env && atoi(local_env))
+    topology->should_disable_thissystem &= ~HWLOC_SHOULD_DISABLE_THISSYSTEM_ENVVAR;
+
+  if (topology->should_disable_thissystem)
+    topology->state &= ~HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM;
+  else
+    topology->state |= HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM;
+}
+
 int
 hwloc_topology_load (struct hwloc_topology *topology)
 {
@@ -4233,7 +4262,7 @@ hwloc_topology_load (struct hwloc_topology *topology)
   /* instantiate all possible other backends now */
   hwloc_disc_components_enable_others(topology);
   /* now that backends are enabled, update the thissystem flag and some callbacks */
-  hwloc_backends_is_thissystem(topology);
+  hwloc_decide_is_thissystem(topology);
   hwloc_backends_find_callbacks(topology);
   /*
    * Now set binding hooks according to HWLOC_TOPOLOGY_STATE_IS_THISSYSTEM in topology->state

--- a/include/hwloc.h
+++ b/include/hwloc.h
@@ -2228,6 +2228,9 @@ enum hwloc_topology_components_flag_e {
  * For instance, CUDA-specific discovery may be expensive and unneeded
  * while generic I/O discovery could still be useful.
  *
+ * The x86 CPUID-based discovery (used in some operating system component)
+ * may also be disabled by passing "x86" to this function.
+ *
  * \return 0 on success.
  * \return -1 on error, for instance if flags are invalid.
  */
@@ -2349,7 +2352,7 @@ enum hwloc_topology_flags_e {
    * would generate, but this flag also prevents hwloc from ever touching other
    * resources during the discovery.
    *
-   * This flag especially tells the x86 backend to never temporarily
+   * This flag especially tells the x86 CPUID detection to never temporarily
    * rebind a thread on any excluded core. This is useful on Windows
    * because such temporary rebinding can change the process binding.
    * Another use-case is to avoid cores that would not be able to

--- a/include/hwloc/plugins.h
+++ b/include/hwloc/plugins.h
@@ -199,14 +199,6 @@ struct hwloc_backend {
   /** \brief Backend flags, currently always 0. */
   unsigned long flags;
 
-  /** \brief Backend-specific 'is_thissystem' property.
-   * Set to 0 if the backend disables the thissystem flag for this topology
-   * (e.g. loading from xml or synthetic string,
-   *  or using a different fsroot on Linux, or a x86 CPUID dump).
-   * Set to -1 if the backend doesn't care (default).
-   */
-  int is_thissystem;
-
   /** \brief Callback for freeing things stored inside the private data.
    * May be NULL.
    */

--- a/include/hwloc/plugins.h
+++ b/include/hwloc/plugins.h
@@ -72,7 +72,6 @@ struct hwloc_disc_component {
    *
    * Usual values are
    * 50 for native OS (or platform) components,
-   * 45 for x86,
    * 40 for no-OS fallback,
    * 30 for global components (xml, synthetic),
    * 20 for pci,

--- a/include/private/components.h
+++ b/include/private/components.h
@@ -27,8 +27,7 @@ extern int hwloc_disc_component_force_enable(struct hwloc_topology *topology,
 					     const void *data1, const void *data2, const void *data3);
 extern void hwloc_disc_components_enable_others(struct hwloc_topology *topology);
 
-/* Compute the topology is_thissystem flag and find some callbacks based on enabled backends */
-extern void hwloc_backends_is_thissystem(struct hwloc_topology *topology);
+/* Find some callbacks based on enabled backends */
 extern void hwloc_backends_find_callbacks(struct hwloc_topology *topology);
 
 /* Initialize the lists of components and backends used by a topology */

--- a/include/private/internal-components.h
+++ b/include/private/internal-components.h
@@ -22,7 +22,6 @@ HWLOC_DECLSPEC extern const struct hwloc_component hwloc_netbsd_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_noos_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_solaris_component;
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_windows_component;
-HWLOC_DECLSPEC extern const struct hwloc_component hwloc_x86_component;
 
 /* I/O discovery */
 HWLOC_DECLSPEC extern const struct hwloc_component hwloc_cuda_component;

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -277,6 +277,18 @@ struct hwloc_topology {
    * temporary variables during discovery
    */
 
+  /* according to backends, should we disable the THISSYSTEM flag?
+   * will be merged with set_flags() and envvar later to set the final state.
+   * 1 means that we should disable THISSYSTEM (may be cleared by set_flags() or envvar).
+   * 3 means should and was forced by envvar (only cleared by envvar).
+   */
+  int should_disable_thissystem;
+#define HWLOC_SHOULD_DISABLE_THISSYSTEM 1
+#define HWLOC_SHOULD_DISABLE_THISSYSTEM_ENVVAR 3
+#define HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(_topology, _envvar) do { \
+    (_topology)->should_disable_thissystem |= ((_envvar) ? HWLOC_SHOULD_DISABLE_THISSYSTEM_ENVVAR : HWLOC_SHOULD_DISABLE_THISSYSTEM); \
+} while (0)
+
   /* set to 1 at the beginning of load() if the filter of any cpu cache type (L1 to L3i) is not NONE,
    * may be checked by backends before querying caches
    * (when they don't know the level of caches they are querying).

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -54,6 +54,18 @@ struct hwloc_internal_location_s {
   } location;
 };
 
+enum hwloc_x86_mode_e {
+  HWLOC_X86_MODE_DEFAULT = 0, /* default set during init */
+  HWLOC_X86_MODE_NONE = 1, /* disabled entirely */
+  HWLOC_X86_MODE_FIRST = 2, /* run first in the backend */
+  HWLOC_X86_MODE_ONLY = 3, /* run first and stops */
+  HWLOC_X86_MODE_LAST = 4, /* run last */
+  HWLOC_X86_MODE_CUSTOM = 5, /* specific to the backend */
+  HWLOC_X86_MODE_DONE = 6, /* already performed */
+};
+
+struct hwloc_x86_backend_data_s;
+
 /*****************************************************
  * WARNING:
  * changes below in this structure (and its children)
@@ -295,6 +307,11 @@ struct hwloc_topology {
    */
   int want_some_cpu_caches;
 
+  /* how to use the x86 cpuid code in OS backends */
+  enum hwloc_x86_mode_e x86_mode;
+  const char *x86_env;
+  struct hwloc_x86_backend_data_s *x86_data;
+
   /* machine-wide memory.
    * temporarily stored there by OSes that only provide this without NUMA information,
    * and actually used later by the core.
@@ -362,6 +379,19 @@ static __hwloc_inline void hwloc__init_infos_static(struct hwloc_infos_s *infos,
   infos->count = count;
   infos->allocated = 0; /* means we won't free */
 }
+
+/* x86 usage in OS backends */
+#ifdef HWLOC_HAVE_X86_CPUID
+extern void hwloc_x86_init(struct hwloc_topology *);
+extern void hwloc_x86_prepare(struct hwloc_topology *);
+extern int hwloc_x86_discover_all(hwloc_topology_t topology);
+extern void hwloc_x86_exit(struct hwloc_topology *);
+#else
+static __hwloc_inline void hwloc_x86_init(hwloc_topology_t topology __hwloc_attribute_unused) { return; }
+static __hwloc_inline void hwloc_x86_prepare(hwloc_topology_t topology __hwloc_attribute_unused) { return; }
+static __hwloc_inline int hwloc_x86_discover_all(hwloc_topology_t topology __hwloc_attribute_unused) { return 0; }
+static __hwloc_inline void hwloc_x86_exit(hwloc_topology_t topology __hwloc_attribute_unused) { return; }
+#endif
 
 /* set native OS binding hooks */
 extern void hwloc_set_native_binding_hooks(struct hwloc_binding_hooks *hooks, struct hwloc_topology_support *support);

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -384,11 +384,13 @@ static __hwloc_inline void hwloc__init_infos_static(struct hwloc_infos_s *infos,
 #ifdef HWLOC_HAVE_X86_CPUID
 extern void hwloc_x86_init(struct hwloc_topology *);
 extern void hwloc_x86_prepare(struct hwloc_topology *);
+extern int hwloc_x86_maybe_hybrid(struct hwloc_topology *); /* 1 if hybrid, 0 if not, -1 if unknown (or x86 not supported/disabled) */
 extern int hwloc_x86_discover_all(hwloc_topology_t topology);
 extern void hwloc_x86_exit(struct hwloc_topology *);
 #else
 static __hwloc_inline void hwloc_x86_init(hwloc_topology_t topology __hwloc_attribute_unused) { return; }
 static __hwloc_inline void hwloc_x86_prepare(hwloc_topology_t topology __hwloc_attribute_unused) { return; }
+static __hwloc_inline int hwloc_x86_maybe_hybrid(hwloc_topology_t topology __hwloc_attribute_unused) { return -1; /* unknown */ }
 static __hwloc_inline int hwloc_x86_discover_all(hwloc_topology_t topology __hwloc_attribute_unused) { return 0; }
 static __hwloc_inline void hwloc_x86_exit(hwloc_topology_t topology __hwloc_attribute_unused) { return; }
 #endif

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -54,6 +54,18 @@ struct hwloc_internal_location_s {
   } location;
 };
 
+enum hwloc_x86_mode_e {
+  HWLOC_X86_MODE_DEFAULT = 0, /* default set during init */
+  HWLOC_X86_MODE_NONE = 1, /* disabled entirely */
+  HWLOC_X86_MODE_FIRST = 2, /* run first in the backend */
+  HWLOC_X86_MODE_ONLY = 3, /* run first and stops */
+  HWLOC_X86_MODE_LAST = 4, /* run last */
+  HWLOC_X86_MODE_CUSTOM = 5, /* specific to the backend */
+  HWLOC_X86_MODE_DONE = 6, /* already performed */
+};
+
+struct hwloc_x86_backend_data_s;
+
 /*****************************************************
  * WARNING:
  * changes below in this structure (and its children)
@@ -299,6 +311,11 @@ struct hwloc_topology {
    */
   int want_some_cpu_caches;
 
+  /* how to use the x86 cpuid code in OS backends */
+  enum hwloc_x86_mode_e x86_mode;
+  const char *x86_env;
+  struct hwloc_x86_backend_data_s *x86_data;
+
   /* machine-wide memory.
    * temporarily stored there by OSes that only provide this without NUMA information,
    * and actually used later by the core.
@@ -366,6 +383,32 @@ static __hwloc_inline void hwloc__init_infos_static(struct hwloc_infos_s *infos,
   infos->count = count;
   infos->allocated = 0; /* means we won't free */
 }
+
+/* x86 usage in OS backends */
+static __hwloc_inline void hwloc_x86_init(struct hwloc_topology *topology)
+{
+  topology->x86_env = NULL;
+  topology->x86_mode = HWLOC_X86_MODE_DEFAULT;
+  topology->x86_data = NULL;
+}
+
+#ifdef HWLOC_HAVE_X86_CPUID
+extern void hwloc_x86_prepare(struct hwloc_topology *topology);
+extern enum hwloc_x86_mode_e hwloc_x86_fixup_mode(struct hwloc_topology *, enum hwloc_x86_mode_e dflt, int maybecustom, const char *osname);
+extern int hwloc_x86_discover_all(hwloc_topology_t topology);
+extern void hwloc_x86_exit(struct hwloc_topology *);
+#else
+static __hwloc_inline void hwloc_x86_prepare(hwloc_topology_t topology)
+{
+  topology->x86_mode = HWLOC_X86_MODE_NONE;
+  assert(!topology->x86_data);
+}
+static __hwloc_inline enum hwloc_x86_mode_e hwloc_x86_fixup_mode(struct hwloc_topology * topology  __hwloc_attribute_unused, enum hwloc_x86_mode_e dflt __hwloc_attribute_unused, int maybecustom  __hwloc_attribute_unused, const char *osname __hwloc_attribute_unused) { return HWLOC_X86_MODE_NONE; }
+static __hwloc_inline int hwloc_x86_discover_all(hwloc_topology_t topology __hwloc_attribute_unused) { return -1; }
+static __hwloc_inline void hwloc_x86_exit(hwloc_topology_t topology) {
+  hwloc_x86_init(topology);
+}
+#endif
 
 /* set native OS binding hooks */
 extern void hwloc_set_native_binding_hooks(struct hwloc_binding_hooks *hooks, struct hwloc_topology_support *support);

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -395,6 +395,7 @@ static __hwloc_inline void hwloc_x86_init(struct hwloc_topology *topology)
 #ifdef HWLOC_HAVE_X86_CPUID
 extern void hwloc_x86_prepare(struct hwloc_topology *topology);
 extern enum hwloc_x86_mode_e hwloc_x86_fixup_mode(struct hwloc_topology *, enum hwloc_x86_mode_e dflt, int maybecustom, const char *osname);
+extern int hwloc_x86_maybe_hybrid(struct hwloc_topology *); /* 1 if hybrid, 0 if not, -1 if unknown (or x86 not supported/disabled) */
 extern int hwloc_x86_discover_all(hwloc_topology_t topology);
 extern void hwloc_x86_exit(struct hwloc_topology *);
 #else
@@ -404,6 +405,7 @@ static __hwloc_inline void hwloc_x86_prepare(hwloc_topology_t topology)
   assert(!topology->x86_data);
 }
 static __hwloc_inline enum hwloc_x86_mode_e hwloc_x86_fixup_mode(struct hwloc_topology * topology  __hwloc_attribute_unused, enum hwloc_x86_mode_e dflt __hwloc_attribute_unused, int maybecustom  __hwloc_attribute_unused, const char *osname __hwloc_attribute_unused) { return HWLOC_X86_MODE_NONE; }
+static __hwloc_inline int hwloc_x86_maybe_hybrid(hwloc_topology_t topology __hwloc_attribute_unused) { return -1; /* unknown */ }
 static __hwloc_inline int hwloc_x86_discover_all(hwloc_topology_t topology __hwloc_attribute_unused) { return -1; }
 static __hwloc_inline void hwloc_x86_exit(hwloc_topology_t topology) {
   hwloc_x86_init(topology);

--- a/include/private/private.h
+++ b/include/private/private.h
@@ -281,6 +281,18 @@ struct hwloc_topology {
    * temporary variables during discovery
    */
 
+  /* according to backends, should we disable the THISSYSTEM flag?
+   * will be merged with set_flags() and envvar later to set the final state.
+   * 1 means that we should disable THISSYSTEM (may be cleared by set_flags() or envvar).
+   * 3 means should and was forced by envvar (only cleared by envvar).
+   */
+  int should_disable_thissystem;
+#define HWLOC_SHOULD_DISABLE_THISSYSTEM 1
+#define HWLOC_SHOULD_DISABLE_THISSYSTEM_ENVVAR 3
+#define HWLOC_MARK_SHOULD_DISABLE_THISSYSTEM(_topology, _envvar) do { \
+    (_topology)->should_disable_thissystem |= ((_envvar) ? HWLOC_SHOULD_DISABLE_THISSYSTEM_ENVVAR : HWLOC_SHOULD_DISABLE_THISSYSTEM); \
+} while (0)
+
   /* set to 1 at the beginning of load() if the filter of any cpu cache type (L1 to L3i) is not NONE,
    * may be checked by backends before querying caches
    * (when they don't know the level of caches they are querying).

--- a/tests/hwloc/hwloc_backends.c
+++ b/tests/hwloc/hwloc_backends.c
@@ -215,13 +215,8 @@ int main(void)
   assert(!err);
   err = hwloc_topology_set_components(topology1, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "xml");
   assert(!err);
-  err = hwloc_topology_set_components(topology1, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "x86");
-#ifdef HWLOC_HAVE_X86_CPUID
+  err = hwloc_topology_set_components(topology1, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "x86"); /* still the only way to disable it in the API */
   assert(!err);
-#else
-  assert(err == -1);
-  assert(errno == EINVAL);
-#endif
 #ifdef HWLOC_LINUX_SYS
   err = hwloc_topology_set_components(topology1, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "linux:0xf");
   assert(!err);
@@ -252,6 +247,7 @@ int main(void)
   err = hwloc_topology_set_components(topology1, HWLOC_TOPOLOGY_COMPONENTS_FLAG_BLACKLIST, "netbsd");
   assert(!err);
 #endif
+
   hwloc_topology_load(topology1);
   backend_name = get_backend_name(topology1);
   assert(backend_name);

--- a/tests/hwloc/linux/fakeheterocpunuma.test
+++ b/tests/hwloc/linux/fakeheterocpunuma.test
@@ -9,5 +9,5 @@ source:  fakeheterocpunuma.tar.bz2
 target:  fakeheterocpunuma.xml
 env:     HWLOC_DEBUG_ALLOW_OVERLAPPING_NODE_CPUSETS=1
 env:     export HWLOC_DEBUG_ALLOW_OVERLAPPING_NODE_CPUSETS
-env:     HWLOC_CPUKINDS_MAXFREQ=1
-env:     export HWLOC_CPUKINDS_MAXFREQ
+env:     HWLOC_CPUKINDS=maxfreq=1
+env:     export HWLOC_CPUKINDS

--- a/tests/hwloc/linux/nvidia-dgx-gb10-nomidr.test
+++ b/tests/hwloc/linux/nvidia-dgx-gb10-nomidr.test
@@ -3,5 +3,5 @@
 # disable MIDR so that frequencies/capacity show too many cpukinds
 source:  nvidia-dgx-gb10.tar.bz2
 target:  nvidia-dgx-gb10-nomidr.xml
-env:     HWLOC_LINUX_CPUKINDS=midr=0
-env:     export HWLOC_LINUX_CPUKINDS
+env:     HWLOC_CPUKINDS=midr=0
+env:     export HWLOC_CPUKINDS

--- a/tests/hwloc/linux/test-topology.sh.in
+++ b/tests/hwloc/linux/test-topology.sh.in
@@ -109,6 +109,7 @@ test_topology ()
     # we don't want the pci backend to annotate PCI vendor/device when supported.
     # We'll set HWLOC_FSROOT and HWLOC_DUMPED_HWDATA_DIR manually below.
     export HWLOC_COMPONENTS=linux,stop
+    export HWLOC_X86=none
     export HWLOC_FSROOT="$sysfsdir"
     export HWLOC_DUMPED_HWDATA_DIR=/var/run/hwloc
 

--- a/tests/hwloc/x86+linux/5intel64-hybrid-lakefield.console
+++ b/tests/hwloc/x86+linux/5intel64-hybrid-lakefield.console
@@ -41,5 +41,5 @@ CPU kind #1 efficiency 1 cpuset 0x00000010
   FrequencyMaxMHz = 3000
   FrequencyBaseMHz = 2000
   CoreType = IntelCore
-Topology infos: LinuxCgroup=/ Backend=Linux OSName=Linux OSRelease=5.3.0-28-generic OSVersion="#30~18.04.1-Ubuntu SMP Fri Jan 17 06:14:09 UTC 2020" HostName=jf1lkf Architecture=x86_64 PageSizeNr=3 PageSizes=4096,2097152,1073741824 Backend=x86
+Topology infos: LinuxCgroup=/ Backend=x86 Backend=Linux OSName=Linux OSRelease=5.3.0-28-generic OSVersion="#30~18.04.1-Ubuntu SMP Fri Jan 17 06:14:09 UTC 2020" HostName=jf1lkf Architecture=x86_64 PageSizeNr=3 PageSizes=4096,2097152,1073741824
 Topology not from this system

--- a/tests/hwloc/x86+linux/5intel64-hybrid-lakefield.test
+++ b/tests/hwloc/x86+linux/5intel64-hybrid-lakefield.test
@@ -2,5 +2,7 @@
 source:  5intel64-hybrid-lakefield.tar.bz2
 target:  5intel64-hybrid-lakefield.console
 options: -v
-env:     HWLOC_COMPONENTS=linux,x86,stop
+env:     HWLOC_COMPONENTS=linux,stop
 env:     export HWLOC_COMPONENTS
+env:     HWLOC_X86=last
+env:     export HWLOC_X86

--- a/tests/hwloc/x86+linux/64amd64-4p2n4ca2co.xml
+++ b/tests/hwloc/x86+linux/64amd64-4p2n4ca2co.xml
@@ -527,9 +527,6 @@
     <u64values length="30">16 22 16 22 10 16 22 16 16 22 </u64values>
     <u64values length="12">22 16 16 10 </u64values>
   </distances2>
-  <cpukind cpuset="0xffffffff,0xffffffff">
-    <info name="FrequencyMaxMHz" value="2100"/>
-  </cpukind>
   <info name="Backend" value="x86"/>
   <info name="Backend" value="Linux"/>
   <info name="OSName" value="Linux"/>

--- a/tests/hwloc/x86+linux/test-topology.sh.in
+++ b/tests/hwloc/x86+linux/test-topology.sh.in
@@ -78,7 +78,8 @@ else
 fi
 
 # set HWLOC_COMPONENTS here so that tests may change the order in the .env below
-export HWLOC_COMPONENTS=x86,linux,stop
+export HWLOC_COMPONENTS=linux,stop
+export HWLOC_X86=first
 
 . "$dir/env"
 

--- a/utils/hwloc/hwloc-gather-cpuid.1in
+++ b/utils/hwloc/hwloc-gather-cpuid.1in
@@ -46,7 +46,7 @@ or in \fB<outdir>\fR if specified.
 These files can be used later to explore the machine topology offline,
 for instance by setting the environment variable \fIHWLOC_CPUID_PATH\fR
 to the directory containing all output files,
-and by forcing the x86 backend with \fIHWLOC_COMPONENTS=x86,stop\fR.
+and by forcing the x86 detection instead of the operating system with \fIHWLOC_X86=only\fR.
 .
 .PP
 The directory contents may also be submitted to hwloc developers

--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -251,6 +251,11 @@ hwloc_utils_enable_input_format(struct hwloc_topology *topology,
       fprintf(stderr, "Cannot force linux component first because HWLOC_COMPONENTS environment variable is already set to %s.\n", env);
     else
       putenv((char *) "HWLOC_COMPONENTS=linux,pci,stop");
+    env = getenv("HWLOC_X86");
+    if (env)
+      fprintf(stderr, "Cannot disable x86 because HWLOC_X86 environment variable is already set to %s.\n", env);
+    else
+      putenv((char *) "HWLOC_X86=none");
     /* normally-set flags are overriden by envvar-forced backends */
     if (flags & HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM)
       putenv((char *) "HWLOC_THISSYSTEM=1");
@@ -273,9 +278,14 @@ hwloc_utils_enable_input_format(struct hwloc_topology *topology,
     }
     env = getenv("HWLOC_COMPONENTS");
     if (env)
-      fprintf(stderr, "Cannot force x86 component first because HWLOC_COMPONENTS environment variable is already set to %s.\n", env);
+      fprintf(stderr, "Cannot force no_os component first because HWLOC_COMPONENTS environment variable is already set to %s.\n", env);
     else
-      putenv((char *) "HWLOC_COMPONENTS=x86,stop");
+      putenv((char *) "HWLOC_COMPONENTS=no_os,stop");
+    env = getenv("HWLOC_X86");
+    if (env)
+      fprintf(stderr, "Cannot force x86-only mode because HWLOC_X86 environment variable is already set to %s.\n", env);
+    else
+      putenv((char *) "HWLOC_X86=only");
     /* normally-set flags are overriden by envvar-forced backends */
     if (flags & HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM)
       putenv((char *) "HWLOC_THISSYSTEM=1");


### PR DESCRIPTION
x86 is now called by OS backends when they need it. By default, Linux/Solaris/Windows call it after their own discovery, NetBSD/FreeBSD/noOS call it first since they don't have any other discovery feature. This is configurable with HWLOC_X86=first/last/only/none

There's some backward compat stuff in HWLOC_COMPONENTS to convert most cases where x86 was involved into HWLOC_X86=...

OS backends may also query some stuff from the x86 info even if x86 didn't build objects. As an example, Linux checks whether the CPU may be hybrid before enabling its complex frequency-based heuristics.

More queries may be added later, e.g. check whether caches are inclusive instead of having x86 annotates Linux objects.

And x86 building of objects may be easily tuned to build some without others depending on what the OS found/needs/
