### PR TITLE
xml: skip preallocated v2 memory tiers left without a nodeset

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -2234,6 +2234,12 @@ done:
   }
 
   for(i=0; i<data->v2_memtiers_nr; i++) {
+    if (!data->v2_memtiers[i].nodeset) {
+      /* tier slot was preallocated by MemoryTiersNr but no NUMANode referenced it,
+       * importing it would push a tier with a NULL nodeset and crash later */
+      free(data->v2_memtiers[i].subtype);
+      continue;
+    }
     hwloc_internal_memtier_v2xml_import(topology, data->v2_memtiers[i].subtype, data->v2_memtiers[i].nodeset);
     /* nodeset is given to the callee */
     data->v2_memtiers[i].nodeset = NULL;


### PR DESCRIPTION
when a v2 topology carries a root MemoryTiersNr info, hwloc__xml_import_obj_info preallocates that many tier slots and only fills one once a NUMANode is tagged with a matching MemoryTier, so if the count is larger than the number of tagged nodes (for instance MemoryTiersNr=2 with no MemoryTier at all) some slots keep a NULL nodeset. hwloc_look_xml then hands every preallocated slot to the memtier import, the empty ones included, and the later tier ranking dereferences the NULL nodeset in hwloc_bitmap_isset, so loading a crafted topology through set_xml/set_xmlbuffer crashes. skip the slots whose nodeset was never set instead of importing them, which leaves valid v2 topologies (every tier filled) unchanged.