### PR TITLE
lstopo: grow per-object text array to fit all osdev lines

### DIFF
--- a/utils/lstopo/lstopo.h
+++ b/utils/lstopo/lstopo.h
@@ -262,7 +262,11 @@ struct lstopo_obj_userdata {
   unsigned internal_xoffset;
 
   /* text lines within object */
-#define LSTOPO_OBJ_TEXT_MAX 4 /* current max number of lines is osdev name + 3 cuda attributes */
+#define LSTOPO_OBJ_TEXT_MAX 8 /* current max number of lines is osdev name
+			       * + 3 coproc attributes (CUDA or LevelZero)
+			       * + 1 storage/memory Size
+			       * + 2 memory CXL sizes
+			       */
   struct lstopo_text_line {
     char text[128];
     unsigned width;


### PR DESCRIPTION
prepare_text() in lstopo-draw.c appends every line with lud->text[lud->ntext++] but nothing bounds ntext against LSTOPO_OBJ_TEXT_MAX, which is still 4 from when the comment was written. The osdev branches are cumulative rather than exclusive, so an OS device can reach seven lines: the name, three coprocessor attributes (CUDA or LevelZero), a storage/memory Size, and the two CXL sizes. Since osdev_type, subtype and the info keys all come straight from imported XML, lstopo --input on a crafted topology overruns the array and lands on the ntext and textwidth fields sitting right after it, which the later loops over ntext then read back.

The worst case is statically bounded here, so rather than adding a check at each of the dozen call sites I have just grown the array and written down how the number is reached. An OSDev with osdev_type="11", subtype CUDA and the matching info attributes aborts under AddressSanitizer in prepare_text before the change and renders normally after it; make check stays green.