### PR TITLE
linux: grow midr cpukind infoarray to fit all six info fields

### DIFF
--- a/hwloc/topology-linux.c
+++ b/hwloc/topology-linux.c
@@ -4146,7 +4146,7 @@ look_sysfscpukinds_by_midr_regs(struct hwloc_topology *topology,
   /* set non-common info in each kinds */
   for(j=0; j<midr_kinds.nr_sets; j++) {
     struct hwloc_infos_s infos;
-    struct hwloc_info_s infoarray[5];
+    struct hwloc_info_s infoarray[6]; /* LinuxCapacity + up to 5 MIDR fields */
     char implementer[10], variant[10], part[10], revision[10], capacitys[25];
     unsigned long capacity;
     unsigned k;


### PR DESCRIPTION
look_sysfscpukinds_by_midr_regs builds up to six info attributes per cpukind, LinuxCapacity plus the five MIDR sub-fields (implementer, architecture, variant, part, revision), but infoarray only has five slots. When two kinds differ in every MIDR field the common mask ends up 0, all five conditions add an entry, k reaches six and the sixth write lands one element past the array on the stack. The assert above only rules out the all-common case, so this isn't caught. It's reachable when loading from a crafted HWLOC_FSROOT whose hwloc-nofile-info reports aarch64 and whose per-cpu midr_el1 files differ in all five fields. Size the array for six entries.