### PR TITLE
utils: fix off-by-one when parsing --restrict nodeset=

### DIFF
--- a/utils/hwloc/hwloc-bind.c
+++ b/utils/hwloc/hwloc-bind.c
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
         usage (callname, stderr);
         exit(EXIT_FAILURE);
       }
-      if(strncmp(argv[1], "nodeset=", 7))
+      if(strncmp(argv[1], "nodeset=", 8))
         restrictstring = strdup(argv[1]);
       else {
         restrictstring = strdup(argv[1]+8);

--- a/utils/hwloc/hwloc-calc.c
+++ b/utils/hwloc/hwloc-calc.c
@@ -426,7 +426,7 @@ int main(int argc, char *argv[])
 	usage (callname, stderr);
 	exit(EXIT_FAILURE);
       }
-      if(strncmp(argv[1], "nodeset=", 7))
+      if(strncmp(argv[1], "nodeset=", 8))
         restrictstring = strdup(argv[1]);
       else {
         restrictstring = strdup(argv[1]+8);


### PR DESCRIPTION
The --restrict handlers in hwloc-calc and hwloc-bind compare the argument against the nodeset= prefix with strncmp(argv[1], "nodeset=", 7), so passing just --restrict nodeset without the trailing = still matches the seven letters and then takes the strdup(argv[1]+8) branch, reading one byte past the end of the eight-byte "nodeset" argument and on into whatever argv/env memory follows. hwloc-info, hwloc-distrib and lstopo already compare the full eight bytes for the same option, so this looks like a stray 7 in these two spots. Bumping both to 8 makes the bare word fall through to the ordinary cpuset path while nodeset=<mask> keeps working as before.