### PR TITLE
xml: avoid stack buffer overflow when exporting distances indexes

### DIFF
--- a/hwloc/topology-xml.c
+++ b/hwloc/topology-xml.c
@@ -2710,7 +2710,7 @@ hwloc__xml_v2export_object (hwloc__xml_export_state_t parentstate, hwloc_topolog
 #define EXPORT_ARRAY(state, type, nr, values, tagname, format, maxperline) do { \
   unsigned _i = 0; \
   while (_i<(nr)) { \
-    char _tmp[255]; /* enough for (snprintf(format)+space) x maxperline */ \
+    char _tmp[512]; /* enough for (largest %llu + space) x maxperline */ \
     char _tmp2[16]; \
     size_t _len = 0; \
     unsigned _j; \
@@ -2731,7 +2731,7 @@ hwloc__xml_v2export_object (hwloc__xml_export_state_t parentstate, hwloc_topolog
 #define EXPORT_TYPE_GPINDEX_ARRAY(state, nr, objs, tagname, maxperline) do { \
   unsigned _i = 0; \
   while (_i<(nr)) { \
-    char _tmp[255]; /* enough for (snprintf(type+index)+space) x maxperline */ \
+    char _tmp[512]; /* enough for (largest type name + ':' + largest %llu + space) x maxperline */ \
     char _tmp2[16]; \
     size_t _len = 0; \
     unsigned _j; \


### PR DESCRIPTION
When a loaded topology is exported back to XML, hwloc___xml_v2export_distances formats each heterogeneous-distances object into a fixed 255-byte stack buffer with sprintf, up to ten "type:gp_index" tokens per indexes line. gp_index is a 64-bit value taken verbatim from imported XML with no upper bound, so a crafted topology whose objects carry twenty-digit gp_indexes makes the tokens long enough that ten of them run past the buffer, which AddressSanitizer flags as a stack overflow write inside hwloc_topology_export_xmlbuffer() after a set_xml() and load(). This bounds each token with snprintf and continues in a fresh child once the buffer is full, roughly what the nearby TODO suggested; the sibling EXPORT_ARRAY macro shares the same buffer so it gets the same change, and topologies with normal indexes still export unchanged.