### PR TITLE
solaris: grow Pproc array to fit large cpu kstat instance id

### DIFF
--- a/hwloc/topology-solaris.c
+++ b/hwloc/topology-solaris.c
@@ -656,13 +656,14 @@ hwloc_look_kstat(struct hwloc_topology *topology)
 	  }
         }
 
-      if (cpuid >= Pproc_alloc) {
+      while (cpuid >= Pproc_alloc) {
+	unsigned oldalloc = Pproc_alloc;
 	struct hwloc_solaris_Pproc *tmp = realloc(Pproc, 2*Pproc_alloc * sizeof(*Pproc));
 	if (!tmp)
 	  goto err;
 	Pproc = tmp;
 	Pproc_alloc *= 2;
-	for(i = Pproc_alloc/2; i < Pproc_alloc; i++) {
+	for(i = oldalloc; i < Pproc_alloc; i++) {
 	  Pproc[i].Lproc = -1;
 	  Pproc[i].Lpkg = -1;
 	  Pproc[i].Ppkg = -1;


### PR DESCRIPTION
In hwloc_look_kstat the per-processor Pproc array is indexed by the cpuid we take from each cpu_info kstat's ks_instance, which is the OS processor id rather than a dense 0..n counter. On large Solaris/illumos machines those ids can be sparse and run well past the initial 256 entries, and the kstat chain isn't sorted by instance so a high id can turn up first. The growth guard is a single if that only reallocs to twice the current size, so when an instance id is at least twice the current allocation (say 512 while the array still holds 256) the array is grown to 512 but the following Pproc[cpuid] writes still land past the end, corrupting the heap during hwloc_topology_load(). The stale Pproc_max is set to cpuid+1 as well, so the later summary loops that walk Pproc[0..Pproc_max-1] read past the allocation too. I came across it while reading the kstat enumeration for something unrelated and couldn't convince myself the single doubling was enough. Turning the if into a while so the array keeps doubling until it really covers cpuid closes it, and I initialise each newly grown region from the previous size. Only Pproc is indexed by an external id here; the sibling Lproc/Lcore/Lpkg arrays advance one element at a time so their guards are already fine.