### PR TITLE
topology: fix double free when duplicating infos fails

### DIFF
--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -770,9 +770,10 @@ int hwloc__tma_dup_infos(struct hwloc_tma *tma,
  failed:
   assert(!tma || !tma->dontfree); /* this tma cannot fail to allocate */
   for(j=0; j<=i; j++) {
-    free(newa[i].name);
-    free(newa[i].value);
+    free(newa[j].name);
+    free(newa[j].value);
   }
+  free(newa);
   hwloc__init_infos(newi);
   return -1;
 }


### PR DESCRIPTION
the cleanup loop in hwloc__tma_dup_infos indexes with j but frees newa[i], so once one of the strdups fails at i of 1 or more the same pointer is handed to free twice and the heap is corrupted, while the earlier entries and the newa array itself leak. hwloc_topology_dup and the cpukinds/memtiers dup paths reach this with infos whose number and size come straight from imported XML, so the allocation pressure needed to hit it is influenced by the input. i verified it with malloc failure injection against the library: the same pointer is freed twice before the change, and each allocation exactly once after, with make check still passing.