### PR TITLE
linux: stop node distance parsing at end of truncated file

### DIFF
--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -2757,6 +2757,9 @@ hwloc_parse_nodes_distances(unsigned nbnodes, unsigned *indexes, uint64_t *dista
       found++;
       if (found == nbnodes)
 	break;
+      if (!*next)
+	/* truncated file, no separator after the last value */
+	break;
       tmp = next+1;
     }
     if (found != nbnodes)


### PR DESCRIPTION
hwloc_parse_nodes_distances reads each NUMA node's sysfs distance file into a fixed buffer and walks the space-separated values with strtoul, advancing tmp = next+1 after every number. If a node/distance file under a container or HWLOC_FSROOT sysfs holds fewer values than there are nodes and the last value runs right up to the buffer's terminating NUL, next ends up pointing at that NUL and next+1 steps one byte past the allocation, so the following strtoul reads out of bounds. We break out of the loop once next reaches the end of the string and let the existing incomplete-file check reject it; well-formed files are unaffected since they stop on found == nbnodes first.