### PR TITLE
x86: bound otherids access to each PU level count in summarize

### DIFF
--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -1086,11 +1086,21 @@ static void summarize(struct hwloc_backend *backend, struct procinfo *infos, uns
 
 	    hwloc_bitmap_copy(remaining_cpuset, complete_cpuset);
 	    while ((i = hwloc_bitmap_first(remaining_cpuset)) != (unsigned) -1) {
-	      unsigned unknownid = infos[i].otherids[level];
+	      unsigned unknownid;
+
+	      /* this PU may report fewer extended topology levels than "one"
+	       * (heterogeneous CPUs, or a partial cpuid dump), or none at all,
+	       * in which case it has no otherids[] entry at this level */
+	      if (!infos[i].otherids || level >= infos[i].levels) {
+		hwloc_bitmap_clr(remaining_cpuset, i);
+		continue;
+	      }
+	      unknownid = infos[i].otherids[level];
 
 	      unknown_cpuset = hwloc_bitmap_alloc();
 	      for (j = i; j < nbprocs; j++) {
-		if (infos[j].otherids[level] == unknownid) {
+		if (infos[j].otherids && level < infos[j].levels
+		    && infos[j].otherids[level] == unknownid) {
 		  hwloc_bitmap_set(unknown_cpuset, j);
 		  hwloc_bitmap_clr(remaining_cpuset, j);
 		}


### PR DESCRIPTION
summarize() groups PUs by their extended-topology ids by reading infos[i].otherids[level] for every present PU using the level count of the last present PU (one). Each PU's otherids[] is only allocated to the number of levels its own cpuid 0x0b/0x1f leaf reported, and stays NULL when it reported none, so a PU with fewer levels than one, or a non-present index walked by the inner j loop, gets read past the end of its array or through a NULL pointer. This can show up on heterogeneous CPUs and is easy to trigger with a crafted cpuid dump replayed via HWLOC_CPUID_PATH, so guard the otherids access against a missing or shorter array at that level before dereferencing.