### PR TITLE
topology: fix dangling object returned by group dont_merge merge

### DIFF
--- a/hwloc/topology.c
+++ b/hwloc/topology.c
@@ -1592,7 +1592,7 @@ hwloc__insert_try_merge_group(hwloc_topology_t topology, hwloc_obj_t old, hwloc_
       /* keep the new one, it doesn't want to be merged */
       hwloc_replace_linked_object(old, new);
       topology->modified = 1;
-      return new;
+      return old;
 
     } else {
       if (old->attr->group.dont_merge)

--- a/tests/hwloc/hwloc_groups.c
+++ b/tests/hwloc/hwloc_groups.c
@@ -162,6 +162,26 @@ int main(void)
   res = hwloc_topology_insert_group_object(topology, group);
   assert(res == group);
   assert(hwloc_topology_get_depth(topology) == 5);
+  /* insert a group identical to the existing (mergeable) group of packages 1+2,
+   * but with dont_merge set. the existing object must be kept in the tree while
+   * the new object's contents are moved into it, and the insert must return that
+   * in-tree object, not the moved-from (now emptied) new object. */
+  group = hwloc_topology_alloc_group_object(topology);
+  assert(group);
+  obj = hwloc_get_obj_by_type(topology, HWLOC_OBJ_PACKAGE, 1);
+  assert(obj);
+  group->cpuset = hwloc_bitmap_dup(obj->cpuset);
+  obj = hwloc_get_obj_by_type(topology, HWLOC_OBJ_PACKAGE, 2);
+  assert(obj);
+  hwloc_bitmap_or(group->cpuset, group->cpuset, obj->cpuset);
+  group->attr->group.dont_merge = 1;
+  res = hwloc_topology_insert_group_object(topology, group);
+  assert(res);
+  assert(res != group); /* the moved-from new object must not be returned */
+  assert(res->type == HWLOC_OBJ_GROUP);
+  assert(res->cpuset); /* must be a valid in-tree object, not an emptied one */
+  assert(res->attr->group.dont_merge == 1);
+  assert(hwloc_topology_get_depth(topology) == 5);
 
   hwloc_topology_destroy(topology);
 


### PR DESCRIPTION
When a Group with dont_merge set is inserted over an existing mergeable Group of the same cpuset, hwloc__insert_try_merge_group() calls hwloc_replace_linked_object(old, new), which moves the new object's contents into the old (still-linked) object and zeroes the new one, but then returns new instead of old. The caller hwloc__insert_object_by_cpuset() gets result==obj so its result!=obj cleanup is skipped and the moved-from struct leaks, and hwloc_topology_insert_group_object() hands the zeroed object (cpuset and attr NULL) back to the caller as if it were the inserted group. The four sibling branches that call hwloc_replace_linked_object() all return old, so this one should too.

dont_merge is settable from imported XML (hwloc__xml_import_object_attr), and this by-cpuset group merge is also reached via the public hwloc_topology_insert_group_object() API and distance-based grouping.

Reproduced with a synthetic topology: inserting a mergeable group over two packages, then inserting an equal group with dont_merge=1, returns an object with type 0 and cpuset/attr NULL before the change and the real in-tree group after it. Added a regression case to tests/hwloc/hwloc_groups.c that fails before and passes after; the whole tests/hwloc suite still passes.
