### PR TITLE
windows: fix win_dlerror newline check and out-of-bounds access

### DIFF
--- a/hwloc/components.c
+++ b/hwloc/components.c
@@ -101,7 +101,7 @@ char const * win_dlerror(void)
                               GetLastError(), MAKELANGID( LANG_NEUTRAL, SUBLANG_DEFAULT ),
                               error_buffer, (DWORD) sizeof( error_buffer ), NULL );
   /* skip the newline at the end, since we always add one in the log ouput */
-  if (error_buffer[len-1] = '\n')
+  if (len > 0 && error_buffer[len-1] == '\n')
     error_buffer[len-1] = '\0';
   return error_buffer;
 }


### PR DESCRIPTION
On Windows builds that load plugins without ltdl, win_dlerror() formats the last OS error into a static buffer and then tries to drop the trailing newline before the string is logged. The condition uses a single = rather than ==, so instead of testing the final character it overwrites it with a newline and, because the assignment is always truthy, then replaces it with a NUL. That silently truncates the last character of every error message, and when FormatMessageA() returns 0 because no message is available, len is 0 and error_buffer[len-1] reads and writes one byte before the buffer. I came across it while reading the plugin loader error path. Guarding on len and comparing with == keeps the newline stripped only when it is actually present and leaves the buffer untouched when the format call produced nothing.