### PR TITLE
utils: cap oversized cell length when printing distance matrix

### DIFF
--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -447,6 +447,9 @@ hwloc_utils_print_distance_matrix(FILE *output, unsigned nbobjs, hwloc_obj_t *ob
     else
       len = snprintf(tmp, MATRIX_ITEM_SIZE_MAX,
                      "%d", (int) index);
+    if (len >= MATRIX_ITEM_SIZE_MAX)
+      /* snprintf() returns the untruncated length, cap it to what actually fits */
+      len = MATRIX_ITEM_SIZE_MAX - 1;
     if (len >= max)
       max = maxrowheader = len; /* update for maxrowheader and max cell lens */
     /* store it at the end of the slot in headers */
@@ -461,6 +464,8 @@ hwloc_utils_print_distance_matrix(FILE *output, unsigned nbobjs, hwloc_obj_t *ob
     for(j=0; j<nbobjs; j++, buf += MATRIX_ITEM_SIZE_MAX) {
       char tmp[MATRIX_ITEM_SIZE_MAX];
       len = snprintf(tmp, MATRIX_ITEM_SIZE_MAX, "%llu", (unsigned long long) matrix[i*nbobjs+j]);
+      if (len >= MATRIX_ITEM_SIZE_MAX)
+        len = MATRIX_ITEM_SIZE_MAX - 1;
       if (len >= max)
         max = len; /* only update the max cell len */
       /* store it at the end of the slot in values */


### PR DESCRIPTION
hwloc_utils_print_distance_matrix() formats every cell into a fixed 24-byte tmp buffer with snprintf, but snprintf returns the untruncated length, so a heterogeneous distances matrix whose OS device name is longer than 23 bytes (the name comes straight from imported XML, so it is attacker-controlled) leaves len larger than MATRIX_ITEM_SIZE_MAX and the following memcpy(buf + (MATRIX_ITEM_SIZE_MAX - len - 1), tmp, len+1) both reads past tmp and writes before the headers allocation, corrupting the heap when lstopo prints the distances of a topology loaded from an untrusted file. Cap len to MATRIX_ITEM_SIZE_MAX-1 after each snprintf so the offset stays in bounds and the cell is just displayed truncated.