### PR TITLE
x86: avoid signed shift overflow when extracting extended topology id

### DIFF
--- a/hwloc/topology-x86.c
+++ b/hwloc/topology-x86.c
@@ -589,7 +589,16 @@ static void read_extended_topo(struct hwloc_x86_backend_data_s *data, struct pro
 	apic_nextshift = eax & 0x1f;
 	apic_type = (ecx & 0xff00) >> 8;
 	apic_id = edx;
-	id = (apic_id >> apic_shift) & ((1 << (apic_packageshift - apic_shift)) - 1);
+	/* apic_packageshift and apic_shift both come from cpuid (eax & 0x1f) and may
+	 * be arbitrary when replaying a dumped cpuid (HWLOC_CPUID_PATH): a package
+	 * shift of 31 would make 1<<31 overflow a signed int, and a shift larger
+	 * than the package shift would make the subtraction wrap into a huge shift
+	 * count. Only extract the id bits when the window is non-empty, otherwise
+	 * there are no bits to keep. */
+	if (apic_packageshift > (int) apic_shift)
+	  id = (apic_id >> apic_shift) & ((1U << (apic_packageshift - apic_shift)) - 1);
+	else
+	  id = 0;
 	hwloc_debug("x2APIC %08x %u: nextshift %u nextnumber %2u type %u id %2u\n",
                     apic_id,
                     level,


### PR DESCRIPTION
read_extended_topo derives a per-level id from the x2apic/extended-topology cpuid leaves, and the mask it builds shifts by apic_packageshift minus apic_shift. both shift amounts come straight from cpuid (eax & 0x1f), so when a dumped cpuid replayed through HWLOC_CPUID_PATH reports a package shift of 31, or a per-level shift larger than the package shift, the expression ends up evaluating 1<<31 or shifting by a wrapped-around count, which is undefined behaviour (ubsan flags both the left shift and the following subtraction). i've guarded the extraction so the id bits are only taken when the window is non-empty and switched the literal to unsigned, which leaves valid monotonic topologies unchanged (the window is empty there only when there are genuinely no bits to keep, where the old masked value was already 0).