### PR TITLE
utils: fix systemd-dbus-api buffer overflow on large cpusets

### DIFF
--- a/utils/hwloc/misc.h
+++ b/utils/hwloc/misc.h
@@ -1015,7 +1015,9 @@ hwloc_utils_parse_cpuset_format(const char *string)
  *   "ay 0x0001 0x03"
  * */
 #define HWLOC_SYSTEMD_DBUS_API_PREFIX_FORMAT "ay 0x%04x"
-#define HWLOC_SYSTEMD_DBUS_API_PREFIX_SIZE 9
+/* "ay 0x" is 5 chars and %04x prints at least 4 hex digits but up to 8 for a
+ * large (32bit) byte count, so budget for the widest prefix */
+#define HWLOC_SYSTEMD_DBUS_API_PREFIX_SIZE 13
 #define HWLOC_SYSTEMD_DBUS_API_BYTES_FORMAT " 0x%02x"
 #define HWLOC_SYSTEMD_DBUS_API_BYTES_SIZE 5
 static __hwloc_inline int hwloc_utils_systemd_asprintf(char ** strp, const struct hwloc_bitmap_s * __hwloc_restrict set)


### PR DESCRIPTION
hwloc_utils_systemd_asprintf sizes its output buffer assuming the "ay 0x%04x" array-length prefix is always 9 bytes, but %04x is only a minimum width, so once the mask needs 0x10000 or more bytes the prefix grows to ten or more characters and the trailing bytes are written past the malloc'd buffer. It is reachable from hwloc-calc and lstopo when a cpuset or nodeset with a high bit (index 524280 or above) is converted with --cpuset-output-format/--nodeset-output-format systemd-dbus-api. I have budgeted the prefix for its widest form (up to eight hex digits for a 32bit byte count) so the allocation always has room; small masks format identically to before.