### PR TITLE
Linux cpukinds envvars

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,8 @@ for more details.
     - hwloc_cpuset_to_nodeset_strict()
     - hwloc_cpuset_from_nodeset_strict()
 * Misc
+  + The HWLOC_CPUKINDS_HOMOGENEOUS environment variable is removed.
+    HWLOC_LINUX_CPUKINDS may be used instead if ever needed.
   + The HWLOC_SHOW_ERRORS environment variable replaces HWLOC_HIDE_ERRORS,
     HWLOC_XML_VERBOSE and HWLOC_SYNTHETIC_VERBOSE, with more configuration options,
     see Environment Variables in the documentation for details.

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -5137,10 +5137,7 @@ removed since their non-strict variants are sufficient.
 </ul>
 
 
-\section upgrade_to_api_3x_misc Miscellaneous changes in 3.0
-
-The <tt>XGMIPeers</tt> info attribute was removed from the RSMI OS devices.
-The XGMIHops (or bandwidth) should rather be used to query the list of AMD GPU peers.
+\section upgrade_to_api_3x_envvar Changes to environment variables in 3.0
 
 The HWLOC_HIDE_ERRORS, HWLOC_XML_VERBOSE and HWLOC_SYNTHETIC_VERBOSE
 environment variables are now obsolete
@@ -5149,6 +5146,12 @@ environment variables are now obsolete
 Error messages from plugins and components are now controlled by
 HWLOC_SHOW_ERRORS as well (while verbose debug messages remain in
 HWLOC_PLUGINS_VERBOSE and HWLOC_COMPONENTS_VERBOSE).
+
+
+\section upgrade_to_api_3x_misc Miscellaneous changes in 3.0
+
+The <tt>XGMIPeers</tt> info attribute was removed from the RSMI OS devices.
+The XGMIHops (or bandwidth) should rather be used to query the list of AMD GPU peers.
 
 
 */

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1228,12 +1228,6 @@ following environment variables.
   If set to 0, max frequencies are entirely ignored.
   </dd>
 
-<dt>HWLOC_CPUKINDS_HOMOGENEOUS=0</dt>
-  <dd>Uniformize max frequency, base frequency and Linux capacity to
-  force a single homogeneous kind of CPUs.
-  Setting to 1 enables this uniformization.
-  </dd>
-
 <dt>HWLOC_LINUX_CPUKINDS=-1</dt>
   <dd>Try to enable the discovery of CPU kinds on Linux.
   This is enabled by default except on old AMD CPUs known to be homogeneous.
@@ -5138,6 +5132,9 @@ removed since their non-strict variants are sufficient.
 
 
 \section upgrade_to_api_3x_envvar Changes to environment variables in 3.0
+
+The HWLOC_CPUKINDS_HOMOGENEOUS environment variable is removed.
+HWLOC_LINUX_CPUKINDS may be used to disabled cpukinds if ever needed.
 
 The HWLOC_HIDE_ERRORS, HWLOC_XML_VERBOSE and HWLOC_SYNTHETIC_VERBOSE
 environment variables are now obsolete

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -59,7 +59,6 @@ struct hwloc_linux_backend_data_s {
   } arch;
   char is_amd_with_CU;
   char is_amd_homogeneous;
-  char has_sysfs_midr_regs;
   char cpukinds_enabled;
   char cpukinds_use_midr;
   char cpukinds_use_cppc;
