### PR TITLE
diff: reject memattr targets with mismatched initiator counts

### DIFF
--- a/hwloc/diff.c
+++ b/hwloc/diff.c
@@ -411,6 +411,8 @@ int hwloc_topology_diff_build(hwloc_topology_t topo1,
                 goto roottoocomplex;
               if (imattr1->flags & HWLOC_MEMATTR_FLAG_NEED_INITIATOR) {
                 unsigned k;
+                if (imtg1->nr_initiators != imtg2->nr_initiators)
+                  goto roottoocomplex;
                 for(k=0; k<imtg1->nr_initiators; k++) {
                   struct hwloc_internal_memattr_initiator_s *imi1 = &imtg1->initiators[k], *imi2 = &imtg2->initiators[k];
                   if (imi1->value != imi2->value

--- a/tests/hwloc/hwloc_topology_diff.c
+++ b/tests/hwloc/hwloc_topology_diff.c
@@ -182,6 +182,49 @@ int main(void)
   assert(err == -2 || err == -3);
   hwloc_topology_diff_destroy(diff);
 
+  printf("building two topologies whose memattr target has different initiator counts\n");
+  {
+    hwloc_topology_t ma1, ma2;
+    hwloc_obj_t numa;
+    struct hwloc_location loc;
+    hwloc_bitmap_t set;
+    unsigned i;
+
+    hwloc_topology_init(&ma1);
+    hwloc_topology_set_synthetic(ma1, "node:1 core:4 pu:1");
+    hwloc_topology_load(ma1);
+    hwloc_topology_init(&ma2);
+    hwloc_topology_set_synthetic(ma2, "node:1 core:4 pu:1");
+    hwloc_topology_load(ma2);
+
+    /* ma1's single NUMA target gets two initiators, ma2's gets only one */
+    numa = hwloc_get_obj_by_type(ma1, HWLOC_OBJ_NUMANODE, 0);
+    for(i=0; i<2; i++) {
+      set = hwloc_bitmap_alloc();
+      hwloc_bitmap_set(set, i);
+      loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+      loc.location.cpuset = set;
+      hwloc_memattr_set_value(ma1, HWLOC_MEMATTR_ID_BANDWIDTH, numa, &loc, 0, 1000+i);
+      hwloc_bitmap_free(set);
+    }
+    numa = hwloc_get_obj_by_type(ma2, HWLOC_OBJ_NUMANODE, 0);
+    set = hwloc_bitmap_alloc();
+    hwloc_bitmap_set(set, 0);
+    loc.type = HWLOC_LOCATION_TYPE_CPUSET;
+    loc.location.cpuset = set;
+    hwloc_memattr_set_value(ma2, HWLOC_MEMATTR_ID_BANDWIDTH, numa, &loc, 0, 1000);
+    hwloc_bitmap_free(set);
+
+    printf("check that the initiator-count mismatch is reported as too complex\n");
+    err = hwloc_topology_diff_build(ma1, ma2, 0, &diff);
+    assert(err == 1);
+    assert(diff->generic.type == HWLOC_TOPOLOGY_DIFF_TOO_COMPLEX);
+    hwloc_topology_diff_destroy(diff);
+
+    hwloc_topology_destroy(ma2);
+    hwloc_topology_destroy(ma1);
+  }
+
   hwloc_topology_destroy(topo3);
   hwloc_topology_destroy(topo2);
   hwloc_topology_destroy(topo1);


### PR DESCRIPTION
hwloc_topology_diff_build() walks the memory attributes of the two topologies, and for each attribute it already checks that the target counts match, but when an attribute needs an initiator it then iterates over imtg1->nr_initiators while reading imtg2->initiators[k] on the matching target of the other topology, without ever checking that the two targets hold the same number of initiators. If the second topology's target has fewer initiators the read walks past the end of its allocation. Both sides here are untrusted, since hwloc-diff and the public hwloc_topology_diff_build() are routinely handed a pair of loaded/XML topologies, and a target's initiator count is just how many values-with-initiator were recorded for it, so the two can easily differ while the target counts still match. I ran into it under AddressSanitizer diffing two topologies where one NUMA node carried two bandwidth initiators and the other only one, which reports a heap-buffer-overflow read in diff.c. Checking nr_initiators for equality before the loop and routing a mismatch through the existing too-complex path closes it, and matching topologies still diff exactly as before.