### PR TITLE
linux: guard pagesize array against hugepages st_nlink underflow

### DIFF
--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -2639,10 +2639,11 @@ static void hwloc_linux_add_pagesize_info(struct hwloc_topology *topology,
     struct stat sb;
 
     /* take the number of links as a good estimate for the number of sizes */
-    if (hwloc_stat("/sys/kernel/mm/hugepages", &sb, data->root_fd) == 0)
+    if (hwloc_stat("/sys/kernel/mm/hugepages", &sb, data->root_fd) == 0 && sb.st_nlink > 2)
       nr_sizes = sb.st_nlink - 2 + 1; /* . and .. ignored, normal size added */
     else
-      nr_sizes = 3; /* 1 normal + 3 huge sizes should be enough is most cases */
+      nr_sizes = 3; /* 1 normal + 3 huge sizes should be enough is most cases;
+                     * also used when st_nlink doesn't count subdirs (e.g. btrfs reports 1) */
 
     sizes = malloc(nr_sizes * sizeof(*sizes));
     if (!sizes) {


### PR DESCRIPTION
hwloc_linux_add_pagesize_info() sizes its pagesize array from the link count of the /sys/kernel/mm/hugepages directory, computing nr_sizes as st_nlink - 2 + 1 on the assumption that a directory's link count is its subdirectory count plus two. That assumption does not hold everywhere: btrfs (and some network/overlay filesystems) report st_nlink == 1 for every directory regardless of how many subdirectories it has. Since nr_sizes is unsigned, st_nlink == 1 makes the expression wrap to 0, so the following malloc(0) hands back a tiny non-NULL chunk and the immediate sizes[0] = data->pagesize already writes past it; the per-entry writes in the loop then keep going because the i == nr_sizes growth guard never fires (i starts at 1, nr_sizes is 0). This matters for hwloc because a captured sysfs tree can be replayed through HWLOC_FSROOT, and that tree may well sit on btrfs. I noticed it while checking the two st_nlink-as-estimate sites in this file; the sibling one in hwloc_linux_get_proc_tids is fine because its counter starts at zero so its guard still triggers. The fix only uses the st_nlink-derived count when st_nlink is above 2 and otherwise falls back to the existing default-of-3 estimate, which the realloc growth path already copes with.