@@ -4330,9 +4329,6 @@ look_sysfscpukinds(struct hwloc_topology *topology,
   if (!data->cpukinds_enabled)
     return 0;
 
-  if (data->cpukinds_use_midr == -1)
-    data->cpukinds_use_midr = data->has_sysfs_midr_regs;
-
   if (data->cpukinds_use_midr)
     return look_sysfscpukinds_by_midr_regs(topology, data);
 
@@ -5084,8 +5080,7 @@ hwloc_linux_parse_cpuinfo(struct hwloc_linux_backend_data_s *data,
     parse_cpuinfo_func = hwloc_linux_parse_cpuinfo_x86;
     break;
   case HWLOC_LINUX_ARCH_ARM:
-    if (data->has_sysfs_midr_regs)
-      /* TODO: if cpukinds disabled or not using MIDR, use the no-midr one */
+    if (data->cpukinds_use_midr)
       parse_cpuinfo_func = hwloc_linux_parse_cpuinfo_arm_midr;
     else
       parse_cpuinfo_func = hwloc_linux_parse_cpuinfo_arm;
@@ -5326,12 +5321,6 @@ hwloc_gather_system_info(struct hwloc_topology *topology,
       data->arch = HWLOC_LINUX_ARCH_LOONGARCH;
     else if (!strcmp(data->utsname.machine, "ia64"))
       data->arch = HWLOC_LINUX_ARCH_IA64;
-  }
-
-  if (data->arch == HWLOC_LINUX_ARCH_ARM) {
-    /* only check cpu0 even if offline since these files contain midr values read during boot */
-    if (!hwloc_access("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1", R_OK, data->root_fd))
-      data->has_sysfs_midr_regs = 1;
   }
 }
 
@@ -7251,6 +7240,12 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
     if (topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS) {
       data->cpukinds_enabled = 0;
     } else {
+      data->cpukinds_use_midr = 0;
+      if (data->arch == HWLOC_LINUX_ARCH_ARM /* was set in hwloc_gather_system_info() */) {
+        /* only check cpu0 even if offline since these files contain midr values read during boot */
+        if (!hwloc_access("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1", R_OK, data->root_fd))
+          data->cpukinds_use_midr = 1;
+      }
       env = getenv("HWLOC_LINUX_CPUKINDS");
       if (env) {
         if (!strcmp(env, "none") || !strcmp(env, "0")) {
@@ -7389,9 +7384,8 @@ hwloc_linux_component_instantiate(struct hwloc_topology *topology,
 
   /* default values */
   data->arch = HWLOC_LINUX_ARCH_UNKNOWN;
-  data->has_sysfs_midr_regs = 0;
   data->cpukinds_enabled = -1; /* not decided yet */
-  data->cpukinds_use_midr = -1; /* unknown yet, will depend on has_sysfs_midr_regs */
+  data->cpukinds_use_midr = 0; /* disabled until files are found */
   data->cpukinds_use_cppc = -1; /* -1 means try, 0 no, 1 yes */
   data->is_amd_with_CU = 0;
   data->is_amd_homogeneous = 0;

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -62,6 +62,8 @@ struct hwloc_linux_backend_data_s {
   char cpukinds_enabled;
   char cpukinds_use_midr;
   char cpukinds_use_cppc;
+  char cpukinds_maxfreq_enabled;
+  int cpukinds_maxfreq_adjust;
   char use_numa_distances;
   char use_numa_distances_for_cpuless;
   char use_numa_initiators;
@@ -4022,24 +4024,14 @@ look_sysfscpukinds_by_freq(struct hwloc_topology *topology,
   struct hwloc_linux_cpukinds_arrays arrays;
   struct hwloc_linux_cpukinds cpufreqs_max, cpufreqs_base, cpu_capacity;
   char *env;
-  int maxfreq_enabled = -1; /* -1 means adjust (default), 0 means ignore, 1 means enforce */
-  unsigned adjust_max = 10;
+  int maxfreq_enabled = data->cpukinds_maxfreq_enabled;
+  unsigned adjust_max = data->cpukinds_maxfreq_adjust;
   int force_homogeneous = 0;
   int i;
 
   arrays.use_cppc_nominal_freq = data->cpukinds_use_cppc;
   arrays.max_without_basefreq = 0;
 
-  env = getenv("HWLOC_CPUKINDS_MAXFREQ");
-  if (env) {
-    if (!strcmp(env, "0")) {
-      maxfreq_enabled = 0;
-    } else if (!strcmp(env, "1")) {
-      maxfreq_enabled = 1;
-    } else if (!strncmp(env, "adjust=", 7)) {
-      adjust_max = atoi(env+7);
-    }
-  }
   if (maxfreq_enabled == 1)
     hwloc_debug("linux/cpufreq: max frequency values are enforced even if it makes CPUs unexpectedly hybrid\n");
   else if (maxfreq_enabled == 0)
@@ -7260,6 +7252,18 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
         }
       }
     }
+    if (data->cpukinds_enabled) {
+      env = getenv("HWLOC_CPUKINDS_MAXFREQ");
+      if (env) {
+        if (!strcmp(env, "0")) {
+          data->cpukinds_maxfreq_enabled = 0;
+        } else if (!strcmp(env, "1")) {
+          data->cpukinds_maxfreq_enabled = 1;
+        } else if (!strncmp(env, "adjust=", 7)) {
+          data->cpukinds_maxfreq_adjust = atoi(env+7);
+        }
+      }
+    }
   }
 
   if (dstatus->phase == HWLOC_DISC_PHASE_CPU) {
@@ -7387,6 +7391,8 @@ hwloc_linux_component_instantiate(struct hwloc_topology *topology,
   data->cpukinds_enabled = -1; /* not decided yet */
   data->cpukinds_use_midr = 0; /* disabled until files are found */
   data->cpukinds_use_cppc = -1; /* -1 means try, 0 no, 1 yes */
+  data->cpukinds_maxfreq_enabled =  -1; /* -1 means adjust (default), 0 means ignore, 1 means enforce */
+  data->cpukinds_maxfreq_adjust = 10;
   data->is_amd_with_CU = 0;
   data->is_amd_homogeneous = 0;
   data->is_fake_numa_uniform = 0;

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -44,7 +44,7 @@
 struct hwloc_linux_backend_data_s {
   char *root_path; /* NULL if unused */
   int root_fd; /* The file descriptor for the file system root, used when browsing, e.g., Linux' sysfs and procfs. */
-  int is_real_fsroot; /* Boolean saying whether root_fd points to the real filesystem root of the system */
+  char is_real_fsroot; /* Boolean saying whether root_fd points to the real filesystem root of the system */
 #ifdef HWLOC_HAVE_LIBUDEV
   struct udev *udev; /* Global udev context */
 #endif
@@ -57,17 +57,17 @@ struct hwloc_linux_backend_data_s {
     HWLOC_LINUX_ARCH_LOONGARCH,
     HWLOC_LINUX_ARCH_UNKNOWN
   } arch;
-  int is_amd_with_CU;
-  int is_amd_homogeneous;
+  char is_amd_with_CU;
+  char is_amd_homogeneous;
+  char has_sysfs_midr_regs;
+  char use_numa_distances;
+  char use_numa_distances_for_cpuless;
+  char use_numa_initiators;
   int is_fake_numa_uniform; /* 0 if not fake, -1 if fake non-uniform, N if fake=<N>U */
-  int has_sysfs_midr_regs;
-  int use_numa_distances;
-  int use_numa_distances_for_cpuless;
-  int use_numa_initiators;
   struct utsname utsname; /* fields contain \0 when unknown */
   int fallback_nbprocessors; /* only used in hwloc_linux_fallback_pu_level(), maybe be <= 0 (error) earlier */
   unsigned pagesize;
-  int need_global_infos;
+  char need_global_infos;
   struct hwloc_infos_s global_infos;
   struct hwloc_infos_s cpukinds_pkg_infos;
 };

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -60,6 +60,9 @@ struct hwloc_linux_backend_data_s {
   char is_amd_with_CU;
   char is_amd_homogeneous;
   char has_sysfs_midr_regs;
+  char cpukinds_enabled;
+  char cpukinds_use_midr;
+  char cpukinds_use_cppc;
   char use_numa_distances;
   char use_numa_distances_for_cpuless;
   char use_numa_initiators;
@@ -4013,8 +4016,7 @@ hwloc_linux_cpukinds_force_homogeneous(struct hwloc_topology *topology,
 /* use frequencies and capacities for finding cpukinds */
 static int
 look_sysfscpukinds_by_freq(struct hwloc_topology *topology,
-                           struct hwloc_linux_backend_data_s *data,
-                           int use_cppc_nominal_freq)
+                           struct hwloc_linux_backend_data_s *data)
 {
   int nr_pus;
   struct hwloc_linux_cpukinds_by_pu *by_pu;
@@ -4026,7 +4028,7 @@ look_sysfscpukinds_by_freq(struct hwloc_topology *topology,
   int force_homogeneous = 0;
   int i;
 
-  arrays.use_cppc_nominal_freq = use_cppc_nominal_freq;
+  arrays.use_cppc_nominal_freq = data->cpukinds_use_cppc;
   arrays.max_without_basefreq = 0;
 
   env = getenv("HWLOC_CPUKINDS_MAXFREQ");
@@ -4318,38 +4320,23 @@ static int
 look_sysfscpukinds(struct hwloc_topology *topology,
                    struct hwloc_linux_backend_data_s *data)
 {
-  char *env;
-  int enabled = -1; /* not decided yet */
-  int use_midr = data->has_sysfs_midr_regs;
-  int use_cppc_nominal_freq = -1; /* -1 means try, 0 no, 1 yes */
-
-  env = getenv("HWLOC_LINUX_CPUKINDS");
-  if (env) {
-    if (!strcmp(env, "none") || !strcmp(env, "0")) {
-      enabled = 0;
-    } else {
-      /* if variable is given, assume anything else means enabled */
-      enabled = 1;
-      if (!strncmp(env, "cppc=", 5))
-        use_cppc_nominal_freq = atoi(env+5);
-      else if (!strncmp(env, "midr=", 5))
-        use_midr = atoi(env+5);
-    }
-  }
-  if (enabled == -1 && data->is_amd_homogeneous) {
+  if (data->cpukinds_enabled == -1 && data->is_amd_homogeneous) {
     /* If not disabled but on pre-Zen5 AMD, disable since useless.
      * This will avoid looking at AMD CPPC which may be slow on Zen2/3 (see #756)
      */
     hwloc_debug("ignoring linux sysfs CPU kind detection on pre-Zen5 AMD CPUs\n");
-    enabled = 0;
+    data->cpukinds_enabled = 0;
   }
-  if (!enabled)
+  if (!data->cpukinds_enabled)
     return 0;
 
-  if (use_midr)
+  if (data->cpukinds_use_midr == -1)
+    data->cpukinds_use_midr = data->has_sysfs_midr_regs;
+
+  if (data->cpukinds_use_midr)
     return look_sysfscpukinds_by_midr_regs(topology, data);
 
-  look_sysfscpukinds_by_freq(topology, data, use_cppc_nominal_freq);
+  look_sysfscpukinds_by_freq(topology, data);
 
   if (data->arch == HWLOC_LINUX_ARCH_X86)
     look_sysfscpukinds_by_pmu_sets(topology, data);
@@ -5597,7 +5584,7 @@ hwloc_linuxfs_look_cpu(struct hwloc_topology *topology,
     hwloc_linux_fallback_pu_level(topology, data);
 
  cpudone:
-  if (!(topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS))
+  if (data->cpukinds_enabled)
     look_sysfscpukinds(topology, data);
 
   /*********************
@@ -7251,13 +7238,33 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
 #ifdef HWLOC_HAVE_LINUXIO
   enum hwloc_type_filter_e pfilter, bfilter, ofilter, mfilter;
 #endif /* HWLOC_HAVE_LINUXIO */
-
   if (data->need_global_infos) {
+    char *env;
+
     /* gather some info in data without actually adding them to the topology yet */
     hwloc_gather_system_info(topology, data);
     hwloc_linuxfs_check_kernel_cmdline(data);
     /* soc info needed for cpukinds quirks in hwloc_linuxfs_look_cpu() */
     hwloc__get_soc_info(data);
+
+    /* initialize cpukinds config */
+    if (topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS) {
+      data->cpukinds_enabled = 0;
+    } else {
+      env = getenv("HWLOC_LINUX_CPUKINDS");
+      if (env) {
+        if (!strcmp(env, "none") || !strcmp(env, "0")) {
+          data->cpukinds_enabled = 0;
+        } else {
+          /* if variable is given, assume anything else means enabled */
+          data->cpukinds_enabled = 1;
+          if (!strncmp(env, "cppc=", 5))
+            data->cpukinds_use_cppc = atoi(env+5);
+          else if (!strncmp(env, "midr=", 5))
+            data->cpukinds_use_midr = atoi(env+5);
+        }
+      }
+    }
   }
 
   if (dstatus->phase == HWLOC_DISC_PHASE_CPU) {
@@ -7289,7 +7296,8 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
 #ifdef HWLOC_HAVE_LINUXPCI
     hwloc_linuxfs_pci_look_pcislots(topology, data);
 #endif /* HWLOC_HAVE_LINUXPCI */
-    hwloc_sysfscpukinds_annotate_packages(topology, data);
+    if (data->cpukinds_enabled)
+      hwloc_sysfscpukinds_annotate_packages(topology, data);
   }
 
   if (dstatus->phase == HWLOC_DISC_PHASE_IO
@@ -7382,6 +7390,9 @@ hwloc_linux_component_instantiate(struct hwloc_topology *topology,
   /* default values */
   data->arch = HWLOC_LINUX_ARCH_UNKNOWN;
   data->has_sysfs_midr_regs = 0;
+  data->cpukinds_enabled = -1; /* not decided yet */
+  data->cpukinds_use_midr = -1; /* unknown yet, will depend on has_sysfs_midr_regs */
+  data->cpukinds_use_cppc = -1; /* -1 means try, 0 no, 1 yes */
   data->is_amd_with_CU = 0;
   data->is_amd_homogeneous = 0;
   data->is_fake_numa_uniform = 0;

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -58,7 +58,6 @@ struct hwloc_linux_backend_data_s {
     HWLOC_LINUX_ARCH_UNKNOWN
   } arch;
   char is_amd_with_CU;
-  char is_amd_homogeneous;
   char cpukinds_enabled;
   char cpukinds_use_midr;
   char cpukinds_use_cppc;
@@ -4311,16 +4310,6 @@ static int
 look_sysfscpukinds(struct hwloc_topology *topology,
                    struct hwloc_linux_backend_data_s *data)
 {
-  if (data->cpukinds_enabled == -1 && data->is_amd_homogeneous) {
-    /* If not disabled but on pre-Zen5 AMD, disable since useless.
-     * This will avoid looking at AMD CPPC which may be slow on Zen2/3 (see #756)
-     */
-    hwloc_debug("ignoring linux sysfs CPU kind detection on pre-Zen5 AMD CPUs\n");
-    data->cpukinds_enabled = 0;
-  }
-  if (!data->cpukinds_enabled)
-    return 0;
-
   if (data->cpukinds_use_midr)
     return look_sysfscpukinds_by_midr_regs(topology, data);
 
@@ -5529,8 +5518,16 @@ hwloc_linuxfs_look_cpu(struct hwloc_topology *topology,
         if (cpufamilynumber && (!strcmp(cpufamilynumber, "21")
                                 || !strcmp(cpufamilynumber, "22")))
           data->is_amd_with_CU = 1;
-        else if (cpufamilynumber && (atoi(cpufamilynumber) < 0x1a))
-          data->is_amd_homogeneous = 1; /* hybrid CPUs started with Zen5 = family 0x1a */
+        else if (cpufamilynumber && (atoi(cpufamilynumber) < 0x1a)) {
+          /* hybrid CPUs started with Zen5 = family 0x1a
+           * If not disabled but on pre-Zen5 AMD, disable since useless.
+           * This will avoid looking at AMD CPPC which may be slow on Zen2/3 (see #756)
+           */
+          if (data->cpukinds_enabled == -1) {
+            hwloc_debug("ignoring linux sysfs CPU kind detection on pre-Zen5 AMD CPUs\n");
+            data->cpukinds_enabled = 0;
+          }
+        }
       }
   }
 
@@ -7394,7 +7391,6 @@ hwloc_linux_component_instantiate(struct hwloc_topology *topology,
   data->cpukinds_maxfreq_enabled =  -1; /* -1 means adjust (default), 0 means ignore, 1 means enforce */
   data->cpukinds_maxfreq_adjust = 10;
   data->is_amd_with_CU = 0;
-  data->is_amd_homogeneous = 0;
   data->is_fake_numa_uniform = 0;
   data->need_global_infos = 1;
   hwloc__init_infos(&data->global_infos);

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -3954,65 +3954,6 @@ hwloc_linux_cpukinds_adjust_maxfreqs(struct hwloc_linux_cpukinds_arrays *arrays,
   }
 }
 
-static void
-hwloc_linux_cpukinds_force_homogeneous(struct hwloc_topology *topology,
-                                       struct hwloc_linux_cpukinds_arrays *arrays)
-{
-  unsigned nr_pus = arrays->nr_pus;
-  struct hwloc_linux_cpukinds_by_pu *by_pu = arrays->by_pu;
-  unsigned i;
-  unsigned long base_freq = ULONG_MAX;
-  unsigned long max_freq = 0;
-  unsigned long capacity = 0;
-  for(i=0; i<nr_pus; i++) {
-    /* use the lowest base_freq for all cores */
-    if (by_pu[i].base_freq && by_pu[i].base_freq < base_freq)
-      base_freq = by_pu[i].base_freq;
-    /* use the highest max_freq for all cores */
-    if (by_pu[i].max_freq > max_freq)
-      max_freq = by_pu[i].max_freq;
-    /* use the highest capacity for all cores */
-    if (by_pu[i].capacity > capacity)
-      capacity = by_pu[i].capacity;
-  }
-  hwloc_debug("linux/cpukinds: forcing homogeneous max_freq %lu base_freq %lu capacity %lu\n",
-              max_freq, base_freq, capacity);
-
-  if (max_freq) {
-    hwloc_bitmap_t rootset = hwloc_bitmap_dup(topology->levels[0][0]->cpuset);
-    if (rootset) {
-      char value[64];
-      snprintf(value, sizeof(value), "%lu", max_freq/1000);
-      hwloc_linux_cpukinds_register_one(topology, rootset,
-                                        HWLOC_CPUKIND_EFFICIENCY_UNKNOWN,
-                                        (char *) "FrequencyMaxMHz", value);
-      /* the cpuset is given to the callee */
-    }
-  }
-  if (base_freq != ULONG_MAX) {
-    hwloc_bitmap_t rootset = hwloc_bitmap_dup(topology->levels[0][0]->cpuset);
-    if (rootset) {
-      char value[64];
-      snprintf(value, sizeof(value), "%lu", base_freq/1000);
-      hwloc_linux_cpukinds_register_one(topology, rootset,
-                                        HWLOC_CPUKIND_EFFICIENCY_UNKNOWN,
-                                        (char *) "FrequencyBaseMHz", value);
-      /* the cpuset is given to the callee */
-    }
-  }
-  if (capacity) {
-    hwloc_bitmap_t rootset = hwloc_bitmap_dup(topology->levels[0][0]->cpuset);
-    if (rootset) {
-      char value[64];
-      snprintf(value, sizeof(value), "%lu", capacity);
-      hwloc_linux_cpukinds_register_one(topology, rootset,
-                                        HWLOC_CPUKIND_EFFICIENCY_UNKNOWN,
-                                        (char *) "LinuxCapacity", value);
-      /* the cpuset is given to the callee */
-    }
-  }
-}
-
 /* use frequencies and capacities for finding cpukinds */
 static int
 look_sysfscpukinds_by_freq(struct hwloc_topology *topology,
@@ -4022,10 +3963,8 @@ look_sysfscpukinds_by_freq(struct hwloc_topology *topology,
   struct hwloc_linux_cpukinds_by_pu *by_pu;
   struct hwloc_linux_cpukinds_arrays arrays;
   struct hwloc_linux_cpukinds cpufreqs_max, cpufreqs_base, cpu_capacity;
-  char *env;
   int maxfreq_enabled = data->cpukinds_maxfreq_enabled;
   unsigned adjust_max = data->cpukinds_maxfreq_adjust;
-  int force_homogeneous = 0;
   int i;
 
   arrays.use_cppc_nominal_freq = data->cpukinds_use_cppc;
@@ -4047,16 +3986,6 @@ look_sysfscpukinds_by_freq(struct hwloc_topology *topology,
 
   arrays.flags = HWLOC_CPUKIND_FLAG_NEED_FREQS | HWLOC_CPUKIND_FLAG_NEED_CAPACITY;
   hwloc_fill_sysfscpukinds_arrays(topology, data, &arrays);
-
-  /* force homogeneity ? */
-  env = getenv("HWLOC_CPUKINDS_HOMOGENEOUS");
-  if (env)
-    force_homogeneous = atoi(env);
-  if (force_homogeneous) {
-    hwloc_linux_cpukinds_force_homogeneous(topology, &arrays);
-    free(by_pu);
-    return 0;
-  }
 
   if (maxfreq_enabled == -1 && !arrays.max_without_basefreq)
     /* we have basefreq, check maxfreq and ignore/fix it if turboboost 3.0 makes the max different on different cores */

--- a/tests/hwloc/linux/nvidia-dgx-gb10-nomidr.xml
+++ b/tests/hwloc/linux/nvidia-dgx-gb10-nomidr.xml
@@ -17,6 +17,11 @@
     <info name="DMIBIOSDate" value="08/06/2025"/>
     <info name="DMISysVendor" value="NVIDIA"/>
     <object type="Package" os_index="36" cpuset="0x000fffff" complete_cpuset="0x000fffff" nodeset="0x00000001" complete_nodeset="0x00000001">
+      <info name="CPUImplementer" value="0x41"/>
+      <info name="CPUArchitecture" value="8"/>
+      <info name="CPUVariant" value="0x0"/>
+      <info name="CPUPart" value="0xd87"/>
+      <info name="CPURevision" value="1"/>
       <object type="NUMANode" os_index="0" cpuset="0x000fffff" complete_cpuset="0x000fffff" nodeset="0x00000001" complete_nodeset="0x00000001" local_memory="128520671232"/>
       <object type="L3Cache" cpuset="0x000003ff" complete_cpuset="0x000003ff" nodeset="0x00000001" complete_nodeset="0x00000001" cache_size="8388608" depth="3" cache_linesize="64" cache_associativity="16" cache_type="0">
         <object type="L2Cache" cpuset="0x00000001" complete_cpuset="0x00000001" nodeset="0x00000001" complete_nodeset="0x00000001" cache_size="524288" depth="2" cache_linesize="64" cache_associativity="8" cache_type="0">


### PR DESCRIPTION
Move the management of cpukinds Linux envvar earlier, remove an obsolete one.