### PR TITLE
rsmi: don't enable both ROCm SMI and AMD SMI

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,7 +17,7 @@ Version 3.0.0
 -------------
 See the section "Upgrading to the hwloc 3.0 API" in the documentation
 for more details.
-* API
+* API functions
   + hwloc_get_type_depth_with_attr() generalizes hwloc_get_type_depth() by
     using object attributes to disambiguate multiple levels with same type.
     - hwloc_type_sscanf_as_depth() is deprecated in favor of
@@ -31,6 +31,8 @@ for more details.
     anymore. They have a dedicated API hwloc_memtiers_get_nr() and
     hwloc_memtiers_get_info() in hwloc/memattrs.h
     - NUMA nodes now have a memory_tier integer attribute.
+  + Add hwloc_get_pci_busid_cpuset() in hwloc/helpers.h.
+* Objects and data structures
   + PCI domains are now always 32bits.
   + The "programming interface" of PCI devices is now exposed
     in PCI object attributes.
@@ -57,7 +59,6 @@ for more details.
       infos as such a structure.
   + Distances structure "MEANS" kinds are renamed to "VALUE", and the new
     "HOPS" kind is used for the XGMIHops matrix instead of "LATENCY.
-  + Add hwloc_get_pci_busid_cpuset() in hwloc/helpers.h.
   + Core objects now have a "cpukind" field in the hwloc_core_attr_s
     structure to report the index of their CPU kind.
     - core[cpukind=1] may now be used to filter core objects on the

--- a/NEWS
+++ b/NEWS
@@ -86,6 +86,8 @@ for more details.
     - hwloc_cpuset_to_nodeset_strict()
     - hwloc_cpuset_from_nodeset_strict()
 * Misc
+  + The HWLOC_CPUKINDS environment variable replaces HWLOC_LINUX_CPUKINDS
+    and HWLOC_CPUKINDS_MAXFREQ.
   + The HWLOC_CPUKINDS_HOMOGENEOUS environment variable is removed.
     HWLOC_LINUX_CPUKINDS may be used instead if ever needed.
   + The HWLOC_SHOW_ERRORS environment variable replaces HWLOC_HIDE_ERRORS,

--- a/config/hwloc.m4
+++ b/config/hwloc.m4
@@ -1275,42 +1275,6 @@ return 0;
         HWLOC_RSMI_LDFLAGS="$HWLOC_RSMI_LDFLAGS -L$amdgpu_dir/lib/"
       fi
 
-      hwloc_rsmi_rocm_happy=no
-      if test "x$enable_rsmi_rocm" != "xno"; then
-        hwloc_rsmi_rocm_happy=yes
-        CPPFLAGS_save="$CPPFLAGS"
-        CPPFLAGS="$CPPFLAGS $HWLOC_RSMI_CPPFLAGS"
-        AC_CHECK_HEADERS([rocm_smi/rocm_smi.h], [
-          LDFLAGS_save="$LDFLAGS"
-          LDFLAGS="$LDFLAGS $HWLOC_RSMI_LDFLAGS"
-          LIBS_save="$LIBS"
-          AC_CHECK_LIB([rocm_smi64],
-                     [rsmi_init],
-                     [AC_MSG_CHECKING([whether a program linked with -lrocm_smi64 can run])
-                      HWLOC_ROCM_SMI_LIBS="-lrocm_smi64"
-                      LIBS="$LIBS $HWLOC_ROCM_SMI_LIBS"
-                      AC_RUN_IFELSE([
-                        AC_LANG_PROGRAM([[
-#include <stdio.h>
-char rsmi_init(int);
-]], [[
-rsmi_init(0); /* may fail if driver fails to find some GPUs */
-return 0;
-]]
-                        )],
-                        [AC_MSG_RESULT([yes])
-                         hwloc_rsmi_warning=no],
-                        [AC_MSG_RESULT([no])
-                         hwloc_rsmi_warning=yes],
-                        [AC_MSG_RESULT([don't know (cross-compiling)])])
-		      AC_CHECK_DECLS([rsmi_dev_partition_id_get],,[:],[[#include <rocm_smi/rocm_smi.h>]])
-		     ], [hwloc_rsmi_rocm_happy=no])
-          LDFLAGS="$LDFLAGS_save"
-          LIBS="$LIBS_save"
-        ], [hwloc_rsmi_rocm_happy=no])
-        CPPFLAGS="$CPPFLAGS_save"
-      fi
-
       hwloc_rsmi_amd_happy=no
       if test "x$enable_rsmi_amd" != "xno"; then
         hwloc_rsmi_amd_happy=yes
@@ -1347,13 +1311,46 @@ return 0;
         CPPFLAGS="$CPPFLAGS_save"
       fi
 
+      # only try ROCm SMI if AMD SMI missing or disabled
+      hwloc_rsmi_rocm_happy=no
+      if test  "x$hwloc_rsmi_amd_happy" != "xyes" -a "x$enable_rsmi_rocm" != "xno"; then
+        hwloc_rsmi_rocm_happy=yes
+        CPPFLAGS_save="$CPPFLAGS"
+        CPPFLAGS="$CPPFLAGS $HWLOC_RSMI_CPPFLAGS"
+        AC_CHECK_HEADERS([rocm_smi/rocm_smi.h], [
+          LDFLAGS_save="$LDFLAGS"
+          LDFLAGS="$LDFLAGS $HWLOC_RSMI_LDFLAGS"
+          LIBS_save="$LIBS"
+          AC_CHECK_LIB([rocm_smi64],
+                     [rsmi_init],
+                     [AC_MSG_CHECKING([whether a program linked with -lrocm_smi64 can run])
+                      HWLOC_ROCM_SMI_LIBS="-lrocm_smi64"
+                      LIBS="$LIBS $HWLOC_ROCM_SMI_LIBS"
+                      AC_RUN_IFELSE([
+                        AC_LANG_PROGRAM([[
+#include <stdio.h>
+char rsmi_init(int);
+]], [[
+rsmi_init(0); /* may fail if driver fails to find some GPUs */
+return 0;
+]]
+                        )],
+                        [AC_MSG_RESULT([yes])
+                         hwloc_rsmi_warning=no],
+                        [AC_MSG_RESULT([no])
+                         hwloc_rsmi_warning=yes],
+                        [AC_MSG_RESULT([don't know (cross-compiling)])])
+		      AC_CHECK_DECLS([rsmi_dev_partition_id_get],,[:],[[#include <rocm_smi/rocm_smi.h>]])
+		     ], [hwloc_rsmi_rocm_happy=no])
+          LDFLAGS="$LDFLAGS_save"
+          LIBS="$LIBS_save"
+        ], [hwloc_rsmi_rocm_happy=no])
+        CPPFLAGS="$CPPFLAGS_save"
+      fi
+
       # merge the result of AMDSMI and ROCm SMI lib checks
       if test "x$hwloc_rsmi_rocm_happy$hwloc_rsmi_amd_happy" = xyesyes; then
-        AC_DEFINE([HWLOC_RSMI_USE_ROCM_SMI], [1], [Define to 1 to enable ROCm SMI API in the rsmi backend])
-        AC_DEFINE([HWLOC_RSMI_USE_AMD_SMI], [1], [Define to 1 to enable AMD SMI API in the rsmi backend])
-	HWLOC_RSMI_LIBS="$HWLOC_ROCM_SMI_LIBS $HWLOC_AMD_SMI_LIBS"
-	AC_MSG_NOTICE([Using both AMD SMI and ROCm SMI for RSMI backend])
-	hwloc_rsmi_happy=yes
+	AC_MSG_ERROR([Cannot use both AMD SMI and ROCm SMI for RSMI backend])
       else if test "x$hwloc_rsmi_rocm_happy$hwloc_rsmi_amd_happy" = xyesno; then
         AC_DEFINE([HWLOC_RSMI_USE_ROCM_SMI], [1], [Define to 1 to enable ROCm SMI API in the rsmi backend])
 	HWLOC_RSMI_LIBS="$HWLOC_ROCM_SMI_LIBS"

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1332,13 +1332,6 @@ following environment variables.
   when HWLOC_PLUGINS_VERBOSE=1.
   </dd>
 
-<dt>HWLOC_RSMI_BACKEND=amd</dt>
-  <dd>Use the new AMD SMI library for querying RSMI OS devices.
-  If set to <tt>rocm</tt> instead, the old ROCm SMI library will
-  be used.
-  The default is AMD SMI is available, otherwise ROCm SMI.
-  </dd>
-
 </dl>
 
 
@@ -4565,9 +4558,8 @@ in <i>Probe / display I/O devices</i> at the end of the configure script output.
 Passing <tt>\--enable-rsmi</tt> will also cause configure to fail
 if RSMI could not be found and enabled in hwloc.
 
-Both the new AMD SMI and the old ROCm SMI libraries may be used
-(the former is used by default unless <tt>HWLOC_RSMI_BACKEND=rocm</tt> is set in the environment).
-Both are compiled in unless <tt>\--disable-rsmi-amd</tt> or <tt>\--disable-rsmi-rocm</tt>
+Either the new AMD SMI and the old ROCm SMI libraries may be used.
+AMD SMI is used by default when available unless <tt>\--disable-rsmi-amd</tt>
 is passed to configure.
 
 

--- a/doc/hwloc.doxy
+++ b/doc/hwloc.doxy
@@ -1209,31 +1209,35 @@ following environment variables.
   <tt>default</tt>, or <tt>none</tt>.
   </dd>
 
-<dt>HWLOC_CPUKINDS_MAXFREQ=adjust=10</dt>
-  <dd>Change the use of the max frequency in the Linux backend.
+<dt>HWLOC_CPUKINDS=-1</dt>
+  <dd>Try to enable the discovery of CPU kinds on Linux.
+  This is enabled by default except on old AMD CPUs known to be homogeneous.
+  Setting to <tt>0</tt> always disables it while any other value enables it.
+
+  A comma-separated list of key-value pairs maybe given, including
+  <tt>cppc=0</tt> for disabling the use of ACPI CPPC nominal frequencies,
+  <tt>midr=0</tt> for disabling the use of ARM MIDR registers.
+
+  Keywords <tt>maxfreq</tt> and <tt>freqadjust</tt>
+  may also be given to configure the frequency-based heuristics.
   hwloc tries to read the base and max frequencies of each core on Linux.
   Some hardware features such as Intel Turbo Boost Max 3.0 make some cores
   report slightly higher max frequencies than others in the same CPU package.
   Despite having slightly different frequencies, these cores are considered
   identical instead of exposing an hybrid CPU.
-  Hence, by default (<tt>adjust=10</tt>), hwloc uniformizes the max frequencies of cores
+  Hence, by default, hwloc uniformizes the max frequencies of cores
   that have the same base frequency (higher values are downgraded by up
-  to 10%).
+  to 10% by default).
   When available, the CPU capacity value is also adjusted accordingly.
 
-  If this environment variable is set to <tt>adjust=X</tt>,
-  the 10% threshold is replaced with X.
-  If set to 1, max frequencies are not adjusted anymore,
+  If the HWLOC_CPUKINDS environment variable contains <tt>freqadjust=X</tt>,
+  the default 10% threshold is replaced with X.
+  If <tt>maxfreq=1</tt>, max frequencies are not adjusted anymore,
   some homogeneous processors may appear hybrid because of this.
-  If set to 0, max frequencies are entirely ignored.
-  </dd>
+  If <tt>maxfreq=0</tt>, max frequencies are entirely ignored.
 
-<dt>HWLOC_LINUX_CPUKINDS=-1</dt>
-  <dd>Try to enable the discovery of CPU kinds on Linux.
-  This is enabled by default except on old AMD CPUs known to be homogeneous.
-  Setting to <tt>1</tt> always enables it, while <tt>0</tt> always disables it.
-  Setting to <tt>cppc=0</tt> enables it without using ACPI CPPC nominal frequency.
-  Setting to <tt>midr=0</tt> enables it without using the ARM MIDR register.
+  This environment variable replaces the former HWLOC_LINUX_CPUKINDS
+  and HWLOC_CPUKINDS_MAXFREQ in hwloc 2.0.
   </dd>
 
 
@@ -5133,8 +5137,11 @@ removed since their non-strict variants are sufficient.
 
 \section upgrade_to_api_3x_envvar Changes to environment variables in 3.0
 
+The HWLOC_CPUKINDS environment variable replaces HWLOC_LINUX_CPUKINDS
+and HWLOC_CPUKINDS_MAXFREQ, see \ref envvar_heuristics.
+
 The HWLOC_CPUKINDS_HOMOGENEOUS environment variable is removed.
-HWLOC_LINUX_CPUKINDS may be used to disabled cpukinds if ever needed.
+HWLOC_LINUX_CPUKINDS may be used to disable cpukinds if ever needed.
 
 The HWLOC_HIDE_ERRORS, HWLOC_XML_VERBOSE and HWLOC_SYNTHETIC_VERBOSE
 environment variables are now obsolete

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -7165,31 +7165,28 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
         if (!hwloc_access("/sys/devices/system/cpu/cpu0/regs/identification/midr_el1", R_OK, data->root_fd))
           data->cpukinds_use_midr = 1;
       }
-      env = getenv("HWLOC_LINUX_CPUKINDS");
+      env = getenv("HWLOC_CPUKINDS");
       if (env) {
         if (!strcmp(env, "none") || !strcmp(env, "0")) {
           data->cpukinds_enabled = 0;
           hwloc_debug("linux/cpukinds: disabled by HWLOC_LINUX_CPUKINDS envvar\n");
         } else {
+          const char *str;
           /* if variable is given, assume anything else means enabled */
           data->cpukinds_enabled = 1;
           hwloc_debug("linux/cpukinds: enabled by HWLOC_LINUX_CPUKINDS envvar\n");
-          if (!strncmp(env, "cppc=", 5))
-            data->cpukinds_use_cppc = atoi(env+5);
-          else if (!strncmp(env, "midr=", 5))
-            data->cpukinds_use_midr = atoi(env+5);
-        }
-      }
-      if (data->cpukinds_enabled) {
-        env = getenv("HWLOC_CPUKINDS_MAXFREQ");
-        if (env) {
-          if (!strcmp(env, "0")) {
-            data->cpukinds_maxfreq_enabled = 0;
-          } else if (!strcmp(env, "1")) {
-            data->cpukinds_maxfreq_enabled = 1;
-          } else if (!strncmp(env, "adjust=", 7)) {
-            data->cpukinds_maxfreq_adjust = atoi(env+7);
-          }
+          str = strstr(env, "cppc=");
+          if (str)
+            data->cpukinds_use_cppc = atoi(str+5);
+          str = strstr(env, "midr=");
+          if (str)
+            data->cpukinds_use_midr = atoi(str+5);
+          str = strstr(env, "maxfreq=");
+          if (str)
+            data->cpukinds_maxfreq_enabled = atoi(str+8);
+          str = strstr(env, "freqadjust=");
+          if (str)
+            data->cpukinds_maxfreq_adjust = atoi(str+11);
         }
       }
       if (data->cpukinds_enabled) {

--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -5453,7 +5453,7 @@ hwloc_linuxfs_look_cpu(struct hwloc_topology *topology,
            * This will avoid looking at AMD CPPC which may be slow on Zen2/3 (see #756)
            */
           if (data->cpukinds_enabled == -1) {
-            hwloc_debug("ignoring linux sysfs CPU kind detection on pre-Zen5 AMD CPUs\n");
+            hwloc_debug("linux/cpukinds: ignoring on pre-Zen5 AMD CPUs\n");
             data->cpukinds_enabled = 0;
           }
         }
@@ -7157,6 +7157,7 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
     /* initialize cpukinds config */
     if (topology->flags & HWLOC_TOPOLOGY_FLAG_NO_CPUKINDS) {
       data->cpukinds_enabled = 0;
+      hwloc_debug("linux/cpukinds: disabled by topology flags\n");
     } else {
       data->cpukinds_use_midr = 0;
       if (data->arch == HWLOC_LINUX_ARCH_ARM /* was set in hwloc_gather_system_info() */) {
@@ -7168,9 +7169,11 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
       if (env) {
         if (!strcmp(env, "none") || !strcmp(env, "0")) {
           data->cpukinds_enabled = 0;
+          hwloc_debug("linux/cpukinds: disabled by HWLOC_LINUX_CPUKINDS envvar\n");
         } else {
           /* if variable is given, assume anything else means enabled */
           data->cpukinds_enabled = 1;
+          hwloc_debug("linux/cpukinds: enabled by HWLOC_LINUX_CPUKINDS envvar\n");
           if (!strncmp(env, "cppc=", 5))
             data->cpukinds_use_cppc = atoi(env+5);
           else if (!strncmp(env, "midr=", 5))
@@ -7188,6 +7191,14 @@ hwloc_look_linuxfs(struct hwloc_backend *backend, struct hwloc_disc_status *dsta
             data->cpukinds_maxfreq_adjust = atoi(env+7);
           }
         }
+      }
+      if (data->cpukinds_enabled) {
+        hwloc_debug("linux/cpukinds: enabled to %d with cppc %d midr %d maxfreq %d adjust %d\n",
+                    data->cpukinds_enabled,
+                    data->cpukinds_use_cppc,
+                    data->cpukinds_use_midr,
+                    data->cpukinds_maxfreq_enabled,
+                    data->cpukinds_maxfreq_adjust);
       }
     }
   }

--- a/hwloc/topology-rsmi.c
+++ b/hwloc/topology-rsmi.c
@@ -753,10 +753,8 @@ hwloc_rsmi_discover(struct hwloc_backend *backend, struct hwloc_disc_status *dst
    */
 
   int ret = 0;
-  const char *env = getenv("HWLOC_RSMI_BACKEND");
   struct hwloc_topology *topology = backend->topology;
   enum hwloc_type_filter_e filter;
-  enum { HWLOC_RSMI_BACKEND_FIRST, HWLOC_RSMI_BACKEND_AMD, HWLOC_RSMI_BACKEND_ROCM, HWLOC_RSMI_BACKEND_BOTH } try = HWLOC_RSMI_BACKEND_FIRST;
 
   assert(dstatus->phase == HWLOC_DISC_PHASE_IO);
 
@@ -764,54 +762,14 @@ hwloc_rsmi_discover(struct hwloc_backend *backend, struct hwloc_disc_status *dst
   if (filter == HWLOC_TYPE_FILTER_KEEP_NONE)
     return 0;
 
-  if (env) {
-    if (!strcmp(env, "amd"))
-      try = HWLOC_RSMI_BACKEND_AMD;
-    else if (!strcmp(env, "rocm"))
-      try = HWLOC_RSMI_BACKEND_ROCM;
-    else if (!strcmp(env, "both"))
-      try = HWLOC_RSMI_BACKEND_BOTH;
-  }
-
-  switch (try) {
-  case HWLOC_RSMI_BACKEND_FIRST:
-    /* use AMD first if available, ROCm otherwise */
+  /* use AMD first if available, ROCm otherwise */
 #if (defined HWLOC_RSMI_USE_AMD_SMI)
-    ret = hwloc_amd_smi_discover(topology);
+  ret = hwloc_amd_smi_discover(topology);
 #elif (defined HWLOC_RSMI_USE_ROCM_SMI)
-    ret = hwloc_rocm_smi_discover(topology);
+  ret = hwloc_rocm_smi_discover(topology);
 #else
-    assert(0); /* not possible at configure */
+#error Cannot enable RSMI backend without either AMD or ROCM SMI
 #endif
-    break;
-  case HWLOC_RSMI_BACKEND_AMD:
-    /* only use AMD */
-#ifdef HWLOC_RSMI_USE_AMD_SMI
-    ret = hwloc_amd_smi_discover(topology);
-#else
-    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER))
-      fprintf(stderr, "hwloc/rsmi: cannot enable AMD SMI in RSMI backend, not available\n");
-#endif
-    break;
-  case HWLOC_RSMI_BACKEND_ROCM:
-    /* only use ROCm */
-#ifdef HWLOC_RSMI_USE_ROCM_SMI
-    ret = hwloc_rocm_smi_discover(topology);
-#else
-    if (HWLOC_SHOW_ERRORS(HWLOC_SHOWMSG_USER))
-      fprintf(stderr, "hwloc/rsmi: cannot enable ROCm SMI in RSMI backend, not available\n");
-#endif
-    break;
-  case HWLOC_RSMI_BACKEND_BOTH:
-    /* use both for debuggin/comparing the outputs */
-#ifdef HWLOC_RSMI_USE_AMD_SMI
-    ret = hwloc_amd_smi_discover(topology);
-#endif /* HWLOC_RSMI_USE_AMD_SMI */
-#ifdef HWLOC_RSMI_USE_ROCM_SMI
-    ret = hwloc_rocm_smi_discover(topology);
-#endif /* HWLOC_RSMI_USE_ROCM_SMI */
-    break;
-  }
   return ret;
 }
 

--- a/tests/hwloc/linux/fakeheterocpunuma.test
+++ b/tests/hwloc/linux/fakeheterocpunuma.test
@@ -9,5 +9,5 @@ source:  fakeheterocpunuma.tar.bz2
 target:  fakeheterocpunuma.xml
 env:     HWLOC_DEBUG_ALLOW_OVERLAPPING_NODE_CPUSETS=1
 env:     export HWLOC_DEBUG_ALLOW_OVERLAPPING_NODE_CPUSETS
-env:     HWLOC_CPUKINDS_MAXFREQ=1
-env:     export HWLOC_CPUKINDS_MAXFREQ
+env:     HWLOC_CPUKINDS=maxfreq=1
+env:     export HWLOC_CPUKINDS

--- a/tests/hwloc/linux/nvidia-dgx-gb10-nomidr.test
+++ b/tests/hwloc/linux/nvidia-dgx-gb10-nomidr.test
@@ -3,5 +3,5 @@
 # disable MIDR so that frequencies/capacity show too many cpukinds
 source:  nvidia-dgx-gb10.tar.bz2
 target:  nvidia-dgx-gb10-nomidr.xml
-env:     HWLOC_LINUX_CPUKINDS=midr=0
-env:     export HWLOC_LINUX_CPUKINDS
+env:     HWLOC_CPUKINDS=midr=0
+env:     export HWLOC_CPUKINDS

--- a/tests/hwloc/ports/Makefile.am
+++ b/tests/hwloc/ports/Makefile.am
@@ -21,7 +21,8 @@ check_LTLIBRARIES = \
         libhwloc-port-opencl.la \
         libhwloc-port-cuda.la \
         libhwloc-port-nvml.la \
-        libhwloc-port-rsmi.la \
+        libhwloc-port-rsmi-amd.la \
+        libhwloc-port-rsmi-rocm.la \
         libhwloc-port-levelzero.la \
         libhwloc-port-gl.la
 check_LIBRARIES = \
@@ -161,13 +162,19 @@ libhwloc_port_nvml_la_CPPFLAGS = $(common_CPPFLAGS) \
         -I$(HWLOC_top_srcdir)/tests/hwloc/ports/include/nvml \
         -DHAVE_DECL_NVMLDEVICEGETMAXPCIELINKGENERATION=1
 
-nodist_libhwloc_port_rsmi_la_SOURCES = topology-rsmi.c
-libhwloc_port_rsmi_la_SOURCES = \
-        include/rsmi/amd_smi/amdsmi.h \
-        include/rsmi/rocm_smi/rocm_smi.h
-libhwloc_port_rsmi_la_CPPFLAGS = $(common_CPPFLAGS) \
+nodist_libhwloc_port_rsmi_amd_la_SOURCES = topology-rsmi.c
+libhwloc_port_rsmi_amd_la_SOURCES = \
+        include/rsmi/amd_smi/amdsmi.h
+libhwloc_port_rsmi_amd_la_CPPFLAGS = $(common_CPPFLAGS) \
         -I$(HWLOC_top_srcdir)/tests/hwloc/ports/include/rsmi \
-        -DHWLOC_RSMI_USE_AMD_SMI -DHWLOC_RSMI_USE_ROCM_SMI
+        -DHWLOC_RSMI_USE_AMD_SMI -UHWLOC_RSMI_USE_ROCM_SMI
+
+nodist_libhwloc_port_rsmi_rocm_la_SOURCES = topology-rsmi.c
+libhwloc_port_rsmi_rocm_la_SOURCES = \
+        include/rsmi/rocm_smi/rocm_smi.h
+libhwloc_port_rsmi_rocm_la_CPPFLAGS = $(common_CPPFLAGS) \
+        -I$(HWLOC_top_srcdir)/tests/hwloc/ports/include/rsmi \
+        -DHWLOC_RSMI_USE_ROCM_SMI -UHWLOC_RSMI_USE_AMD_SMI
 
 nodist_libhwloc_port_levelzero_la_SOURCES = topology-levelzero.c
 libhwloc_port_levelzero_la_SOURCES = \

--- a/tests/hwloc/rsmi.c
+++ b/tests/hwloc/rsmi.c
@@ -198,13 +198,13 @@ int main(void)
   hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT);
   hwloc_topology_load(topology);
 
-#ifdef HWLOC_RSMI_USE_ROCM_SMI
+#if (defined HWLOC_RSMI_USE_ROCM_SMI)
   check_rsmi(topology);
-#endif /* HWLOC_RSMI_USE_ROCM_SMI */
-  printf("\n");
-#ifdef HWLOC_RSMI_USE_AMD_SMI
+#elif (defined HWLOC_RSMI_USE_AMD_SMI)
   check_amdsmi(topology);
-#endif /* HWLOC_RSMI_USE_AMD_SMI */
+#else
+#error Cannot enable RSMI backend without either AMD or ROCM SMI
+#endif
 
   hwloc_topology_destroy(topology);
   return 0;


### PR DESCRIPTION
rsmi: don't enable both ROCm SMI and AMD SMI

ROCm 7.14 fails to return devices from AMD SMI if ROCm SMI is loaded
(even if not used).
Tracked upstream at https://github.com/ROCm/rocm-systems/issues/7643

We also saw one case where loading both would cause strange crashes
related to OpenCL.

Disable ROCm SMI at build time unless AMD SMI is disabled/missing.
We still have --disable-rsmi-amd at configure time in case AMD SMI
doesn't work.
The HWLOC_RSMI_BACKEND envvar is removed.

Closes #826
